### PR TITLE
[PAG-698] add UAT PROD pagoPA env

### DIFF
--- a/src/env/prod/backend.ini
+++ b/src/env/prod/backend.ini
@@ -1,0 +1,1 @@
+subscription=PROD-pagoPA

--- a/src/env/prod/backend.tfvars
+++ b/src/env/prod/backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "io-infra-rg"
+storage_account_name = "pagopainfraterraformprod"
+container_name       = "azurepstate"
+key                  = "prod.terraform.tfstate"

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -1,0 +1,10 @@
+env_short         = "p"
+mock_ec_enabled   = false
+mock_ec_always_on = false
+tags = {
+  CreatedBy   = "Terraform"
+  Environment = "Prod"
+  Owner       = "pagoPA"
+  Source      = "https://github.com/pagopa/pagopa-infra"
+  CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
+}

--- a/src/env/uat/backend.ini
+++ b/src/env/uat/backend.ini
@@ -1,0 +1,1 @@
+subscription=UAT-pagoPA

--- a/src/env/uat/backend.tfvars
+++ b/src/env/uat/backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "io-infra-rg"
+storage_account_name = "pagopainfraterraformuat"
+container_name       = "azureustate"
+key                  = "uat.terraform.tfstate"

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -1,0 +1,10 @@
+env_short         = "u"
+mock_ec_enabled   = true
+mock_ec_always_on = true
+tags = {
+  CreatedBy   = "Terraform"
+  Environment = "Uat"
+  Owner       = "pagoPA"
+  Source      = "https://github.com/pagopa/pagopa-infra"
+  CostCenter  = "TS310 - PAGAMENTI & SERVIZI"
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The purpose of this PR is to add `UAT-pagoPA` and `PROD-pagoPA` env on `pagopa.it`
### List of changes

Added : 
- `uat` folder env
- `prod` folder env

Updated : 
- `terraform.sh` according to CSTAR project 

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
