### PR TITLE
[PPR-82] update ehub configuration

### DIFF
--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -150,7 +150,7 @@ eventhubs = [
     name              = "nodo-dei-pagamenti-log"
     partitions        = 1 # in PROD shall be changed
     message_retention = 1 # in PROD shall be changed
-    consumers         = ["logstash-rx1", "logstash-rx2", "logstash-rx3"]
+    consumers         = ["logstash-pdnd", "logstash-oper", "logstash-tech"]
     keys = [
       {
         name   = "logstash-SIA"
@@ -159,19 +159,19 @@ eventhubs = [
         manage = false
       },
       {
-        name   = "logstash-rx1"
+        name   = "logstash-pdnd"
         listen = true
         send   = false
         manage = false
       },
       {
-        name   = "logstash-rx2"
+        name   = "logstash-oper"
         listen = true
         send   = false
         manage = false
       },
       {
-        name   = "logstash-rx3"
+        name   = "logstash-tech"
         listen = true
         send   = false
         manage = false
@@ -183,7 +183,7 @@ eventhubs = [
     name              = "nodo-dei-pagamenti-re"
     partitions        = 1 # in PROD shall be changed
     message_retention = 1 # in PROD shall be changed
-    consumers         = ["nodo-dei-pagamenti-rx1", "nodo-dei-pagamenti-rx2"]
+    consumers         = ["nodo-dei-pagamenti-pdnd", "nodo-dei-pagamenti-oper"]
     keys = [
       {
         name   = "nodo-dei-pagamenti-SIA"
@@ -192,13 +192,13 @@ eventhubs = [
         manage = false
       },
       {
-        name   = "nodo-dei-pagamenti-rx1" # pdnd
+        name   = "nodo-dei-pagamenti-pdnd" # pdnd
         listen = true
         send   = false
         manage = false
       },
       {
-        name   = "nodo-dei-pagamenti-rx2" # oper
+        name   = "nodo-dei-pagamenti-oper" # oper
         listen = true
         send   = false
         manage = false

--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -183,7 +183,7 @@ eventhubs = [
     name              = "nodo-dei-pagamenti-re"
     partitions        = 1 # in PROD shall be changed
     message_retention = 1 # in PROD shall be changed
-    consumers         = ["nodo-dei-pagamenti-rx1"]
+    consumers         = ["nodo-dei-pagamenti-rx1", "nodo-dei-pagamenti-rx2"]
     keys = [
       {
         name   = "nodo-dei-pagamenti-SIA"
@@ -192,7 +192,13 @@ eventhubs = [
         manage = false
       },
       {
-        name   = "nodo-dei-pagamenti-rx1"
+        name   = "nodo-dei-pagamenti-rx1" # pdnd
+        listen = true
+        send   = false
+        manage = false
+      },
+      {
+        name   = "nodo-dei-pagamenti-rx2" # oper
         listen = true
         send   = false
         manage = false

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -99,6 +99,10 @@ checkout_pagopaproxy_host           = "https://io-p-app-pagopaproxyprod.azureweb
 
 ehns_sku_name = "Standard"
 
+# to avoid https://docs.microsoft.com/it-it/azure/event-hubs/event-hubs-messaging-exceptions#error-code-50002
+ehns_auto_inflate_enabled     = true
+ehns_maximum_throughput_units = 5
+
 ehns_alerts_enabled = false
 ehns_metric_alerts = {
   no_trx = {
@@ -184,7 +188,7 @@ eventhubs = [
     name              = "nodo-dei-pagamenti-re"
     partitions        = 32 # in PROD shall be changed
     message_retention = 7  # in PROD shall be changed
-    consumers         = ["nodo-dei-pagamenti-rx1"]
+    consumers         = ["nodo-dei-pagamenti-rx1", "nodo-dei-pagamenti-rx2"]
     keys = [
       {
         name   = "nodo-dei-pagamenti-SIA"
@@ -193,7 +197,13 @@ eventhubs = [
         manage = false
       },
       {
-        name   = "nodo-dei-pagamenti-rx1"
+        name   = "nodo-dei-pagamenti-rx1" # pdnd
+        listen = true
+        send   = false
+        manage = false
+      },
+      {
+        name   = "nodo-dei-pagamenti-rx2" # oper
         listen = true
         send   = false
         manage = false

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -155,7 +155,7 @@ eventhubs = [
     name              = "nodo-dei-pagamenti-log"
     partitions        = 32 # in PROD shall be changed
     message_retention = 7  # in PROD shall be changed
-    consumers         = ["logstash-rx1", "logstash-rx2", "logstash-rx3"]
+    consumers         = ["logstash-pdnd", "logstash-oper", "logstash-tech"]
     keys = [
       {
         name   = "logstash-SIA"
@@ -164,19 +164,19 @@ eventhubs = [
         manage = false
       },
       {
-        name   = "logstash-rx1"
+        name   = "logstash-pdnd"
         listen = true
         send   = false
         manage = false
       },
       {
-        name   = "logstash-rx2"
+        name   = "logstash-oper"
         listen = true
         send   = false
         manage = false
       },
       {
-        name   = "logstash-rx3"
+        name   = "logstash-tech"
         listen = true
         send   = false
         manage = false
@@ -188,7 +188,7 @@ eventhubs = [
     name              = "nodo-dei-pagamenti-re"
     partitions        = 32 # in PROD shall be changed
     message_retention = 7  # in PROD shall be changed
-    consumers         = ["nodo-dei-pagamenti-rx1", "nodo-dei-pagamenti-rx2"]
+    consumers         = ["nodo-dei-pagamenti-pdnd", "nodo-dei-pagamenti-oper"]
     keys = [
       {
         name   = "nodo-dei-pagamenti-SIA"
@@ -197,13 +197,13 @@ eventhubs = [
         manage = false
       },
       {
-        name   = "nodo-dei-pagamenti-rx1" # pdnd
+        name   = "nodo-dei-pagamenti-pdnd" # pdnd
         listen = true
         send   = false
         manage = false
       },
       {
-        name   = "nodo-dei-pagamenti-rx2" # oper
+        name   = "nodo-dei-pagamenti-oper" # oper
         listen = true
         send   = false
         manage = false

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -152,7 +152,7 @@ eventhubs = [
     name              = "nodo-dei-pagamenti-log"
     partitions        = 1 # in PROD shall be changed
     message_retention = 1 # in PROD shall be changed
-    consumers         = ["logstash-rx1", "logstash-rx2", "logstash-rx3"]
+    consumers         = ["logstash-pdnd", "logstash-oper", "logstash-tech"]
     keys = [
       {
         name   = "logstash-SIA"
@@ -161,19 +161,19 @@ eventhubs = [
         manage = false
       },
       {
-        name   = "logstash-rx1"
+        name   = "logstash-pdnd"
         listen = true
         send   = false
         manage = false
       },
       {
-        name   = "logstash-rx2"
+        name   = "logstash-oper"
         listen = true
         send   = false
         manage = false
       },
       {
-        name   = "logstash-rx3"
+        name   = "logstash-tech"
         listen = true
         send   = false
         manage = false
@@ -185,7 +185,7 @@ eventhubs = [
     name              = "nodo-dei-pagamenti-re"
     partitions        = 1 # in PROD shall be changed
     message_retention = 1 # in PROD shall be changed
-    consumers         = ["nodo-dei-pagamenti-rx1", "nodo-dei-pagamenti-rx2"]
+    consumers         = ["nodo-dei-pagamenti-pdnd", "nodo-dei-pagamenti-oper"]
     keys = [
       {
         name   = "nodo-dei-pagamenti-SIA"
@@ -194,13 +194,13 @@ eventhubs = [
         manage = false
       },
       {
-        name   = "nodo-dei-pagamenti-rx1" # pdnd
+        name   = "nodo-dei-pagamenti-pdnd" # pdnd
         listen = true
         send   = false
         manage = false
       },
       {
-        name   = "nodo-dei-pagamenti-rx2" # oper
+        name   = "nodo-dei-pagamenti-oper" # oper
         listen = true
         send   = false
         manage = false

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -185,7 +185,7 @@ eventhubs = [
     name              = "nodo-dei-pagamenti-re"
     partitions        = 1 # in PROD shall be changed
     message_retention = 1 # in PROD shall be changed
-    consumers         = ["nodo-dei-pagamenti-rx1"]
+    consumers         = ["nodo-dei-pagamenti-rx1", "nodo-dei-pagamenti-rx2"]
     keys = [
       {
         name   = "nodo-dei-pagamenti-SIA"
@@ -194,7 +194,13 @@ eventhubs = [
         manage = false
       },
       {
-        name   = "nodo-dei-pagamenti-rx1"
+        name   = "nodo-dei-pagamenti-rx1" # pdnd
+        listen = true
+        send   = false
+        manage = false
+      },
+      {
+        name   = "nodo-dei-pagamenti-rx2" # oper
         listen = true
         send   = false
         manage = false


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

The purpose of this PR si to [scale up ](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-scalability#throughput-units) ehub configuration in prod env to avoid [throttlings](https://docs.microsoft.com/it-it/azure/event-hubs/event-hubs-messaging-exceptions#error-code-50002) and add new consumer group for `nodo-dei-pagamenti-re` 

### List of changes

- updated
  - enabled   `ehns_auto_inflate_enabled` and set to 5 throughput units 
- added
  - a new one consumer group `nodo-dei-pagamenti-rx2` for `nodo-dei-pagamenti-re` ( for operational support )

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
