### PR TITLE
[PM] always_on true in all envs for buyer-banks

### DIFF
--- a/src/buyerbanks_function.tf
+++ b/src/buyerbanks_function.tf
@@ -34,7 +34,7 @@ module "buyerbanks_function" {
   health_check_path                        = "info"
   subnet_out_id                            = module.buyerbanks_function_snet.id
   runtime_version                          = "~3"
-  always_on                                = var.env_short == "p" ? true : false
+  always_on                                = true
   application_insights_instrumentation_key = azurerm_application_insights.application_insights.instrumentation_key
 
   app_service_plan_info = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- always on in all envs for buyerbanks

### Motivation and context

The API exposed by `fn-buyerbanks` are invoked by a Payment Manager batch once a day, so to avoid finding the function "off" the only time it is invoked, set always on in all envs for buyerbanks
### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
