### PR TITLE
fdr enable always_on + fix `os_type` to `linux` for fn

### DIFF
--- a/src/buyerbanks_function.tf
+++ b/src/buyerbanks_function.tf
@@ -159,7 +159,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "buyerbanks_update_alert"
     | where toint(Sucess) < 1
 
   QUERY
-  , format("%s-fn-%s", local.project, module.buyerbanks_function.name))
+  , format("%s", module.buyerbanks_function.name))
   severity    = 1
   frequency   = 60
   time_window = 1440

--- a/src/buyerbanks_function.tf
+++ b/src/buyerbanks_function.tf
@@ -24,17 +24,16 @@ module "buyerbanks_function_snet" {
 }
 
 module "buyerbanks_function" {
-  source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v1.0.84"
+  source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v2.2.0"
 
   resource_group_name                      = azurerm_resource_group.buyerbanks_rg.name
-  prefix                                   = var.prefix
-  env_short                                = var.env_short
-  name                                     = "buyerbanks"
+  name                                     = format("%s-fn-buyerbanks", local.project)
   location                                 = var.location
   health_check_path                        = "info"
-  subnet_out_id                            = module.buyerbanks_function_snet.id
+  subnet_id                                = module.buyerbanks_function_snet.id
   runtime_version                          = "~3"
   always_on                                = true
+  os_type                                  = "linux"
   application_insights_instrumentation_key = azurerm_application_insights.application_insights.instrumentation_key
 
   app_service_plan_info = {

--- a/src/buyerbanks_function.tf
+++ b/src/buyerbanks_function.tf
@@ -246,7 +246,8 @@ data "azurerm_key_vault_secret" "pagopa_buyerbank_thumbprint_peer" {
  */
 resource "azurerm_key_vault_certificate" "buyerbanks_cert" {
 
-  name         = format("%s-cert", module.buyerbanks_function.name)
+  name = format("%s-buyerbanks-cert", local.project) # module.buyerbanks_function.name
+
   key_vault_id = module.key_vault.id
 
   certificate_policy {

--- a/src/buyerbanks_function.tf
+++ b/src/buyerbanks_function.tf
@@ -36,12 +36,15 @@ module "buyerbanks_function" {
   os_type                                  = "linux"
   application_insights_instrumentation_key = azurerm_application_insights.application_insights.instrumentation_key
 
+  app_service_plan_name = format("%s-plan-fnbuyerbanks", local.project)
   app_service_plan_info = {
     kind                         = var.buyerbanks_function_kind
     sku_tier                     = var.buyerbanks_function_sku_tier
     sku_size                     = var.buyerbanks_function_sku_size
     maximum_elastic_worker_count = 0
   }
+
+  storage_account_name = replace(format("%s-st-fnbuyerbanks", local.project), "-", "")
 
   app_settings = {
     FUNCTIONS_WORKER_RUNTIME          = "node"
@@ -73,7 +76,7 @@ module "buyerbanks_function" {
 
 resource "azurerm_monitor_autoscale_setting" "buyerbanks_function" {
 
-  name                = format("%s-%s-autoscale", local.project, module.buyerbanks_function.name)
+  name                = format("%s-autoscale", module.buyerbanks_function.name)
   resource_group_name = azurerm_resource_group.buyerbanks_rg.name
   location            = var.location
   target_resource_id  = module.buyerbanks_function.app_service_plan_id
@@ -136,7 +139,7 @@ resource "azurerm_monitor_autoscale_setting" "buyerbanks_function" {
 resource "azurerm_monitor_scheduled_query_rules_alert" "buyerbanks_update_alert" {
   count = var.env_short == "p" ? 1 : 0
 
-  name                = format("%s-%s-availability-alert", local.project, module.buyerbanks_function.name)
+  name                = format("%s-availability-alert", module.buyerbanks_function.name)
   resource_group_name = azurerm_resource_group.buyerbanks_rg.name
   location            = var.location
 
@@ -243,7 +246,7 @@ data "azurerm_key_vault_secret" "pagopa_buyerbank_thumbprint_peer" {
  */
 resource "azurerm_key_vault_certificate" "buyerbanks_cert" {
 
-  name         = format("%s-%s-cert", local.project, module.buyerbanks_function.name)
+  name         = format("%s-cert", module.buyerbanks_function.name)
   key_vault_id = module.key_vault.id
 
   certificate_policy {

--- a/src/checkout_function.tf
+++ b/src/checkout_function.tf
@@ -27,16 +27,16 @@ module "checkout_function_snet" {
 
 module "checkout_function" {
   count  = var.checkout_enabled ? 1 : 0
-  source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v1.0.84"
+  source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v2.2.0"
 
-  resource_group_name                      = azurerm_resource_group.checkout_be_rg[0].name
-  prefix                                   = var.prefix
-  env_short                                = var.env_short
-  name                                     = "checkout"
-  location                                 = var.location
-  health_check_path                        = "info"
-  subnet_out_id                            = module.checkout_function_snet[0].id
-  runtime_version                          = "~3"
+  resource_group_name = azurerm_resource_group.checkout_be_rg[0].name
+  name                = format("%s-fn-checkout", local.project)
+  location            = var.location
+  health_check_path   = "info"
+  subnet_id           = module.checkout_function_snet[0].id
+  runtime_version     = "~3"
+  os_type             = "linux"
+
   always_on                                = var.checkout_function_always_on
   application_insights_instrumentation_key = azurerm_application_insights.application_insights.instrumentation_key
 

--- a/src/checkout_function.tf
+++ b/src/checkout_function.tf
@@ -40,13 +40,15 @@ module "checkout_function" {
   always_on                                = var.checkout_function_always_on
   application_insights_instrumentation_key = azurerm_application_insights.application_insights.instrumentation_key
 
-
+  app_service_plan_name = format("%s-plan-fncheckout", local.project)
   app_service_plan_info = {
     kind                         = var.checkout_function_kind
     sku_tier                     = var.checkout_function_sku_tier
     sku_size                     = var.checkout_function_sku_size
     maximum_elastic_worker_count = 0
   }
+
+  storage_account_name = replace(format("%s-st-fncheckout", local.project), "-", "")
 
   app_settings = {
     FUNCTIONS_WORKER_RUNTIME       = "node"
@@ -83,7 +85,7 @@ module "checkout_function" {
 resource "azurerm_monitor_autoscale_setting" "checkout_function" {
   count = var.checkout_enabled && var.env_short != "d" ? 1 : 0
 
-  name                = format("%s-%s-autoscale", local.project, module.checkout_function[0].name)
+  name                = format("%s-autoscale", module.checkout_function[0].name)
   resource_group_name = azurerm_resource_group.checkout_be_rg[0].name
   location            = var.location
   target_resource_id  = module.checkout_function[0].app_service_plan_id
@@ -147,7 +149,7 @@ resource "azurerm_monitor_autoscale_setting" "checkout_function" {
 resource "azurerm_monitor_scheduled_query_rules_alert" "checkout_availability" {
   count = var.checkout_enabled && var.env_short == "p" ? 1 : 0
 
-  name                = format("%s-%s-availability-alert", local.project, module.checkout_function[0].name)
+  name                = format("%s-availability-alert", module.checkout_function[0].name)
   resource_group_name = azurerm_resource_group.checkout_be_rg[0].name
   location            = var.location
 

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -300,10 +300,12 @@ cobadge_hostname   = "portal.test.pagopa.gov.it" #TO UPDATE with prod hostname
 fesp_hostname      = "portal.test.pagopa.gov.it"
 
 # fdr
-fdr_delete_retention_days       = 30
-reporting_fdr_function_kind     = "Linux"
-reporting_fdr_function_sku_tier = "PremiumV3"
-reporting_fdr_function_sku_size = "P1v3"
+fdr_delete_retention_days        = 30
+reporting_fdr_function_kind      = "Linux"
+reporting_fdr_function_sku_tier  = "PremiumV3"
+reporting_fdr_function_sku_size  = "P1v3"
+reporting_fdr_function_always_on = true
+
 
 # gpd
 gpd_plan_kind     = "Linux"

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -301,10 +301,11 @@ cobadge_hostname   = "portal.test.pagopa.gov.it"
 fesp_hostname      = "portal.test.pagopa.gov.it"
 
 # fdr
-fdr_delete_retention_days       = 30
-reporting_fdr_function_kind     = "Linux"
-reporting_fdr_function_sku_tier = "Standard"
-reporting_fdr_function_sku_size = "S1"
+fdr_delete_retention_days        = 30
+reporting_fdr_function_kind      = "Linux"
+reporting_fdr_function_sku_tier  = "Standard"
+reporting_fdr_function_sku_size  = "S1"
+reporting_fdr_function_always_on = true
 
 # gpd
 gpd_plan_kind     = "Linux"

--- a/src/gpd_reporting.tf
+++ b/src/gpd_reporting.tf
@@ -183,7 +183,7 @@ module "reporting_analysis_function" {
 
 # autoscaling
 resource "azurerm_monitor_autoscale_setting" "reporting_function" {
-  name                = format("%s-%s-autoscale", local.project, module.reporting_batch_function.name)
+  name                = format("%s-autoscale", module.reporting_batch_function.name)
   resource_group_name = azurerm_resource_group.gpd_rg.name
   location            = var.location
   target_resource_id  = azurerm_app_service_plan.gpd_service_plan.id

--- a/src/gpd_reporting.tf
+++ b/src/gpd_reporting.tf
@@ -26,6 +26,7 @@ module "reporting_batch_function" {
   health_check_path                        = "info"
   subnet_id                                = module.reporting_function_snet.id
   runtime_version                          = "~3"
+  os_type                                  = "linux"
   always_on                                = var.reporting_batch_function_always_on
   application_insights_instrumentation_key = azurerm_application_insights.application_insights.instrumentation_key
   app_service_plan_id                      = azurerm_app_service_plan.gpd_service_plan.id
@@ -73,12 +74,14 @@ module "reporting_batch_function" {
 module "reporting_service_function" {
   source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v2.2.0"
 
-  resource_group_name                      = azurerm_resource_group.gpd_rg.name
-  name                                     = format("%s-fn-gpd-service", local.project)
-  location                                 = var.location
-  health_check_path                        = "info"
-  subnet_id                                = module.reporting_function_snet.id
-  runtime_version                          = "~3"
+  resource_group_name = azurerm_resource_group.gpd_rg.name
+  name                = format("%s-fn-gpd-service", local.project)
+  location            = var.location
+  health_check_path   = "info"
+  subnet_id           = module.reporting_function_snet.id
+  runtime_version     = "~3"
+  os_type             = "linux"
+
   always_on                                = var.reporting_service_function_always_on
   application_insights_instrumentation_key = azurerm_application_insights.application_insights.instrumentation_key
   app_service_plan_id                      = azurerm_app_service_plan.gpd_service_plan.id
@@ -128,12 +131,14 @@ module "reporting_service_function" {
 module "reporting_analysis_function" {
   source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v2.2.0"
 
-  resource_group_name                      = azurerm_resource_group.gpd_rg.name
-  name                                     = format("%s-fn-gpd-analysis", local.project)
-  location                                 = var.location
-  health_check_path                        = "info"
-  subnet_id                                = module.reporting_function_snet.id
-  runtime_version                          = "~3"
+  resource_group_name = azurerm_resource_group.gpd_rg.name
+  name                = format("%s-fn-gpd-analysis", local.project)
+  location            = var.location
+  health_check_path   = "info"
+  subnet_id           = module.reporting_function_snet.id
+  runtime_version     = "~3"
+  os_type             = "linux"
+
   always_on                                = var.reporting_analysis_function_always_on
   application_insights_instrumentation_key = azurerm_application_insights.application_insights.instrumentation_key
   app_service_plan_id                      = azurerm_app_service_plan.gpd_service_plan.id

--- a/src/reporting_function.tf
+++ b/src/reporting_function.tf
@@ -77,7 +77,7 @@ module "reporting_fdr_function" {
 
 resource "azurerm_monitor_autoscale_setting" "reporting_fdr_function" {
 
-  name                = format("%s-%s-autoscale", local.project, module.reporting_fdr_function.name)
+  name                = format("%s-autoscale", module.reporting_fdr_function.name)
   resource_group_name = azurerm_resource_group.reporting_fdr_rg.name
   location            = var.location
   target_resource_id  = module.reporting_fdr_function.app_service_plan_id

--- a/src/reporting_function.tf
+++ b/src/reporting_function.tf
@@ -28,14 +28,13 @@ module "reporting_fdr_function_snet" {
 module "reporting_fdr_function" {
   source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v2.2.0"
 
-  resource_group_name = azurerm_resource_group.reporting_fdr_rg.name
-  name                = format("%s-fn-reportingfdr", local.project)
-  location            = var.location
-  health_check_path   = "info"
-  subnet_id           = module.reporting_fdr_function_snet[0].id
-  runtime_version     = "~3"
-  os_type             = "linux"
-
+  resource_group_name                      = azurerm_resource_group.reporting_fdr_rg.name
+  name                                     = format("%s-fn-reportingfdr", local.project)
+  location                                 = var.location
+  health_check_path                        = "info"
+  subnet_id                                = module.reporting_fdr_function_snet[0].id
+  runtime_version                          = "~3"
+  os_type                                  = "linux"
   always_on                                = var.reporting_fdr_function_always_on
   application_insights_instrumentation_key = azurerm_application_insights.application_insights.instrumentation_key
 

--- a/src/reporting_function.tf
+++ b/src/reporting_function.tf
@@ -26,16 +26,16 @@ module "reporting_fdr_function_snet" {
 }
 
 module "reporting_fdr_function" {
-  source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v1.0.84"
+  source = "git::https://github.com/pagopa/azurerm.git//function_app?ref=v2.2.0"
 
-  resource_group_name                      = azurerm_resource_group.reporting_fdr_rg.name
-  prefix                                   = var.prefix
-  env_short                                = var.env_short
-  name                                     = "reportingfdr"
-  location                                 = var.location
-  health_check_path                        = "info"
-  subnet_out_id                            = module.reporting_fdr_function_snet[0].id
-  runtime_version                          = "~3"
+  resource_group_name = azurerm_resource_group.reporting_fdr_rg.name
+  name                = format("%s-fn-reportingfdr", local.project)
+  location            = var.location
+  health_check_path   = "info"
+  subnet_id           = module.reporting_fdr_function_snet[0].id
+  runtime_version     = "~3"
+  os_type             = "linux"
+
   always_on                                = var.reporting_fdr_function_always_on
   application_insights_instrumentation_key = azurerm_application_insights.application_insights.instrumentation_key
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

The purpose of this PR is to set `always_on` to `true` for `reporting_fdr_fn` in UAT and PROD env and add `os_type` to `linux` for all fn app.

### List of changes

Udpated : 
  - all module `function_app` to `2.2.0` rev
  - add `os_type` to `linux` for all fn ( as suggested by @pasqualedevita )
  - set `always_on` to `true` for reporting fdr function in UAT and PROD

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
