### PR TITLE
Add recaptcha check on payment activation endpoint for unauthorized API

### DIFF
--- a/src/api/checkout/checkout_payment_activations/v1/_swagger.json.tpl
+++ b/src/api/checkout/checkout_payment_activations/v1/_swagger.json.tpl
@@ -23,6 +23,12 @@
         "parameters": [
           {
             "$ref": "#/parameters/RptId"
+          },
+          {
+            "in": "query",
+            "name": "recaptchaResponse",
+            "type": "string",
+            "required": true
           }
         ],
         "responses": {

--- a/src/api/checkout/checkout_payment_activations/v1/_swagger.json.tpl
+++ b/src/api/checkout/checkout_payment_activations/v1/_swagger.json.tpl
@@ -80,6 +80,12 @@
                 "codiceContestoPagamento": "ABC123"
               }
             }
+          },
+          {
+            "in": "query",
+            "name": "recaptchaResponse",
+            "type": "string",
+            "required": true
           }
         ],
         "responses": {

--- a/src/apim_checkout.tf
+++ b/src/apim_checkout.tf
@@ -149,6 +149,15 @@ resource "azurerm_api_management_api_operation_policy" "get_activation_status_ap
   xml_content = file("./api/checkout/checkout_payment_activations/v1/_idpayment_check.xml.tpl")
 }
 
+resource "azurerm_api_management_api_operation_policy" "activate_payment_api" {
+  api_name            = format("%s-checkout-payment-activations-api-v1", local.project)
+  api_management_name = module.apim.name
+  resource_group_name = azurerm_resource_group.rg_api.name
+  operation_id        = "activatePayment"
+
+  xml_content = file("./api/checkout/checkout_payment_activations/v1/_recaptcha_check.xml.tpl")
+}
+
 # Payment activation authenticated APIs
 resource "azurerm_api_management_api_version_set" "checkout_payment_activations_auth_api" {
   name                = format("%s-checkout-payment-activations-auth-api", local.project)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

* Add recaptcha check on payment activation endpoint for unauthorized API
* Update swagger associated to this API group to include recaptcha response query parameter

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR aims to add a captcha check to the `activatePayment` operation on the Checkout payment activations API, as is currently done for the `getPaymentInfo` operation. This check is added as the former, being a delicate and stateful operation, is more in need of protections against malevolent actors (e.g. users spamming requests to the endpoint and blocking payments for other users).

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
