### PR TITLE
[PCFG-155] add CSP to apiconfig FE

### DIFF
--- a/src/api_config_fe.tf
+++ b/src/api_config_fe.tf
@@ -74,8 +74,8 @@ module "api_config_fe_cdn" {
       {
         action = "Overwrite"
         name   = "Content-Security-Policy-Report-Only"
-        value = format("default-src 'self'; connect-src 'self' https://api.%s.%s/; "
-        , var.dns_zone_prefix, var.external_domain)
+        value = format("object-src 'none'; connect-src 'self' https://api.%s.%s/; script-src https://api.%s.%s/"
+        , var.dns_zone_prefix, var.external_domain, var.dns_zone_prefix, var.external_domain)
       }
     ]
   }

--- a/src/api_config_fe.tf
+++ b/src/api_config_fe.tf
@@ -59,5 +59,26 @@ module "api_config_fe_cdn" {
     }
   }]
 
+  global_delivery_rule = {
+    cache_expiration_action       = []
+    cache_key_query_string_action = []
+    modify_request_header_action  = []
+
+    # HSTS
+    modify_response_header_action = [{
+      action = "Overwrite"
+      name   = "Strict-Transport-Security"
+      value  = "max-age=31536000"
+      },
+      # Content-Security-Policy (in Report mode)
+      {
+        action = "Overwrite"
+        name   = "Content-Security-Policy-Report-Only"
+        value = format("default-src 'self'; connect-src 'self' https://api.%s.%s/; "
+        , var.dns_zone_prefix, var.external_domain)
+      }
+    ]
+  }
+
   tags = var.tags
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

The purpose of this PR is to add `Content-Security-Policy` to api-config FE in [Report-Only](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only)
### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
