### PR TITLE
Add option to set additional origins for checkout APIs

### DIFF
--- a/src/api/checkout/checkout_payment_activations/v1/_base_policy.xml.tpl
+++ b/src/api/checkout/checkout_payment_activations/v1/_base_policy.xml.tpl
@@ -3,6 +3,7 @@
       <cors>
         <allowed-origins>
           <origin>${origin}</origin>
+          ${additional_origin_tags}
         </allowed-origins>
         <allowed-methods>
           <method>POST</method>

--- a/src/api/checkout/checkout_payments/v1/_base_policy.xml.tpl
+++ b/src/api/checkout/checkout_payments/v1/_base_policy.xml.tpl
@@ -3,6 +3,7 @@
       <cors>
         <allowed-origins>
           <origin>${origin}</origin>
+          ${additional_origin_tags}
         </allowed-origins>
         <allowed-methods>
           <method>POST</method>

--- a/src/apim_checkout.tf
+++ b/src/apim_checkout.tf
@@ -92,7 +92,8 @@ module "apim_checkout_payments_api_v1" {
   })
 
   xml_content = templatefile("./api/checkout/checkout_payments/v1/_base_policy.xml.tpl", {
-    origin = format("https://%s.%s/", var.dns_zone_checkout, var.external_domain)
+    origin                 = format("https://%s.%s/", var.dns_zone_checkout, var.external_domain)
+    additional_origin_tags = var.env_short == "u" ? format("<origin>https://dev.checkout.%s/</origin>", var.external_domain) : ""
   })
 }
 
@@ -128,7 +129,8 @@ module "apim_checkout_payment_activations_api_v1" {
   })
 
   xml_content = templatefile("./api/checkout/checkout_payment_activations/v1/_base_policy.xml.tpl", {
-    origin = format("https://%s.%s/", var.dns_zone_checkout, var.external_domain)
+    origin                 = format("https://%s.%s/", var.dns_zone_checkout, var.external_domain)
+    additional_origin_tags = var.env_short == "u" ? format("<origin>https://dev.checkout.%s/</origin>", var.external_domain) : ""
   })
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

* Add option to set additional origins for checkout APIs

### Motivation and context
This PR is necessary to allow the checkout frontend instance deployed on the DEV environment to use UAT backend.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
