### PR TITLE
Add cdInfoWisp in app_gateway_deny_paths

### DIFF
--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -83,7 +83,8 @@ app_gateway_deny_paths = [
   "/nodo/*",
   "/payment-manager/clients/*",
   "/payment-manager/restapi-rtd/*",
-  "/payment-manager/db-logging/*"
+  "/payment-manager/db-logging/*",
+  "/checkout/io-for-node/*"
 ]
 
 # nat_gateway

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -68,7 +68,8 @@ app_gateway_deny_paths = [
   "/nodo/*",
   "/payment-manager/clients/*",
   "/payment-manager/restapi-rtd/*",
-  "/payment-manager/db-logging/*"
+  "/payment-manager/db-logging/*",
+  "/checkout/io-for-node/*"
 ]
 
 # nat_gateway


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Add cdInfoWisp in `app_gateway_deny_paths`;

### Motivation and context

The goal of this PR is deny  CdInfoWisp Web Service in App Gtw for uat and prod.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
