### PR TITLE
Segregate response types and HTTP status codes by Nodo faults in Checkout API

### DIFF
--- a/src/api/checkout/checkout_payment_activations/v1/_base_policy.xml.tpl
+++ b/src/api/checkout/checkout_payment_activations/v1/_base_policy.xml.tpl
@@ -27,7 +27,7 @@
         </set-header>
         <set-variable name="body" value="@(context.Response.Body.As<JObject>())" />
         <choose>
-            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
+            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502 || context.Response.StatusCode == 598) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
                 <return-response>
                     <set-status code="400" />
                     <set-header name="Content-Type" exists-action="override">

--- a/src/api/checkout/checkout_payment_activations/v1/_base_policy.xml.tpl
+++ b/src/api/checkout/checkout_payment_activations/v1/_base_policy.xml.tpl
@@ -27,7 +27,7 @@
         </set-header>
         <set-variable name="body" value="@(context.Response.Body.As<JObject>())" />
         <choose>
-            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502 || context.Response.StatusCode == 598) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
+            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502 || context.Response.StatusCode == 503 || context.Response.StatusCode == 598) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
                 <return-response>
                     <set-status code="400" />
                     <set-header name="Content-Type" exists-action="override">

--- a/src/api/checkout/checkout_payment_activations/v1/_base_policy.xml.tpl
+++ b/src/api/checkout/checkout_payment_activations/v1/_base_policy.xml.tpl
@@ -27,7 +27,7 @@
         </set-header>
         <set-variable name="body" value="@(context.Response.Body.As<JObject>())" />
         <choose>
-            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 424) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
+            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
                 <return-response>
                     <set-status code="400" />
                     <set-header name="Content-Type" exists-action="override">

--- a/src/api/checkout/checkout_payment_activations/v1/_swagger.json.tpl
+++ b/src/api/checkout/checkout_payment_activations/v1/_swagger.json.tpl
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "title": "Checkout API",
     "contact": {
       "name": "pagoPA team",
@@ -45,21 +45,33 @@
             }
           },
           "400": {
-            "description": "Invalid input or PagoPA response",
+            "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/ValidationFaultPaymentProblemJson"
             }
           },
-          "424": {
-            "description": "PagoPA service error. The requests cannot be handled by PagoPa services.",
-            "schema": {
-              "$ref": "#/definitions/ProblemJson"
-            }
-          },
-          "500": {
+          "502": {
             "description": "PagoPA services are not available or request is rejected by PagoPa",
             "schema": {
-              "$ref": "#/definitions/PaymentProblemJson"
+              "$ref": "#/definitions/GatewayFaultPaymentProblemJson"
+            }
+          },
+          "503": {
+            "description": "EC services are not available",
+            "schema": {
+              "$ref": "#/definitions/PartyConfigurationFaultPaymentProblemJson"
+            }
+          },
+          "504": {
+            "description": "Timeout from PagoPA services",
+            "schema": {
+              "$ref": "#/definitions/PartyTimeoutFaultPaymentProblemJson"
+            }
+          },
+          "598": {
+            "description": "Service connection error while connecting to PagoPA services",
+            "schema": {
+              "$ref": "#/definitions/PartyConnectionFaultPaymentProblemJson"
             }
           }
         }
@@ -107,21 +119,33 @@
             }
           },
           "400": {
-            "description": "Invalid input or PagoPA response",
+            "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/ValidationFaultPaymentProblemJson"
             }
           },
-          "424": {
-            "description": "PagoPA service error. The requests cannot be handled by PagoPa services.",
+          "502": {
+            "description": "PagoPA services are not available or request is rejected by PagoPa",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/GatewayFaultPaymentProblemJson"
             }
           },
-          "500": {
-            "description": "PagoPA services are not available",
+          "503": {
+            "description": "EC services are not available",
             "schema": {
-              "$ref": "#/definitions/PaymentProblemJson"
+              "$ref": "#/definitions/PartyConfigurationFaultPaymentProblemJson"
+            }
+          },
+          "504": {
+            "description": "Timeout from PagoPA services",
+            "schema": {
+              "$ref": "#/definitions/PartyTimeoutFaultPaymentProblemJson"
+            }
+          },
+          "598": {
+            "description": "Service connection error while connecting to PagoPA services",
+            "schema": {
+              "$ref": "#/definitions/PartyConnectionFaultPaymentProblemJson"
             }
           }
         }
@@ -153,7 +177,7 @@
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/ValidationFaultPaymentProblemJson"
             }
           },
           "404": {
@@ -162,10 +186,10 @@
               "$ref": "#/definitions/ProblemJson"
             }
           },
-          "500": {
-            "description": "Service unavailable",
+          "502": {
+            "description": "PagoPA services are not available or request is rejected by PagoPa",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/GatewayFaultPaymentProblemJson"
             }
           }
         }
@@ -203,6 +227,201 @@
         },
         "detail_v2": {
           "$ref": "#/definitions/PaymentFaultV2"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "ValidationFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to validation errors.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/ValidationFault"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "GatewayFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to Nodo errors.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/GatewayFault"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "PartyConfigurationFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to EC fatal errors.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/PartyConfigurationFault"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "PartyConnectionFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to connection errors towards ECs.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/PartyConnectionFault"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "PartyTimeoutFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to EC timeouts.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/PartyTimeoutFault"
         },
         "instance": {
           "type": "string",
@@ -431,6 +650,65 @@
         "PAYMENT_UNKNOWN",
         "DOMAIN_UNKNOWN",
         "PPT_MULTI_BENEFICIARIO",
+        "GENERIC_ERROR"
+      ]
+    },
+    "ValidationFault": {
+      "description": "Fault codes for validation/syntactical errors, should be mapped to 400 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "PPT_DOMINIO_SCONOSCIUTO",
+        "PPT_INTERMEDIARIO_PA_SCONOSCIUTO",
+        "PPT_STAZIONE_INT_PA_SCONOSCIUTA"
+      ]
+    },
+    "GatewayFault": {
+      "description": "Fault codes for generic downstream services errors, should be mapped to 502 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "GENERIC_ERROR",
+        "PPT_PAGAMENTO_IN_CORSO",
+        "PPT_PAGAMENTO_DUPLICATO",
+        "PPT_SINTASSI_EXTRAXSD",
+        "PPT_SINTASSI_XSD",
+        "PPT_PSP_SCONOSCIUTO",
+        "PPT_PSP_DISABILITATO",
+        "PPT_INTERMEDIARIO_PSP_SCONOSCIUTO",
+        "PPT_INTERMEDIARIO_PSP_DISABILITATO",
+        "PPT_CANALE_SCONOSCIUTO",
+        "PPT_CANALE_DISABILITATO",
+        "PPT_AUTENTICAZIONE",
+        "PPT_AUTORIZZAZIONE",
+        "PPT_CODIFICA_PSP_SCONOSCIUTA",
+        "PPT_SEMANTICA",
+        "PPT_SYSTEM_ERROR"
+      ]
+    },
+    "PartyConfigurationFault": {
+      "description": "Fault codes for fatal errors from ECs, should be mapped to 503 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "PPT_DOMINIO_DISABILITATO",
+        "PPT_INTERMEDIARIO_PA_DISABILITATO",
+        "PPT_STAZIONE_INT_PA_DISABILITATA",
+        "PPT_ERRORE_EMESSO_DA_PAA",
+        "PPT_STAZIONE_INT_PA_ERRORE_RESPONSE",
+        "PPT_IBAN_NON_CENSITO"
+      ]
+    },
+    "PartyConnectionFault": {
+      "description": "Fault codes for connection errors to ECs, should be mapped to 598 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE",
+        "PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO"
+      ]
+    },
+    "PartyTimeoutFault": {
+      "description": "Fault codes for timeout errors, should be mapped to 504 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "PPT_STAZIONE_INT_PA_TIMEOUT",
         "GENERIC_ERROR"
       ]
     },

--- a/src/api/checkout/checkout_payment_activations_auth/v1/_base_policy.xml.tpl
+++ b/src/api/checkout/checkout_payment_activations_auth/v1/_base_policy.xml.tpl
@@ -37,7 +37,7 @@
         </set-header>
         <set-variable name="body" value="@(context.Response.Body.As<JObject>())" />
         <choose>
-            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
+            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502 || context.Response.StatusCode == 598) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
                 <return-response>
                     <set-status code="500" />
                     <set-header name="Content-Type" exists-action="override">

--- a/src/api/checkout/checkout_payment_activations_auth/v1/_base_policy.xml.tpl
+++ b/src/api/checkout/checkout_payment_activations_auth/v1/_base_policy.xml.tpl
@@ -37,7 +37,7 @@
         </set-header>
         <set-variable name="body" value="@(context.Response.Body.As<JObject>())" />
         <choose>
-            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502 || context.Response.StatusCode == 598) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
+            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502 || || context.Response.StatusCode == 503 || || context.Response.StatusCode == 504 || context.Response.StatusCode == 598) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
                 <return-response>
                     <set-status code="500" />
                     <set-header name="Content-Type" exists-action="override">

--- a/src/api/checkout/checkout_payment_activations_auth/v1/_base_policy.xml.tpl
+++ b/src/api/checkout/checkout_payment_activations_auth/v1/_base_policy.xml.tpl
@@ -37,7 +37,7 @@
         </set-header>
         <set-variable name="body" value="@(context.Response.Body.As<JObject>())" />
         <choose>
-            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 424) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
+            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
                 <return-response>
                     <set-status code="500" />
                     <set-header name="Content-Type" exists-action="override">

--- a/src/api/checkout/checkout_payment_activations_auth/v1/_swagger.json.tpl
+++ b/src/api/checkout/checkout_payment_activations_auth/v1/_swagger.json.tpl
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "title": "Checkout authenticated API",
     "contact": {
       "name": "pagoPA team",
@@ -39,15 +39,33 @@
             }
           },
           "400": {
-            "description": "Invalid input or PagoPA response",
+            "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/ValidationFaultPaymentProblemJson"
             }
           },
-          "500": {
+          "502": {
             "description": "PagoPA services are not available or request is rejected by PagoPa",
             "schema": {
-              "$ref": "#/definitions/PaymentProblemJson"
+              "$ref": "#/definitions/GatewayFaultPaymentProblemJson"
+            }
+          },
+          "503": {
+            "description": "EC services are not available",
+            "schema": {
+              "$ref": "#/definitions/PartyConfigurationFaultPaymentProblemJson"
+            }
+          },
+          "504": {
+            "description": "Timeout from PagoPA services",
+            "schema": {
+              "$ref": "#/definitions/PartyTimeoutFaultPaymentProblemJson"
+            }
+          },
+          "598": {
+            "description": "Service connection error while connecting to PagoPA services",
+            "schema": {
+              "$ref": "#/definitions/PartyConnectionFaultPaymentProblemJson"
             }
           }
         }
@@ -89,15 +107,33 @@
             }
           },
           "400": {
-            "description": "Invalid input or PagoPA response",
+            "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/ValidationFaultPaymentProblemJson"
             }
           },
-          "500": {
-            "description": "PagoPA services are not available",
+          "502": {
+            "description": "PagoPA services are not available or request is rejected by PagoPa",
             "schema": {
-              "$ref": "#/definitions/PaymentProblemJson"
+              "$ref": "#/definitions/GatewayFaultPaymentProblemJson"
+            }
+          },
+          "503": {
+            "description": "EC services are not available",
+            "schema": {
+              "$ref": "#/definitions/PartyConfigurationFaultPaymentProblemJson"
+            }
+          },
+          "504": {
+            "description": "Timeout from PagoPA services",
+            "schema": {
+              "$ref": "#/definitions/PartyTimeoutFaultPaymentProblemJson"
+            }
+          },
+          "598": {
+            "description": "Service connection error while connecting to PagoPA services",
+            "schema": {
+              "$ref": "#/definitions/PartyConnectionFaultPaymentProblemJson"
             }
           }
         }
@@ -129,7 +165,7 @@
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/ValidationFaultPaymentProblemJson"
             }
           },
           "404": {
@@ -138,10 +174,10 @@
               "$ref": "#/definitions/ProblemJson"
             }
           },
-          "500": {
-            "description": "Service unavailable",
+          "502": {
+            "description": "PagoPA services are not available or request is rejected by PagoPa",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/GatewayFaultPaymentProblemJson"
             }
           }
         }
@@ -179,6 +215,201 @@
         },
         "detail_v2": {
           "$ref": "#/definitions/PaymentFaultV2"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "ValidationFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to validation errors.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/ValidationFault"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "GatewayFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to Nodo errors.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/GatewayFault"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "PartyConfigurationFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to EC fatal errors.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/PartyConfigurationFault"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "PartyConnectionFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to connection errors towards ECs.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/PartyConnectionFault"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "PartyTimeoutFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to EC timeouts.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/PartyTimeoutFault"
         },
         "instance": {
           "type": "string",
@@ -407,6 +638,65 @@
         "PAYMENT_UNKNOWN",
         "DOMAIN_UNKNOWN",
         "PPT_MULTI_BENEFICIARIO",
+        "GENERIC_ERROR"
+      ]
+    },
+    "ValidationFault": {
+      "description": "Fault codes for validation/syntactical errors, should be mapped to 400 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "PPT_DOMINIO_SCONOSCIUTO",
+        "PPT_INTERMEDIARIO_PA_SCONOSCIUTO",
+        "PPT_STAZIONE_INT_PA_SCONOSCIUTA"
+      ]
+    },
+    "GatewayFault": {
+      "description": "Fault codes for generic downstream services errors, should be mapped to 502 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "GENERIC_ERROR",
+        "PPT_PAGAMENTO_IN_CORSO",
+        "PPT_PAGAMENTO_DUPLICATO",
+        "PPT_SINTASSI_EXTRAXSD",
+        "PPT_SINTASSI_XSD",
+        "PPT_PSP_SCONOSCIUTO",
+        "PPT_PSP_DISABILITATO",
+        "PPT_INTERMEDIARIO_PSP_SCONOSCIUTO",
+        "PPT_INTERMEDIARIO_PSP_DISABILITATO",
+        "PPT_CANALE_SCONOSCIUTO",
+        "PPT_CANALE_DISABILITATO",
+        "PPT_AUTENTICAZIONE",
+        "PPT_AUTORIZZAZIONE",
+        "PPT_CODIFICA_PSP_SCONOSCIUTA",
+        "PPT_SEMANTICA",
+        "PPT_SYSTEM_ERROR"
+      ]
+    },
+    "PartyConfigurationFault": {
+      "description": "Fault codes for fatal errors from ECs, should be mapped to 503 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "PPT_DOMINIO_DISABILITATO",
+        "PPT_INTERMEDIARIO_PA_DISABILITATO",
+        "PPT_STAZIONE_INT_PA_DISABILITATA",
+        "PPT_ERRORE_EMESSO_DA_PAA",
+        "PPT_STAZIONE_INT_PA_ERRORE_RESPONSE",
+        "PPT_IBAN_NON_CENSITO"
+      ]
+    },
+    "PartyConnectionFault": {
+      "description": "Fault codes for connection errors to ECs, should be mapped to 598 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE",
+        "PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO"
+      ]
+    },
+    "PartyTimeoutFault": {
+      "description": "Fault codes for timeout errors, should be mapped to 504 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "PPT_STAZIONE_INT_PA_TIMEOUT",
         "GENERIC_ERROR"
       ]
     },

--- a/src/api/checkout/checkout_payment_activations_auth/v2/_base_policy.xml.tpl
+++ b/src/api/checkout/checkout_payment_activations_auth/v2/_base_policy.xml.tpl
@@ -37,7 +37,7 @@
         </set-header>
           <set-variable name="body" value="@(context.Response.Body.As<JObject>())" />
         <choose>
-            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502 || context.Response.StatusCode == 598) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
+            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502 || context.Response.StatusCode == 503 || context.Response.StatusCode == 504 || context.Response.StatusCode == 598) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
                 <return-response>
                     <set-status code="502" />
                     <set-header name="Content-Type" exists-action="override">

--- a/src/api/checkout/checkout_payment_activations_auth/v2/_base_policy.xml.tpl
+++ b/src/api/checkout/checkout_payment_activations_auth/v2/_base_policy.xml.tpl
@@ -37,7 +37,7 @@
         </set-header>
           <set-variable name="body" value="@(context.Response.Body.As<JObject>())" />
         <choose>
-            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
+            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502 || context.Response.StatusCode == 598) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
                 <return-response>
                     <set-status code="502" />
                     <set-header name="Content-Type" exists-action="override">

--- a/src/api/checkout/checkout_payment_activations_auth/v2/_base_policy.xml.tpl
+++ b/src/api/checkout/checkout_payment_activations_auth/v2/_base_policy.xml.tpl
@@ -37,15 +37,15 @@
         </set-header>
           <set-variable name="body" value="@(context.Response.Body.As<JObject>())" />
         <choose>
-            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 424) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
+            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 502) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
                 <return-response>
-                    <set-status code="424" />
+                    <set-status code="502" />
                     <set-header name="Content-Type" exists-action="override">
                         <value>application/json</value>
                     </set-header>
                     <set-body>@{
                     return new JObject(
-                            new JProperty("status", 424),
+                            new JProperty("status", 502),
                             new JProperty("detail_v2", ((JObject) context.Variables["body"])["detail_v2"]),
                             new JProperty("detail", ((JObject) context.Variables["body"])["detail"]),
                             new JProperty("title", ((JObject) context.Variables["body"])["title"])

--- a/src/api/checkout/checkout_payment_activations_auth/v2/_swagger.json.tpl
+++ b/src/api/checkout/checkout_payment_activations_auth/v2/_swagger.json.tpl
@@ -39,21 +39,33 @@
             }
           },
           "400": {
-            "description": "Invalid input or PagoPA response",
+            "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/ValidationFaultPaymentProblemJson"
             }
           },
-          "424": {
-            "description": "PagoPA service error. The requests cannot be handled by PagoPa services.",
-            "schema": {
-              "$ref": "#/definitions/ProblemJson"
-            }
-          },
-          "500": {
+          "502": {
             "description": "PagoPA services are not available or request is rejected by PagoPa",
             "schema": {
-              "$ref": "#/definitions/PaymentProblemJson"
+              "$ref": "#/definitions/GatewayFaultPaymentProblemJson"
+            }
+          },
+          "503": {
+            "description": "EC services are not available",
+            "schema": {
+              "$ref": "#/definitions/PartyConfigurationFaultPaymentProblemJson"
+            }
+          },
+          "504": {
+            "description": "Timeout from PagoPA services",
+            "schema": {
+              "$ref": "#/definitions/PartyTimeoutFaultPaymentProblemJson"
+            }
+          },
+          "598": {
+            "description": "Service connection error while connecting to PagoPA services",
+            "schema": {
+              "$ref": "#/definitions/PartyConnectionFaultPaymentProblemJson"
             }
           }
         }
@@ -95,21 +107,33 @@
             }
           },
           "400": {
-            "description": "Invalid input or PagoPA response",
+            "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/ValidationFaultPaymentProblemJson"
             }
           },
-          "424": {
-            "description": "PagoPA service error. The requests cannot be handled by PagoPa services.",
+          "502": {
+            "description": "PagoPA services are not available or request is rejected by PagoPa",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/GatewayFaultPaymentProblemJson"
             }
           },
-          "500": {
-            "description": "PagoPA services are not available",
+          "503": {
+            "description": "EC services are not available",
             "schema": {
-              "$ref": "#/definitions/PaymentProblemJson"
+              "$ref": "#/definitions/PartyConfigurationFaultPaymentProblemJson"
+            }
+          },
+          "504": {
+            "description": "Timeout from PagoPA services",
+            "schema": {
+              "$ref": "#/definitions/PartyTimeoutFaultPaymentProblemJson"
+            }
+          },
+          "598": {
+            "description": "Service connection error while connecting to PagoPA services",
+            "schema": {
+              "$ref": "#/definitions/PartyConnectionFaultPaymentProblemJson"
             }
           }
         }
@@ -141,7 +165,7 @@
           "400": {
             "description": "Invalid input",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/ValidationFaultPaymentProblemJson"
             }
           },
           "404": {
@@ -150,10 +174,10 @@
               "$ref": "#/definitions/ProblemJson"
             }
           },
-          "500": {
-            "description": "Service unavailable",
+          "502": {
+            "description": "PagoPA services are not available or request is rejected by PagoPa",
             "schema": {
-              "$ref": "#/definitions/ProblemJson"
+              "$ref": "#/definitions/GatewayFaultPaymentProblemJson"
             }
           }
         }
@@ -191,6 +215,201 @@
         },
         "detail_v2": {
           "$ref": "#/definitions/PaymentFaultV2"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "ValidationFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to validation errors.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/ValidationFault"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "GatewayFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to Nodo errors.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/GatewayFault"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "PartyConfigurationFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to EC fatal errors.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/PartyConfigurationFault"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "PartyConnectionFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to connection errors towards ECs.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/PartyConnectionFault"
+        },
+        "instance": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the specific occurrence of the problem.\nIt may or may not yield further information if dereferenced."
+        }
+      },
+      "required": [
+        "detail",
+        "detail_v2"
+      ]
+    },
+    "PartyTimeoutFaultPaymentProblemJson": {
+      "description": "A PaymentProblemJson-like type specific for the GetPayment and ActivatePayment operations.\nPossible values of `detail_v2` are limited to faults pertaining to EC timeouts.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "format": "uri",
+          "description": "An absolute URI that identifies the problem type. When dereferenced,\nit SHOULD provide human-readable documentation for the problem type\n(e.g., using HTML).",
+          "default": "about:blank",
+          "example": "https://example.com/problem/constraint-violation"
+        },
+        "title": {
+          "type": "string",
+          "description": "A short, summary of the problem type. Written in english and readable\nfor engineers (usually not suited for non technical stakeholders and\nnot localized); example: Service Unavailable"
+        },
+        "status": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 100,
+          "maximum": 600,
+          "exclusiveMaximum": true
+        },
+        "detail": {
+          "$ref": "#/definitions/PaymentFault"
+        },
+        "detail_v2": {
+          "$ref": "#/definitions/PartyTimeoutFault"
         },
         "instance": {
           "type": "string",
@@ -419,6 +638,65 @@
         "PAYMENT_UNKNOWN",
         "DOMAIN_UNKNOWN",
         "PPT_MULTI_BENEFICIARIO",
+        "GENERIC_ERROR"
+      ]
+    },
+    "ValidationFault": {
+      "description": "Fault codes for validation/syntactical errors, should be mapped to 400 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "PPT_DOMINIO_SCONOSCIUTO",
+        "PPT_INTERMEDIARIO_PA_SCONOSCIUTO",
+        "PPT_STAZIONE_INT_PA_SCONOSCIUTA"
+      ]
+    },
+    "GatewayFault": {
+      "description": "Fault codes for generic downstream services errors, should be mapped to 502 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "GENERIC_ERROR",
+        "PPT_PAGAMENTO_IN_CORSO",
+        "PPT_PAGAMENTO_DUPLICATO",
+        "PPT_SINTASSI_EXTRAXSD",
+        "PPT_SINTASSI_XSD",
+        "PPT_PSP_SCONOSCIUTO",
+        "PPT_PSP_DISABILITATO",
+        "PPT_INTERMEDIARIO_PSP_SCONOSCIUTO",
+        "PPT_INTERMEDIARIO_PSP_DISABILITATO",
+        "PPT_CANALE_SCONOSCIUTO",
+        "PPT_CANALE_DISABILITATO",
+        "PPT_AUTENTICAZIONE",
+        "PPT_AUTORIZZAZIONE",
+        "PPT_CODIFICA_PSP_SCONOSCIUTA",
+        "PPT_SEMANTICA",
+        "PPT_SYSTEM_ERROR"
+      ]
+    },
+    "PartyConfigurationFault": {
+      "description": "Fault codes for fatal errors from ECs, should be mapped to 503 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "PPT_DOMINIO_DISABILITATO",
+        "PPT_INTERMEDIARIO_PA_DISABILITATO",
+        "PPT_STAZIONE_INT_PA_DISABILITATA",
+        "PPT_ERRORE_EMESSO_DA_PAA",
+        "PPT_STAZIONE_INT_PA_ERRORE_RESPONSE",
+        "PPT_IBAN_NON_CENSITO"
+      ]
+    },
+    "PartyConnectionFault": {
+      "description": "Fault codes for connection errors to ECs, should be mapped to 598 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "PPT_STAZIONE_INT_PA_IRRAGGIUNGIBILE",
+        "PPT_STAZIONE_INT_PA_SERVIZIO_NONATTIVO"
+      ]
+    },
+    "PartyTimeoutFault": {
+      "description": "Fault codes for timeout errors, should be mapped to 504 HTTP status code.",
+      "type": "string",
+      "x-extensible-enum": [
+        "PPT_STAZIONE_INT_PA_TIMEOUT",
         "GENERIC_ERROR"
       ]
     },


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

 * Update Swagger spec associated to API
 * Add new HTTP status code handling in APIM policy

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This PR makes monitoring the affected API easier while providing a stricter API specification

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
