### PR TITLE
[PPD-175] add reporting autoscaling

### DIFF
--- a/src/gpd_reporting.tf
+++ b/src/gpd_reporting.tf
@@ -302,95 +302,97 @@ resource "azurerm_monitor_autoscale_setting" "reporting_function" {
       maximum = var.reporting_function_autoscale_maximum
     }
 
-    # reporting_batch on queue size reporting_organizations_queue
-    rule {
-      metric_trigger {
-        metric_name = "ApproximateMessageCount"
+    # disable rules for batch and service
 
-        metric_resource_id = join("/", ["${module.flows.id}", "services/queue/queues", "${azurerm_storage_queue.reporting_organizations_queue.name}"])
-        time_grain         = "PT1M"
-        statistic          = "Average"
-        time_window        = "PT1M"
-        time_aggregation   = "Average"
-        operator           = "GreaterThanOrEqual"
-        threshold          = 10
-      }
+    # # reporting_batch on queue size reporting_organizations_queue
+    # rule {
+    #   metric_trigger {
+    #     metric_name = "ApproximateMessageCount"
 
-      scale_action {
-        direction = "Increase"
-        type      = "ChangeCount"
-        value     = "1"
-        cooldown  = "PT1M"
-      }
+    #     metric_resource_id = join("/", ["${module.flows.id}", "services/queue/queues", "${azurerm_storage_queue.reporting_organizations_queue.name}"])
+    #     time_grain         = "PT1M"
+    #     statistic          = "Average"
+    #     time_window        = "PT1M"
+    #     time_aggregation   = "Average"
+    #     operator           = "GreaterThanOrEqual"
+    #     threshold          = 10
+    #   }
 
-    }
+    #   scale_action {
+    #     direction = "Increase"
+    #     type      = "ChangeCount"
+    #     value     = "1"
+    #     cooldown  = "PT1M"
+    #   }
 
-    rule {
-      metric_trigger {
-        metric_name        = "ApproximateMessageCount"
-        metric_resource_id = join("/", ["${module.flows.id}", "services/queue/queues", "${azurerm_storage_queue.reporting_organizations_queue.name}"])
-        time_grain         = "PT1M"
-        statistic          = "Average"
-        time_window        = "PT1M"
-        time_aggregation   = "Average"
-        operator           = "LessThan"
-        threshold          = 10
-      }
+    # }
 
-      scale_action {
-        direction = "Decrease"
-        type      = "ChangeCount"
-        value     = "1"
-        cooldown  = "PT1M"
-      }
+    # rule {
+    #   metric_trigger {
+    #     metric_name        = "ApproximateMessageCount"
+    #     metric_resource_id = join("/", ["${module.flows.id}", "services/queue/queues", "${azurerm_storage_queue.reporting_organizations_queue.name}"])
+    #     time_grain         = "PT1M"
+    #     statistic          = "Average"
+    #     time_window        = "PT1M"
+    #     time_aggregation   = "Average"
+    #     operator           = "LessThan"
+    #     threshold          = 10
+    #   }
 
-
-    }
-
-    # reporting_service on queue size reporting_flows_queue
-    rule {
-      metric_trigger {
-        metric_name = "ApproximateMessageCount"
-
-        metric_resource_id = join("/", ["${module.flows.id}", "services/queue/queues", "${azurerm_storage_queue.reporting_flows_queue.name}"])
-        time_grain         = "PT1M"
-        statistic          = "Average"
-        time_window        = "PT1M"
-        time_aggregation   = "Average"
-        operator           = "GreaterThanOrEqual"
-        threshold          = 10
-      }
-
-      scale_action {
-        direction = "Increase"
-        type      = "ChangeCount"
-        value     = "1"
-        cooldown  = "PT1M"
-      }
-
-    }
-
-    rule {
-      metric_trigger {
-        metric_name        = "ApproximateMessageCount"
-        metric_resource_id = join("/", ["${module.flows.id}", "services/queue/queues", "${azurerm_storage_queue.reporting_flows_queue.name}"])
-        time_grain         = "PT1M"
-        statistic          = "Average"
-        time_window        = "PT1M"
-        time_aggregation   = "Average"
-        operator           = "LessThan"
-        threshold          = 10
-      }
-
-      scale_action {
-        direction = "Decrease"
-        type      = "ChangeCount"
-        value     = "1"
-        cooldown  = "PT1M"
-      }
+    #   scale_action {
+    #     direction = "Decrease"
+    #     type      = "ChangeCount"
+    #     value     = "1"
+    #     cooldown  = "PT1M"
+    #   }
 
 
-    }
+    # }
+
+    # # reporting_service on queue size reporting_flows_queue
+    # rule {
+    #   metric_trigger {
+    #     metric_name = "ApproximateMessageCount"
+
+    #     metric_resource_id = join("/", ["${module.flows.id}", "services/queue/queues", "${azurerm_storage_queue.reporting_flows_queue.name}"])
+    #     time_grain         = "PT1M"
+    #     statistic          = "Average"
+    #     time_window        = "PT1M"
+    #     time_aggregation   = "Average"
+    #     operator           = "GreaterThanOrEqual"
+    #     threshold          = 10
+    #   }
+
+    #   scale_action {
+    #     direction = "Increase"
+    #     type      = "ChangeCount"
+    #     value     = "1"
+    #     cooldown  = "PT1M"
+    #   }
+
+    # }
+
+    # rule {
+    #   metric_trigger {
+    #     metric_name        = "ApproximateMessageCount"
+    #     metric_resource_id = join("/", ["${module.flows.id}", "services/queue/queues", "${azurerm_storage_queue.reporting_flows_queue.name}"])
+    #     time_grain         = "PT1M"
+    #     statistic          = "Average"
+    #     time_window        = "PT1M"
+    #     time_aggregation   = "Average"
+    #     operator           = "LessThan"
+    #     threshold          = 10
+    #   }
+
+    #   scale_action {
+    #     direction = "Decrease"
+    #     type      = "ChangeCount"
+    #     value     = "1"
+    #     cooldown  = "PT1M"
+    #   }
+
+
+    # }
 
     # reporting_analysis on http requests
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

The purpose of this PR is to fix [reporting](https://pagopa.atlassian.net/wiki/spaces/PPD/pages/456525211/Design+Review+-+Rendicontazione) az-fn autoscaling.


### List of changes

Add `azurerm_monitor_autoscale_setting` for az function : 
  - `reporting_batch_function`
  - `reporting_service_function`
  - `reporting_analysis_function`

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
