### PR TITLE
[PPD-189] resize Postgres Flexible UAT and PROD

### DIFF
--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -412,7 +412,7 @@ canoneunico_queue_message_delay = 3600 // in seconds = 1h
 pgres_flex_params = {
 
   private_endpoint_enabled = true
-  sku_name                 = "GP_Standard_D4ds_v3"
+  sku_name                 = "GP_Standard_D4s_v3"
   db_version               = "13"
   # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
   # 2097152, 4194304, 8388608, 16777216, and 33554432.

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -412,7 +412,7 @@ canoneunico_queue_message_delay = 3600 // in seconds = 1h
 pgres_flex_params = {
 
   private_endpoint_enabled = true
-  sku_name                 = "GP_Standard_D4s_v4"
+  sku_name                 = "GP_Standard_D4ds_v4"
   db_version               = "13"
   # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
   # 2097152, 4194304, 8388608, 16777216, and 33554432.

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -412,7 +412,7 @@ canoneunico_queue_message_delay = 3600 // in seconds = 1h
 pgres_flex_params = {
 
   private_endpoint_enabled = true
-  sku_name                 = "GP_Standard_D4ds_v4"
+  sku_name                 = "GP_Standard_D4ds_v3"
   db_version               = "13"
   # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
   # 2097152, 4194304, 8388608, 16777216, and 33554432.

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -412,7 +412,7 @@ canoneunico_queue_message_delay = 3600 // in seconds = 1h
 pgres_flex_params = {
 
   private_endpoint_enabled = true
-  sku_name                 = "GP_Standard_D4ds_v4"
+  sku_name                 = "GP_Standard_D4s_v4"
   db_version               = "13"
   # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
   # 2097152, 4194304, 8388608, 16777216, and 33554432.

--- a/src/env/prod/terraform.tfvars
+++ b/src/env/prod/terraform.tfvars
@@ -412,7 +412,7 @@ canoneunico_queue_message_delay = 3600 // in seconds = 1h
 pgres_flex_params = {
 
   private_endpoint_enabled = true
-  sku_name                 = "GP_Standard_D8s_v3"
+  sku_name                 = "GP_Standard_D4s_v4"
   db_version               = "13"
   # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
   # 2097152, 4194304, 8388608, 16777216, and 33554432.

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -391,7 +391,7 @@ canoneunico_function_autoscale_default = 1
 pgres_flex_params = {
 
   private_endpoint_enabled = true
-  sku_name                 = "GP_Standard_D2ds_v3"
+  sku_name                 = "GP_Standard_D2s_v3"
   db_version               = "13"
   # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
   # 2097152, 4194304, 8388608, 16777216, and 33554432.

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -391,7 +391,7 @@ canoneunico_function_autoscale_default = 1
 pgres_flex_params = {
 
   private_endpoint_enabled = true
-  sku_name                 = "GP_Standard_D2s_v3"
+  sku_name                 = "GP_Standard_D2s_v4"
   db_version               = "13"
   # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
   # 2097152, 4194304, 8388608, 16777216, and 33554432.

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -391,7 +391,7 @@ canoneunico_function_autoscale_default = 1
 pgres_flex_params = {
 
   private_endpoint_enabled = true
-  sku_name                 = "GP_Standard_D2ds_v4"
+  sku_name                 = "GP_Standard_D2s_v4"
   db_version               = "13"
   # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
   # 2097152, 4194304, 8388608, 16777216, and 33554432.

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -391,7 +391,7 @@ canoneunico_function_autoscale_default = 1
 pgres_flex_params = {
 
   private_endpoint_enabled = true
-  sku_name                 = "GP_Standard_D2ds_v4"
+  sku_name                 = "GP_Standard_D2ds_v3"
   db_version               = "13"
   # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
   # 2097152, 4194304, 8388608, 16777216, and 33554432.

--- a/src/env/uat/terraform.tfvars
+++ b/src/env/uat/terraform.tfvars
@@ -391,7 +391,7 @@ canoneunico_function_autoscale_default = 1
 pgres_flex_params = {
 
   private_endpoint_enabled = true
-  sku_name                 = "GP_Standard_D2s_v4"
+  sku_name                 = "GP_Standard_D2ds_v4"
   db_version               = "13"
   # Possible values are 32768, 65536, 131072, 262144, 524288, 1048576,
   # 2097152, 4194304, 8388608, 16777216, and 33554432.


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

The purpose of this PR is to : 
- downscale in PROD from `D8` to `D4`

:warning: **this change'll lead to a period of temporary unavailability of the postgres DB**


### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
