### PR TITLE
[CHK-418] Fix missing remapping of 404 HTTP status code

### DIFF
--- a/src/api/checkout/checkout_payment_activations/v1/_base_policy.xml.tpl
+++ b/src/api/checkout/checkout_payment_activations/v1/_base_policy.xml.tpl
@@ -27,7 +27,7 @@
         </set-header>
         <set-variable name="body" value="@(context.Response.Body.As<JObject>())" />
         <choose>
-            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 409 || context.Response.StatusCode == 424 || context.Response.StatusCode == 502 || context.Response.StatusCode == 503 || context.Response.StatusCode == 504) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
+            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 404 || context.Response.StatusCode == 409 || context.Response.StatusCode == 424 || context.Response.StatusCode == 502 || context.Response.StatusCode == 503 || context.Response.StatusCode == 504) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
                 <return-response>
                     <set-status code="400" />
                     <set-header name="Content-Type" exists-action="override">

--- a/src/api/checkout/checkout_payment_activations_auth/v1/_base_policy.xml.tpl
+++ b/src/api/checkout/checkout_payment_activations_auth/v1/_base_policy.xml.tpl
@@ -37,7 +37,7 @@
         </set-header>
         <set-variable name="body" value="@(context.Response.Body.As<JObject>())" />
         <choose>
-            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 409 || context.Response.StatusCode == 424 || context.Response.StatusCode == 502 || context.Response.StatusCode == 503 || context.Response.StatusCode == 504) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
+            <when condition="@( (context.Response.StatusCode == 500 || context.Response.StatusCode == 404 || context.Response.StatusCode == 409 || context.Response.StatusCode == 424 || context.Response.StatusCode == 502 || context.Response.StatusCode == 503 || context.Response.StatusCode == 504) && ((JObject) context.Variables["body"])["detail_v2"] != null )">
                 <return-response>
                     <set-status code="500" />
                     <set-header name="Content-Type" exists-action="override">


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

* Fix missing remapping of 404 HTTP status code in Checkout APIs

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In a previous PR (#236) Checkout policies were updated in order to backward-compatibly upgrade the API. This PR fixes a retrocompatibility bug by adding a previously unmapped HTTP status code to a 400 status code as expected by old API versions.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
