### PR TITLE
[PPR-353] fix content-type verificatore

### DIFF
--- a/src/api/nodopagamenti_api/nodeForPsp/v1/activate_nm3.xml
+++ b/src/api/nodopagamenti_api/nodeForPsp/v1/activate_nm3.xml
@@ -84,7 +84,7 @@
             <when condition="@(context.Variables.ContainsKey("attvazionePrenotata"))">
                 <return-response>
                     <set-header name="Content-Type" exists-action="override">
-                        <value>application/xml</value>
+                        <value>text/xml</value>
                     </set-header>
                     <set-body template="liquid">
 						<soapenv:Envelope xmlns:tns="http://pagopa-api.pagopa.gov.it/node/nodeForPsp.wsdl" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:nfpsp="http://pagopa-api.pagopa.gov.it/node/nodeForPsp.xsd" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
@@ -142,7 +142,7 @@
                             <set-url>{{urlnodo}}</set-url>
                             <set-method>POST</set-method>
                             <set-header name="Content-Type" exists-action="override">
-                                <value>application/xml</value>
+                                <value>text/xml</value>
                             </set-header>
                             <set-header name="SOAPAction" exists-action="override">
                                 <value>verifyPaymentNotice</value>
@@ -196,7 +196,7 @@
                                     </when>
                                 </choose>
                                 <set-header name="Content-Type" exists-action="override">
-                                    <value>application/xml</value>
+                                    <value>text/xml</value>
                                 </set-header>
                                 <set-header name="SOAPAction" exists-action="override">
                                     <value>activatePaymentNotice</value>
@@ -373,7 +373,7 @@
                                     <when condition="@("".Equals((string)context.Variables["originalFaultCode"]))">
                                         <return-response>
                                             <set-header name="Content-Type" exists-action="override">
-                                                <value>application/xml</value>
+                                                <value>text/xml</value>
                                             </set-header>
                                             <set-body template="liquid">
 												<soapenv:Envelope xmlns:tns="http://pagopa-api.pagopa.gov.it/node/nodeForPsp.wsdl" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:nfpsp="http://pagopa-api.pagopa.gov.it/node/nodeForPsp.xsd" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
@@ -395,7 +395,7 @@
                                     <otherwise>
                                         <return-response>
                                             <set-header name="Content-Type" exists-action="override">
-                                                <value>application/xml</value>
+                                                <value>text/xml</value>
                                             </set-header>
                                             <set-body template="liquid">
 												<soapenv:Envelope xmlns:tns="http://pagopa-api.pagopa.gov.it/node/nodeForPsp.wsdl" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:nfpsp="http://pagopa-api.pagopa.gov.it/node/nodeForPsp.xsd" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
@@ -433,7 +433,7 @@
                 }" />
                         <set-method>POST</set-method>
                         <set-header name="Content-Type" exists-action="override">
-                            <value>application/xml</value>
+                            <value>text/xml</value>
                         </set-header>
                         <set-header name="SOAPAction" exists-action="override">
                             <value>activatePaymentNotice</value>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Change content-type in custom response.
From application/xml to text/xml

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Some proxies don't accept the content type application/xml

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [X] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
