### PR TITLE
feat: Add activateIO reservation policy

### DIFF
--- a/src/api/nodopagamenti_api/nodeForIO/v1/activateIO_reservation_nm3.xml
+++ b/src/api/nodopagamenti_api/nodeForIO/v1/activateIO_reservation_nm3.xml
@@ -1,0 +1,64 @@
+<policies>
+    <inbound>
+        <set-variable name="readrequest" value="@(context.Request.Body.As<string>(preserveContent: true))" />
+        <set-variable name="fiscalCode" value="@{
+            var dom2parse = ((string) context.Variables["readrequest"]);
+            String[] spearator = {"fiscalCode"};
+            String[] result = dom2parse.Split(spearator, StringSplitOptions.RemoveEmptyEntries);
+            var fiscalCode = result[1].Substring(1,result[1].Length-3);
+            return fiscalCode;
+        }" />
+        <set-variable name="noticeNumber" value="@{
+            var dom2parse = ((string) context.Variables["readrequest"]);
+            String[] spearator = {"noticeNumber"};
+            String[] result = dom2parse.Split(spearator, StringSplitOptions.RemoveEmptyEntries);
+            var noticeNumber = result[1].Substring(1,result[1].Length-3);
+            return noticeNumber;
+        }" />
+        <!--
+        if attvazionePrenotata then sent PPT_ATTIVAZIONE_IN_CORSO
+        else store PPT_ATTIVAZIONE_IN_CORSO in attvazionePrenotata for fiscalCode and noticeNumber
+        -->
+        <cache-lookup-value key="@((string) context.Variables["fiscalCode"]+""+(string) context.Variables["noticeNumber"])" variable-name="attvazionePrenotata" caching-type="internal" />
+        <choose>
+            <when condition="@(context.Variables.ContainsKey("attvazionePrenotata"))">
+                <return-response>
+                    <set-header name="Content-Type" exists-action="override">
+                        <value>text/xml</value>
+                    </set-header>
+                    <set-body template="liquid">
+						<soapenv:Envelope xmlns:tns="http://pagopa-api.pagopa.gov.it/node/nodoForIO.wsdl" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:nfpsp="http://pagopa-api.pagopa.gov.it/node/nodoForIO.xsd" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+							<soapenv:Body>
+								<nfpsp:activateIOPaymentRes>
+									<outcome>KO</outcome>
+									<fault>
+										<faultCode>PPT_ATTIVAZIONE_IN_CORSO</faultCode>
+										<faultString>E' in corso un'altra attivazione per lo stesso avviso</faultString>
+										<id>NodoDeiPagamentiSPC</id>
+										<description>E' in corso un'altra attivazione per lo stesso avviso</description>
+									</fault>
+								</nfpsp:activateIOPaymentRes>
+							</soapenv:Body>
+						</soapenv:Envelope>
+					</set-body>
+                </return-response>
+            </when>
+            <otherwise>
+                <cache-store-value key="@((string) context.Variables["fiscalCode"]+""+(string) context.Variables["noticeNumber"])" value="PPT_ATTIVAZIONE_IN_CORSO" duration="30" caching-type="internal" />
+            </otherwise>
+        </choose>
+        <base />
+        <set-backend-service base-url="{{urlnodo}}" />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <!-- on activatePaymentNotice response delete cache attvazionePrenotata #2 -->
+        <cache-remove-value key="@((string) context.Variables["fiscalCode"]+""+(string) context.Variables["noticeNumber"])" caching-type="internal" />
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/apim_nodo_services.tf
+++ b/src/apim_nodo_services.tf
@@ -291,6 +291,16 @@ resource "azurerm_api_management_api_policy" "apim_node_for_io_policy" {
   xml_content = file("./api/nodopagamenti_api/nodeForIO/v1/_base_policy.xml")
 }
 
+resource "azurerm_api_management_api_operation_policy" "activateIO_reservation_policy" {
+
+  api_name            = resource.azurerm_api_management_api.apim_node_for_io_api_v1.name
+  api_management_name = module.apim.name
+  resource_group_name = azurerm_resource_group.rg_api.name
+  operation_id        = var.env_short == "d" ? "61dc5018b78e981290d7c176" : var.env_short == "u" ? "61dedb1e72975e13800fd80f" : "61dedb1eea7c4a07cc7d47b8"
+
+  #tfsec:ignore:GEN005
+  xml_content = file("./api/nodopagamenti_api/nodeForIO/v1/activateIO_reservation_nm3.xml")
+}
 
 ############################
 ## WS psp for node (NM3) ##


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

The purpose of this PR is to enable activateIO reservation policy APIm

![image](https://user-images.githubusercontent.com/36746022/174767837-12e2fb5a-cb87-46a2-b236-a6d073777e14.png)

### List of changes

Add : 
  - apim policy for`nodo/node-for-io/v1` with `SOAPAction: "activateIOPayment"`

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
