### PR TITLE
Update DNS IP for DB Nodo on Cloud 

### DIFF
--- a/src/appgateway.tf
+++ b/src/appgateway.tf
@@ -212,7 +212,7 @@ module "app_gw" {
         },
         {
           name          = "http-deny-path2"
-          rule_sequence = 1
+          rule_sequence = 2
           condition = {
             variable    = "var_uri_path"
             pattern     = join("|", var.app_gateway_deny_paths_2)

--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -78,6 +78,7 @@ app_gateway_deny_paths = [
   "/notfound/*",
 ]
 app_gateway_deny_paths_2 = [
+  "/notfound2/*",
 ]
 
 # postgresql

--- a/src/env/dev/terraform.tfvars
+++ b/src/env/dev/terraform.tfvars
@@ -308,9 +308,9 @@ eventhubs = [
 acr_enabled = true
 
 # db nodo dei pagamenti
-db_port                            = 1523
+db_port                            = 1522
 db_service_name                    = "NDPSPCT_PP_NODO4_CFG"
-dns_a_reconds_dbnodo_ips           = ["10.8.3.228"]
+dns_a_reconds_dbnodo_ips           = ["10.70.67.18"]
 private_dns_zone_db_nodo_pagamenti = "d.db-nodo-pagamenti.com"
 
 # API Config

--- a/src/network.tf
+++ b/src/network.tf
@@ -110,6 +110,13 @@ module "route_table_peering_sia" {
       next_hop_type          = "VirtualAppliance"
       next_hop_in_ip_address = "10.70.249.10"
     },
+    {
+      # dev nodo db oncloud
+      name                   = "to-nodo-db-oncloud-sia-dev"
+      address_prefix         = "10.70.67.0/24"
+      next_hop_type          = "VirtualAppliance"
+      next_hop_in_ip_address = "10.70.249.10"
+    },
   ]
 
   tags = var.tags


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

The purpose of this pr is to change ip and port of dns `d.db-nodo-pagamenti.com` for nodo-dei-pagamenti's db from onPrem to onCloud according to [Regole di Rete](https://pagopa.atlassian.net/wiki/spaces/PPA/pages/464650382/Regole+di+Rete)

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
