### PR TITLE
fix: update readme with new terraform.sh location

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ tfenv install
 
 ## Environment management
 
-In order to properly populate terraform variables for each environment, a script located at `src/terraform.sh` is provided.
+In order to properly populate terraform variables for each environment, a script located at `src/core/terraform.sh` is provided.
 
 Terraform invocations described here where environent parameters are required can be replaced with invocations to `terraform.sh` by passing an environment specification. For example:
 
@@ -30,7 +30,7 @@ Terraform invocations described here where environent parameters are required ca
 ./terraform.sh plan dev -target=module=api_config
 ```
 
-**NOTE**: `terraform.sh` must be run from the `src` folder.
+**NOTE**: `terraform.sh` must be run from the `src/core` folder.
 
 ## Terraform modules
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context
Readme is not updated and the location of the `terraform.sh` script is not correct

<!--- Why is this change required? What problem does it solve? -->
This change is necessary in order to facilitate the usage of the `terraform.sh` script

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
