### PR TITLE
feat: Add mock EC-PSP-PM Nexi via UAT/PRF 

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -40,9 +40,15 @@
 | <a name="module_apim_gpd_product"></a> [apim\_gpd\_product](#module\_apim\_gpd\_product) | git::https://github.com/pagopa/azurerm.git//api_management_product | v1.0.90 |
 | <a name="module_apim_gpd_reporting_analysis_product"></a> [apim\_gpd\_reporting\_analysis\_product](#module\_apim\_gpd\_reporting\_analysis\_product) | git::https://github.com/pagopa/azurerm.git//api_management_product | v1.0.90 |
 | <a name="module_apim_mock_ec_api"></a> [apim\_mock\_ec\_api](#module\_apim\_mock\_ec\_api) | git::https://github.com/pagopa/azurerm.git//api_management_api | v1.0.90 |
+| <a name="module_apim_mock_ec_nexi_api"></a> [apim\_mock\_ec\_nexi\_api](#module\_apim\_mock\_ec\_nexi\_api) | git::https://github.com/pagopa/azurerm.git//api_management_api | v1.0.90 |
+| <a name="module_apim_mock_ec_nexi_product"></a> [apim\_mock\_ec\_nexi\_product](#module\_apim\_mock\_ec\_nexi\_product) | git::https://github.com/pagopa/azurerm.git//api_management_product | v1.0.90 |
 | <a name="module_apim_mock_ec_product"></a> [apim\_mock\_ec\_product](#module\_apim\_mock\_ec\_product) | git::https://github.com/pagopa/azurerm.git//api_management_product | v1.0.90 |
+| <a name="module_apim_mock_pm_nexi_api"></a> [apim\_mock\_pm\_nexi\_api](#module\_apim\_mock\_pm\_nexi\_api) | git::https://github.com/pagopa/azurerm.git//api_management_api | v1.0.90 |
+| <a name="module_apim_mock_pm_nexi_product"></a> [apim\_mock\_pm\_nexi\_product](#module\_apim\_mock\_pm\_nexi\_product) | git::https://github.com/pagopa/azurerm.git//api_management_product | v1.0.90 |
 | <a name="module_apim_mock_psp_api"></a> [apim\_mock\_psp\_api](#module\_apim\_mock\_psp\_api) | git::https://github.com/pagopa/azurerm.git//api_management_api | v1.0.90 |
 | <a name="module_apim_mock_psp_mng_api"></a> [apim\_mock\_psp\_mng\_api](#module\_apim\_mock\_psp\_mng\_api) | git::https://github.com/pagopa/azurerm.git//api_management_api | v1.0.90 |
+| <a name="module_apim_mock_psp_nexi_api"></a> [apim\_mock\_psp\_nexi\_api](#module\_apim\_mock\_psp\_nexi\_api) | git::https://github.com/pagopa/azurerm.git//api_management_api | v1.0.90 |
+| <a name="module_apim_mock_psp_nexi_product"></a> [apim\_mock\_psp\_nexi\_product](#module\_apim\_mock\_psp\_nexi\_product) | git::https://github.com/pagopa/azurerm.git//api_management_product | v1.0.90 |
 | <a name="module_apim_mock_psp_product"></a> [apim\_mock\_psp\_product](#module\_apim\_mock\_psp\_product) | git::https://github.com/pagopa/azurerm.git//api_management_product | v1.0.90 |
 | <a name="module_apim_nodo_dei_pagamenti_product"></a> [apim\_nodo\_dei\_pagamenti\_product](#module\_apim\_nodo\_dei\_pagamenti\_product) | git::https://github.com/pagopa/azurerm.git//api_management_product | v1.0.90 |
 | <a name="module_apim_nodo_fatturazione_api"></a> [apim\_nodo\_fatturazione\_api](#module\_apim\_nodo\_fatturazione\_api) | git::https://github.com/pagopa/azurerm.git//api_management_api | v1.0.90 |
@@ -232,6 +238,9 @@
 | [azurerm_api_management_api_version_set.checkout_payment_activations_auth_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |
 | [azurerm_api_management_api_version_set.checkout_transactions_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |
 | [azurerm_api_management_api_version_set.mock_ec_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |
+| [azurerm_api_management_api_version_set.mock_ec_nexi_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |
+| [azurerm_api_management_api_version_set.mock_pm_nexi_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |
+| [azurerm_api_management_api_version_set.mock_psp_nexi_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |
 | [azurerm_api_management_api_version_set.node_for_io_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |
 | [azurerm_api_management_api_version_set.node_for_psp_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |
 | [azurerm_api_management_api_version_set.nodo_fatturazione_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |

--- a/src/core/api/mock_nexi/ec/v1/_base_policy.xml
+++ b/src/core/api/mock_nexi/ec/v1/_base_policy.xml
@@ -1,0 +1,15 @@
+<policies>
+    <inbound>
+        <base />
+        <set-backend-service base-url="http://{{aks-lb-nexi}}${mock_base_path}" />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/core/api/mock_nexi/ec/v1/mock.openapi.json.tpl
+++ b/src/core/api/mock_nexi/ec/v1/mock.openapi.json.tpl
@@ -1,0 +1,71 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Mock",
+    "description": "Api and Models",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://${host}"
+    }
+  ],
+  "paths": {
+    "/*": {
+      "get": {
+        "summary": "get",
+        "operationId": "get",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "summary": "post",
+        "operationId": "post",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "put": {
+        "summary": "put",
+        "operationId": "put",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "delete": {
+        "summary": "del",
+        "operationId": "del",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "head": {
+        "summary": "head",
+        "operationId": "head",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "options": {
+        "summary": "opt",
+        "operationId": "opt",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/core/api/mock_nexi/pm/v1/_base_policy.xml
+++ b/src/core/api/mock_nexi/pm/v1/_base_policy.xml
@@ -1,0 +1,15 @@
+<policies>
+    <inbound>
+        <base />
+        <set-backend-service base-url="http://{{aks-lb-nexi}}${mock_base_path}" />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/core/api/mock_nexi/pm/v1/mock.openapi.json.tpl
+++ b/src/core/api/mock_nexi/pm/v1/mock.openapi.json.tpl
@@ -1,0 +1,71 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Mock",
+    "description": "Api and Models",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://${host}"
+    }
+  ],
+  "paths": {
+    "/*": {
+      "get": {
+        "summary": "get",
+        "operationId": "get",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "summary": "post",
+        "operationId": "post",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "put": {
+        "summary": "put",
+        "operationId": "put",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "delete": {
+        "summary": "del",
+        "operationId": "del",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "head": {
+        "summary": "head",
+        "operationId": "head",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "options": {
+        "summary": "opt",
+        "operationId": "opt",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/core/api/mock_nexi/psp/v1/_base_policy.xml
+++ b/src/core/api/mock_nexi/psp/v1/_base_policy.xml
@@ -1,0 +1,15 @@
+<policies>
+    <inbound>
+        <base />
+        <set-backend-service base-url="http://{{aks-lb-nexi}}${mock_base_path}" />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/core/api/mock_nexi/psp/v1/mock.openapi.json.tpl
+++ b/src/core/api/mock_nexi/psp/v1/mock.openapi.json.tpl
@@ -1,0 +1,71 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Mock",
+    "description": "Api and Models",
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "https://${host}"
+    }
+  ],
+  "paths": {
+    "/*": {
+      "get": {
+        "summary": "get",
+        "operationId": "get",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "post": {
+        "summary": "post",
+        "operationId": "post",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "put": {
+        "summary": "put",
+        "operationId": "put",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "delete": {
+        "summary": "del",
+        "operationId": "del",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "head": {
+        "summary": "head",
+        "operationId": "head",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      },
+      "options": {
+        "summary": "opt",
+        "operationId": "opt",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/core/api_product/mock_nexi/_base_policy.xml
+++ b/src/core/api_product/mock_nexi/_base_policy.xml
@@ -1,0 +1,26 @@
+<!--
+    IMPORTANT:
+    - Policy elements can appear only within the <inbound>, <outbound>, <backend> section elements.
+    - To apply a policy to the incoming request (before it is forwarded to the backend service), place a corresponding policy element within the <inbound> section element.
+    - To apply a policy to the outgoing response (before it is sent back to the caller), place a corresponding policy element within the <outbound> section element.
+    - To add a policy, place the cursor at the desired insertion point and select a policy from the sidebar.
+    - To remove a policy, delete the corresponding policy statement from the policy document.
+    - Position the <base> element within a section element to inherit all policies from the corresponding section element in the enclosing scope.
+    - Remove the <base> element to prevent inheriting policies from the corresponding section element in the enclosing scope.
+    - Policies are applied in the order of their appearance, from the top down.
+    - Comments within policy elements are not supported and may disappear. Place your comments between policy elements or at a higher level scope.
+-->
+<policies>
+    <inbound>
+        <base />     
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/core/apim_mock_ec_psp_pm_nexi.tf
+++ b/src/core/apim_mock_ec_psp_pm_nexi.tf
@@ -1,0 +1,198 @@
+
+############################
+## Mock Nexi cfg in PRF   ##
+############################
+
+# PM  -> lb aks uat 10.70.74.200+ /mock-pm-prf  +   /PerfPMMock/RestAPI
+# EC  -> lb aks uat 10.70.74.200+ /ec-mockprf   +   /servizio
+# PSP -> lb aks uat 10.70.74.200+ /psp-mockprf  +   /simulatorePSP
+
+############################
+## Mock EC Nexi           ##
+############################
+
+module "apim_mock_ec_nexi_product" {
+  count  = var.env_short == "u" ? 1 : 0 # only UAT pointing out to NEXI PRF environment 
+  source = "git::https://github.com/pagopa/azurerm.git//api_management_product?ref=v1.0.90"
+
+  product_id   = "product-mock-ec-nexi"
+  display_name = "product-mock-ec-nexi"
+  description  = "product-mock-ec-nexi"
+
+  api_management_name = module.apim.name
+  resource_group_name = azurerm_resource_group.rg_api.name
+
+  published             = true
+  subscription_required = false
+  approval_required     = false
+
+  policy_xml = file("./api_product/mock_nexi/_base_policy.xml")
+}
+
+resource "azurerm_api_management_api_version_set" "mock_ec_nexi_api" {
+  count = var.env_short == "u" ? 1 : 0 # only UAT pointing out to NEXI PRF environment 
+
+  name                = format("%s-mock-ec-nexi-api", var.env_short)
+  resource_group_name = azurerm_resource_group.rg_api.name
+  api_management_name = module.apim.name
+  display_name        = "Mock Ec Nexi"
+  versioning_scheme   = "Segment"
+}
+
+module "apim_mock_ec_nexi_api" {
+  count  = var.env_short == "u" ? 1 : 0 # only UAT pointing out to NEXI PRF environment 
+  source = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=v1.0.90"
+
+  name                  = format("%s-mock-ec-nexi-api", var.env_short)
+  api_management_name   = module.apim.name
+  resource_group_name   = azurerm_resource_group.rg_api.name
+  product_ids           = [module.apim_mock_ec_nexi_product[0].product_id]
+  subscription_required = false
+
+  version_set_id = azurerm_api_management_api_version_set.mock_ec_nexi_api[0].id
+  api_version    = "v1"
+
+  description  = "Mock Ec Nexi PRF"
+  display_name = "Mock Ec Nexi PRF "
+  path         = "ec-mockprf"
+  protocols    = ["https"]
+
+  service_url = null
+
+  content_format = "openapi"
+  content_value = templatefile("./api/mock_nexi/ec/v1/mock.openapi.json.tpl", {
+    host = azurerm_api_management_custom_domain.api_custom_domain.proxy[0].host_name
+  })
+
+  xml_content = templatefile("./api/mock_nexi/ec/v1/_base_policy.xml", {
+    mock_base_path = "/ec-mockprf/servizio"
+  })
+
+}
+
+
+############################
+## Mock PSP Nexi         ##
+############################
+
+module "apim_mock_psp_nexi_product" {
+  count  = var.env_short == "u" ? 1 : 0 # only UAT pointing out to NEXI PRF environment 
+  source = "git::https://github.com/pagopa/azurerm.git//api_management_product?ref=v1.0.90"
+
+  product_id   = "product-mock-psp-nexi"
+  display_name = "product-mock-psp-nexi"
+  description  = "product-mock-psp-nexi"
+
+  api_management_name = module.apim.name
+  resource_group_name = azurerm_resource_group.rg_api.name
+
+  published             = true
+  subscription_required = false
+  approval_required     = false
+
+  policy_xml = file("./api_product/mock_nexi/_base_policy.xml")
+}
+
+resource "azurerm_api_management_api_version_set" "mock_psp_nexi_api" {
+  count = var.env_short == "u" ? 1 : 0 # only UAT pointing out to NEXI PRF environment 
+
+  name                = format("%s-mock-psp-nexi-api", var.env_short)
+  resource_group_name = azurerm_resource_group.rg_api.name
+  api_management_name = module.apim.name
+  display_name        = "Mock Psp Nexi"
+  versioning_scheme   = "Segment"
+}
+
+module "apim_mock_psp_nexi_api" {
+  count  = var.env_short == "u" ? 1 : 0 # only UAT pointing out to NEXI PRF environment 
+  source = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=v1.0.90"
+
+  name                  = format("%s-mock-psp-nexi-api", var.env_short)
+  api_management_name   = module.apim.name
+  resource_group_name   = azurerm_resource_group.rg_api.name
+  product_ids           = [module.apim_mock_psp_nexi_product[0].product_id]
+  subscription_required = false
+
+  version_set_id = azurerm_api_management_api_version_set.mock_psp_nexi_api[0].id
+  api_version    = "v1"
+
+  description  = "Mock Psp Nexi PRF"
+  display_name = "Mock Psp Nexi PRF "
+  path         = "psp-mockprf"
+  protocols    = ["https"]
+
+  service_url = null
+
+  content_format = "openapi"
+  content_value = templatefile("./api/mock_nexi/psp/v1/mock.openapi.json.tpl", {
+    host = azurerm_api_management_custom_domain.api_custom_domain.proxy[0].host_name
+  })
+
+  xml_content = templatefile("./api/mock_nexi/psp/v1/_base_policy.xml", {
+    mock_base_path = "/psp-mockprf/simulatorePSP"
+  })
+
+}
+
+############################
+## Mock PM Nexi           ##
+############################
+
+module "apim_mock_pm_nexi_product" {
+  count  = var.env_short == "u" ? 1 : 0 # only UAT pointing out to NEXI PRF environment 
+  source = "git::https://github.com/pagopa/azurerm.git//api_management_product?ref=v1.0.90"
+
+  product_id   = "product-mock-pm-nexi"
+  display_name = "product-mock-pm-nexi"
+  description  = "product-mock-pm-nexi"
+
+  api_management_name = module.apim.name
+  resource_group_name = azurerm_resource_group.rg_api.name
+
+  published             = true
+  subscription_required = false
+  approval_required     = false
+
+  policy_xml = file("./api_product/mock_nexi/_base_policy.xml")
+}
+
+resource "azurerm_api_management_api_version_set" "mock_pm_nexi_api" {
+  count = var.env_short == "u" ? 1 : 0 # only UAT pointing out to NEXI PRF environment 
+
+  name                = format("%s-mock-pm-nexi-api", var.env_short)
+  resource_group_name = azurerm_resource_group.rg_api.name
+  api_management_name = module.apim.name
+  display_name        = "Mock PM Nexi"
+  versioning_scheme   = "Segment"
+}
+
+module "apim_mock_pm_nexi_api" {
+  count  = var.env_short == "u" ? 1 : 0 # only UAT pointing out to NEXI PRF environment 
+  source = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=v1.0.90"
+
+  name                  = format("%s-mock-pm-nexi-api", var.env_short)
+  api_management_name   = module.apim.name
+  resource_group_name   = azurerm_resource_group.rg_api.name
+  product_ids           = [module.apim_mock_pm_nexi_product[0].product_id]
+  subscription_required = false
+
+  version_set_id = azurerm_api_management_api_version_set.mock_pm_nexi_api[0].id
+  api_version    = "v1"
+
+  description  = "Mock PM Nexi PRF"
+  display_name = "Mock PM Nexi PRF "
+  path         = "mock-pm-prf"
+  protocols    = ["https"]
+
+  service_url = null
+
+  content_format = "openapi"
+  content_value = templatefile("./api/mock_nexi/psp/v1/mock.openapi.json.tpl", {
+    host = azurerm_api_management_custom_domain.api_custom_domain.proxy[0].host_name
+  })
+
+  xml_content = templatefile("./api/mock_nexi/psp/v1/_base_policy.xml", {
+    mock_base_path = "/mock-pm-prf/PerfPMMock/RestAPI"
+  })
+
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

The purpose of this PR is to add for Nexi EC-PSP-PM api on apim pagoPA UAT/PRF dns

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
