### PR TITLE
fix: Cosmosdb ignore througthput to allow cost advisor

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -173,7 +173,7 @@
 | <a name="module_payments_app_service"></a> [payments\_app\_service](#module\_payments\_app\_service) | git::https://github.com/pagopa/azurerm.git//app_service | v2.8.0 |
 | <a name="module_payments_app_service_slot_staging"></a> [payments\_app\_service\_slot\_staging](#module\_payments\_app\_service\_slot\_staging) | git::https://github.com/pagopa/azurerm.git//app_service_slot | v2.2.0 |
 | <a name="module_payments_cosmos_db"></a> [payments\_cosmos\_db](#module\_payments\_cosmos\_db) | git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_database | v2.1.15 |
-| <a name="module_payments_cosmosdb_containers"></a> [payments\_cosmosdb\_containers](#module\_payments\_cosmosdb\_containers) | git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_container | v2.1.8 |
+| <a name="module_payments_cosmosdb_containers"></a> [payments\_cosmosdb\_containers](#module\_payments\_cosmosdb\_containers) | git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_container | v3.2.4 |
 | <a name="module_payments_receipt"></a> [payments\_receipt](#module\_payments\_receipt) | git::https://github.com/pagopa/azurerm.git//storage_account | v2.8.0 |
 | <a name="module_postgres_flexible_server_private"></a> [postgres\_flexible\_server\_private](#module\_postgres\_flexible\_server\_private) | git::https://github.com/pagopa/azurerm.git//postgres_flexible_server | v2.8.1 |
 | <a name="module_postgres_flexible_snet"></a> [postgres\_flexible\_snet](#module\_postgres\_flexible\_snet) | git::https://github.com/pagopa/azurerm.git//subnet | v2.1.13 |

--- a/src/core/cosmos_db_payments.tf
+++ b/src/core/cosmos_db_payments.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "cosmosdb_rg" {
-  name     = format("%s-cosmosdb-paymentsdb-rg", local.project)
+  name     = "${local.project}-cosmosdb-paymentsdb-rg"
   location = var.location
 
   tags = var.tags
@@ -7,7 +7,7 @@ resource "azurerm_resource_group" "cosmosdb_rg" {
 
 module "cosmosdb_paymentsdb_snet" {
   source               = "git::https://github.com/pagopa/azurerm.git//subnet?ref=v2.15.1"
-  name                 = format("%s-cosmosb-paymentsdb-snet", local.project)
+  name                 = "${local.project}-cosmosb-paymentsdb-snet"
   address_prefixes     = var.cidr_subnet_cosmosdb_paymentsdb
   resource_group_name  = azurerm_resource_group.rg_vnet.name
   virtual_network_name = module.vnet.name
@@ -18,7 +18,7 @@ module "cosmosdb_paymentsdb_snet" {
 
 module "cosmos_payments_account" {
   source   = "git::https://github.com/pagopa/azurerm.git//cosmosdb_account?ref=v2.1.18"
-  name     = format("%s-payments-cosmos-account", local.project)
+  name     = "${local.project}-payments-cosmos-account"
   location = var.location
 
   resource_group_name = azurerm_resource_group.cosmosdb_rg.name
@@ -46,7 +46,7 @@ module "cosmos_payments_account" {
   allowed_virtual_network_subnet_ids = var.cosmos_document_db_params.public_network_access_enabled ? [] : [module.logic_app_biz_evt_snet.id]
 
   # private endpoint
-  private_endpoint_name    = format("%s-cosmos-payments-sql-endpoint", local.project)
+  private_endpoint_name    = "${local.project}-cosmos-payments-sql-endpoint"
   private_endpoint_enabled = var.cosmos_document_db_params.private_endpoint_enabled
   subnet_id                = module.cosmosdb_paymentsdb_snet.id
   private_dns_zone_ids     = [azurerm_private_dns_zone.privatelink_documents_azure_com.id]
@@ -77,7 +77,7 @@ locals {
 }
 
 module "payments_cosmosdb_containers" {
-  source   = "git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_container?ref=v2.1.8"
+  source   = "git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_container?ref=v3.2.4"
   for_each = { for c in local.payments_cosmosdb_containers : c.name => c }
 
   name                = each.value.name

--- a/src/domains/afm-common/03_cosmosdb_marketplace.tf
+++ b/src/domains/afm-common/03_cosmosdb_marketplace.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "afm_rg" {
-  name     = format("%s-rg", local.project)
+  name     = "${local.project}-rg"
   location = var.location
 
   tags = var.tags
@@ -7,7 +7,7 @@ resource "azurerm_resource_group" "afm_rg" {
 
 module "afm_marketplace_cosmosdb_snet" {
   source               = "git::https://github.com/pagopa/azurerm.git//subnet?ref=v1.0.90"
-  name                 = format("%s-marketplace-cosmosdb-snet", local.project)
+  name                 = "${local.project}-marketplace-cosmosdb-snet"
   address_prefixes     = var.cidr_subnet_afm_marketplace_cosmosdb
   resource_group_name  = local.vnet_resource_group_name
   virtual_network_name = local.vnet_name
@@ -23,7 +23,7 @@ module "afm_marketplace_cosmosdb_snet" {
 
 module "afm_marketplace_cosmosdb_account" {
   source   = "git::https://github.com/pagopa/azurerm.git//cosmosdb_account?ref=v2.1.18"
-  name     = format("%s-marketplace-cosmos-account", local.project)
+  name     = "${local.project}-marketplace-cosmos-account"
   location = var.location
 
   resource_group_name = azurerm_resource_group.afm_rg.name
@@ -51,7 +51,7 @@ module "afm_marketplace_cosmosdb_account" {
   allowed_virtual_network_subnet_ids = var.afm_marketplace_cosmos_db_params.public_network_access_enabled ? [] : [data.azurerm_subnet.aks_subnet.id]
 
   # private endpoint
-  private_endpoint_name    = format("%s-marketplace-cosmos-sql-endpoint", local.project)
+  private_endpoint_name    = "${local.project}-marketplace-cosmos-sql-endpoint"
   private_endpoint_enabled = var.afm_marketplace_cosmos_db_params.private_endpoint_enabled
   subnet_id                = module.afm_marketplace_cosmosdb_snet.id
   private_dns_zone_ids     = [data.azurerm_private_dns_zone.cosmos.id]
@@ -111,7 +111,7 @@ locals {
 
 # cosmosdb container for marketplace
 module "afm_marketplace_cosmosdb_containers" {
-  source   = "git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_container?ref=v2.1.8"
+  source   = "git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_container?ref=v3.2.5"
   for_each = { for c in local.afm_marketplace_cosmosdb_containers : c.name => c }
 
   name                = each.value.name

--- a/src/domains/afm-common/README.md
+++ b/src/domains/afm-common/README.md
@@ -14,7 +14,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_afm_marketplace_cosmosdb_account"></a> [afm\_marketplace\_cosmosdb\_account](#module\_afm\_marketplace\_cosmosdb\_account) | git::https://github.com/pagopa/azurerm.git//cosmosdb_account | v2.1.18 |
-| <a name="module_afm_marketplace_cosmosdb_containers"></a> [afm\_marketplace\_cosmosdb\_containers](#module\_afm\_marketplace\_cosmosdb\_containers) | git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_container | v2.1.8 |
+| <a name="module_afm_marketplace_cosmosdb_containers"></a> [afm\_marketplace\_cosmosdb\_containers](#module\_afm\_marketplace\_cosmosdb\_containers) | git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_container | v3.2.5 |
 | <a name="module_afm_marketplace_cosmosdb_database"></a> [afm\_marketplace\_cosmosdb\_database](#module\_afm\_marketplace\_cosmosdb\_database) | git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_database | v2.1.15 |
 | <a name="module_afm_marketplace_cosmosdb_snet"></a> [afm\_marketplace\_cosmosdb\_snet](#module\_afm\_marketplace\_cosmosdb\_snet) | git::https://github.com/pagopa/azurerm.git//subnet | v1.0.90 |
 | <a name="module_key_vault"></a> [key\_vault](#module\_key\_vault) | git::https://github.com/pagopa/azurerm.git//key_vault | v2.13.1 |

--- a/src/domains/gps-common/03_cosmosdb.tf
+++ b/src/domains/gps-common/03_cosmosdb.tf
@@ -1,5 +1,5 @@
 resource "azurerm_resource_group" "gps_rg" {
-  name     = format("%s-rg", local.project)
+  name     = "${local.project}-rg"
   location = var.location
 
   tags = var.tags
@@ -7,7 +7,7 @@ resource "azurerm_resource_group" "gps_rg" {
 
 module "gps_cosmosdb_snet" {
   source               = "git::https://github.com/pagopa/azurerm.git//subnet?ref=v1.0.90"
-  name                 = format("%s-cosmosdb-snet", local.project)
+  name                 = "${local.project}-cosmosdb-snet"
   address_prefixes     = var.cidr_subnet_gps_cosmosdb
   resource_group_name  = local.vnet_resource_group_name
   virtual_network_name = local.vnet_name
@@ -23,7 +23,7 @@ module "gps_cosmosdb_snet" {
 
 module "gps_cosmosdb_account" {
   source   = "git::https://github.com/pagopa/azurerm.git//cosmosdb_account?ref=v2.1.18"
-  name     = format("%s-cosmos-account", local.project)
+  name     = "${local.project}-cosmos-account"
   location = var.location
 
   resource_group_name = azurerm_resource_group.gps_rg.name
@@ -51,7 +51,7 @@ module "gps_cosmosdb_account" {
   allowed_virtual_network_subnet_ids = var.cosmos_gps_db_params.public_network_access_enabled ? var.env_short == "d" ? [] : [data.azurerm_subnet.aks_subnet.id] : [data.azurerm_subnet.aks_subnet.id]
 
   # private endpoint
-  private_endpoint_name    = format("%s-cosmos-sql-endpoint", local.project)
+  private_endpoint_name    = "${local.project}-cosmos-sql-endpoint"
   private_endpoint_enabled = var.cosmos_gps_db_params.private_endpoint_enabled
   subnet_id                = module.gps_cosmosdb_snet.id
   private_dns_zone_ids     = [data.azurerm_private_dns_zone.cosmos.id]
@@ -86,7 +86,7 @@ locals {
 
 # cosmosdb container
 module "gps_cosmosdb_containers" {
-  source   = "git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_container?ref=v2.1.8"
+  source   = "git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_container?ref=v3.2.5"
   for_each = { for c in local.gps_cosmosdb_containers : c.name => c }
 
   name                = each.value.name

--- a/src/domains/gps-common/README.md
+++ b/src/domains/gps-common/README.md
@@ -13,7 +13,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_gps_cosmosdb_account"></a> [gps\_cosmosdb\_account](#module\_gps\_cosmosdb\_account) | git::https://github.com/pagopa/azurerm.git//cosmosdb_account | v2.1.18 |
-| <a name="module_gps_cosmosdb_containers"></a> [gps\_cosmosdb\_containers](#module\_gps\_cosmosdb\_containers) | git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_container | v2.1.8 |
+| <a name="module_gps_cosmosdb_containers"></a> [gps\_cosmosdb\_containers](#module\_gps\_cosmosdb\_containers) | git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_container | v3.2.5 |
 | <a name="module_gps_cosmosdb_database"></a> [gps\_cosmosdb\_database](#module\_gps\_cosmosdb\_database) | git::https://github.com/pagopa/azurerm.git//cosmosdb_sql_database | v2.1.15 |
 | <a name="module_gps_cosmosdb_snet"></a> [gps\_cosmosdb\_snet](#module\_gps\_cosmosdb\_snet) | git::https://github.com/pagopa/azurerm.git//subnet | v1.0.90 |
 | <a name="module_key_vault"></a> [key\_vault](#module\_key\_vault) | git::https://github.com/pagopa/azurerm.git//key_vault | v2.13.1 |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Updated modules mongodb collection 

### Motivation and context

cosmosdb ignore througthput to allow cost advisor

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
