### PR TITLE
[Biz-Events] feat: add missing config for biz events datastore deploy

### DIFF
--- a/src/core/outputs.tf
+++ b/src/core/outputs.tf
@@ -74,3 +74,8 @@ output "ehub_biz_event_rx_conn_str" {
   value     = module.event_hub01.keys["nodo-dei-pagamenti-biz-evt.pagopa-biz-evt-rx"].primary_connection_string
   sensitive = true
 }
+
+output "ehub_biz_event_tx_primary_key" {
+  value     = module.event_hub01.keys["nodo-dei-pagamenti-biz-evt.pagopa-biz-evt-tx"].primary_key
+  sensitive = true
+}

--- a/src/domains/bizevents-common/02_security.tf
+++ b/src/domains/bizevents-common/02_security.tf
@@ -96,3 +96,10 @@ resource "azurerm_key_vault_secret" "cosmos_biz_key" {
 
   key_vault_id = module.key_vault.id
 }
+resource "azurerm_key_vault_secret" "ehub_tx_biz_key" {
+  name         = format("ehub-tx-%s-biz-key", var.env_short)
+  value        = data.terraform_remote_state.core.outputs.ehub_biz_event_tx_primary_key
+  content_type = "text/plain"
+
+  key_vault_id = module.key_vault.id
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- add in Biz-Events key vault primary key of ehub-tx 

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
