### PR TITLE
fix: add linux_fx_version for checkout & buyerbank

### DIFF
--- a/src/core/buyerbanks_function.tf
+++ b/src/core/buyerbanks_function.tf
@@ -52,6 +52,7 @@ module "buyerbanks_function" {
   storage_account_name = replace(format("%s-st-fnbuyerbanks", local.project), "-", "")
 
   app_settings = {
+    linux_fx_version                  = "NODE|14-lts"
     FUNCTIONS_WORKER_RUNTIME          = "node"
     WEBSITE_NODE_DEFAULT_VERSION      = "14.16.0"
     FUNCTIONS_WORKER_PROCESS_COUNT    = 4

--- a/src/core/checkout_function.tf
+++ b/src/core/checkout_function.tf
@@ -55,6 +55,8 @@ module "checkout_function" {
   storage_account_name = replace(format("%s-st-fncheckout", local.project), "-", "")
 
   app_settings = {
+    linux_fx_version = "NODE|14-lts"
+
     FUNCTIONS_WORKER_RUNTIME       = "node"
     WEBSITE_NODE_DEFAULT_VERSION   = "14.16.0"
     FUNCTIONS_WORKER_PROCESS_COUNT = 4


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- `linux_fx_version` for `checkout_function`
-  `linux_fx_version` for `buyerbanks_function`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
