### PR TITLE
fix: delete v1 in swagger closepayment

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -252,6 +252,8 @@
 | [azurerm_api_management_api_operation_policy.activateIO_reservation_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.activate_payment_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.close_payment_api_v1](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |
+| [azurerm_api_management_api_operation_policy.close_payment_api_v1_auth](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |
+| [azurerm_api_management_api_operation_policy.close_payment_api_v1_dev](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.donazioni_activate_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.donazioni_sendrt_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.donazioni_verify_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -251,6 +251,7 @@
 | [azurerm_api_management_api_diagnostic.apim_logs](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_diagnostic) | resource |
 | [azurerm_api_management_api_operation_policy.activateIO_reservation_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.activate_payment_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |
+| [azurerm_api_management_api_operation_policy.close_payment_api_v1](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.donazioni_activate_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.donazioni_sendrt_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.donazioni_verify_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_operation_policy) | resource |

--- a/src/core/api/nodopagamenti_api/nodoPerPM/v1/_closepayment_policy.xml.tpl
+++ b/src/core/api/nodopagamenti_api/nodoPerPM/v1/_closepayment_policy.xml.tpl
@@ -1,7 +1,7 @@
 <policies>
     <inbound>
       <base />
-      <set-backend-service base-url="${base-url}" />
+      <set-backend-service base-url="${base-url}/v1" />
     </inbound>
     <outbound>
       <base />

--- a/src/core/api/nodopagamenti_api/nodoPerPM/v1/_swagger.json.tpl
+++ b/src/core/api/nodopagamenti_api/nodoPerPM/v1/_swagger.json.tpl
@@ -547,7 +547,7 @@
         }
       }
     },
-    "/v1/closepayment": {
+    "/closepayment": {
       "post": {
         "tags": [
           "nodo"

--- a/src/core/apim_nodo_services.tf
+++ b/src/core/apim_nodo_services.tf
@@ -467,12 +467,15 @@ module "apim_nodo_per_pm_api_v1" {
   })
 }
 
-# resource "azurerm_api_management_api_operation_policy" "close_payment_api_v1" {
-#   api_name            = format("%s-nodo-per-pm-api-v1", local.project)
-#   api_management_name = module.apim.name
-#   resource_group_name = azurerm_resource_group.rg_api.name
-#   operation_id        = "closePayment"
-
+resource "azurerm_api_management_api_operation_policy" "close_payment_api_v1" {
+  api_name            = format("%s-nodo-per-pm-api-v1", local.project)
+  api_management_name = module.apim.name
+  resource_group_name = azurerm_resource_group.rg_api.name
+  operation_id        = "closePayment"
+  xml_content = templatefile("./api/nodopagamenti_api/nodoPerPM/v1/_closepayment_policy.xml.tpl", {
+    base-url = var.env_short == "p" || var.env_short == "u" ? "https://{{ip-nodo}}" : "http://{{aks-lb-nexi}}{{base-path-nodo-oncloud}}"
+  })
+}
 
 module "apim_nodo_per_pm_api_v2" {
 

--- a/src/core/apim_nodo_services_auth.tf
+++ b/src/core/apim_nodo_services_auth.tf
@@ -467,16 +467,15 @@ module "apim_nodo_per_pm_api_v1_auth" {
   })
 }
 
-# resource "azurerm_api_management_api_operation_policy" "close_payment_api_v1_auth" {
-#   api_name            = format("%s-nodo-per-pm-api-v1", local.project)
-#   api_management_name = module.apim.name
-#   resource_group_name = azurerm_resource_group.rg_api.name
-#   operation_id        = "closePayment"
-
-#   xml_content = templatefile("./api/nodopagamenti_api/nodoPerPM/v1/_closepayment_policy.xml.tpl", {
-#     base-url = var.env_short == "d" ? "http://{{aks-lb-nexi}}{{base-path-nodo-oncloud}}/v1" : "https://{{ip-nodo}}/v1"
-#   })
-# }
+resource "azurerm_api_management_api_operation_policy" "close_payment_api_v1_auth" {
+  api_name            = format("%s-nodo-per-pm-api-auth-v1", local.project)
+  api_management_name = module.apim.name
+  resource_group_name = azurerm_resource_group.rg_api.name
+  operation_id        = "closePayment"
+  xml_content = templatefile("./api/nodopagamenti_api/nodoPerPM/v1/_closepayment_policy.xml.tpl", {
+    base-url = var.env_short == "p" || var.env_short == "u" ? "https://{{ip-nodo}}" : "http://{{aks-lb-nexi}}{{base-path-nodo-oncloud}}"
+  })
+}
 
 module "apim_nodo_per_pm_api_v2_auth" {
 

--- a/src/core/apim_nodo_services_dev.tf
+++ b/src/core/apim_nodo_services_dev.tf
@@ -505,17 +505,15 @@ module "apim_nodo_per_pm_api_v1_dev" {
   })
 }
 
-# resource "azurerm_api_management_api_operation_policy" "close_payment_api_v1_dev" {
-#   api_name            = format("%s-nodo-per-pm-api-v1-dev", local.project)
-#   api_management_name = module.apim.name
-#   resource_group_name = azurerm_resource_group.rg_api.name
-#   operation_id        = "closePayment"
-
-#   xml_content = templatefile("./api/nodopagamenti_api/nodoPerPM/v1/_closepayment_policy.xml.tpl", {
-#     # base-url = var.env_short == "p" ? "https://{{ip-nodo}}" : "http://{{aks-lb-nexi}}{{base-path-nodo-oncloud}}/webservices/input" 
-#     base-url = var.env_short == "p" || var.env_short == "u" ? "https://{{ip-nodo}}" : "http://{{aks-lb-nexi}}/nodo-dev/webservices/input"
-#   })
-# }
+resource "azurerm_api_management_api_operation_policy" "close_payment_api_v1_dev" {
+  api_name            = format("%s-nodo-per-pm-api-dev-v1", local.project)
+  api_management_name = module.apim.name
+  resource_group_name = azurerm_resource_group.rg_api.name
+  operation_id        = "closePayment"
+  xml_content = templatefile("./api/nodopagamenti_api/nodoPerPM/v1/_closepayment_policy.xml.tpl", {
+    base-url = var.env_short == "p" || var.env_short == "u" ? "https://{{ip-nodo}}" : "http://{{aks-lb-nexi}}{{base-path-nodo-oncloud}}"
+  })
+}
 
 module "apim_nodo_per_pm_api_v2_dev" {
   count  = var.env_short == "d" ? 1 : 0


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Delete `/v1/ ` in closepaymentV1 swagger in order to expose api according to:
   - `https://api.platform.pagopa.it/nodo/nodo-per-pm/v1/closepayment`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
