### PR TITLE
feat: Add apim and kv secret for gpd-reporting PAGOPA-719

### DIFF
--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -134,6 +134,7 @@ app_gateway_deny_paths_2 = [
   "/gps/spontaneous-payments-service/.*", # internal use no sub-keys
   "/gps/gpd-payments/.*",                 # internal use no sub-keys
   "/gps/gpd-payment-receipts/.*",         # internal use no sub-keys
+  "/gps/gpd-reporting-orgs-enrollment/.*" # internal use
 ]
 app_gateway_allowed_paths_pagopa_onprem_only = {
   paths = [

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -120,6 +120,7 @@ app_gateway_deny_paths_2 = [
   "/fatturazione/.*",
   "/payment-manager/pp-restapi-server/.*",
   #"/pagopa-node-forwarder/.*"
+  "/gps/gpd-reporting-orgs-enrollment/.*" # internal use
 ]
 app_gateway_allowed_paths_pagopa_onprem_only = {
   paths = [

--- a/src/domains/gps-app/04_apim_reporting_enrollment.tf
+++ b/src/domains/gps-app/04_apim_reporting_enrollment.tf
@@ -1,0 +1,76 @@
+###########################################
+## Product GPD REPORTING ORGS ENROLLMENT ##
+###########################################
+
+locals {
+  apim_reporting-orgs-enrollment_service_api = {
+    display_name          = "GPD pagoPA - Reporting Orgs Enrollment"
+    description           = "API to support Reporting orgs enrollment"
+    path                  = "gps/gpd-reporting-orgs-enrollment/api"
+    subscription_required = true
+    service_url           = null
+  }
+}
+
+##############
+## Products ##
+##############
+
+module "apim_gpd_enrollment_product" {
+  source = "git::https://github.com/pagopa/azurerm.git//api_management_product?ref=v4.0.0"
+
+  product_id   = "gpd-reporting-orgs-enrollment"
+  display_name = local.apim_reporting-orgs-enrollment_service_api.display_name
+  description  = local.apim_reporting-orgs-enrollment_service_api.description
+
+  api_management_name = local.pagopa_apim_name
+  resource_group_name = local.pagopa_apim_rg
+
+  published             = true
+  subscription_required = local.apim_reporting-orgs-enrollment_service_api.subscription_required
+  approval_required     = true
+  subscriptions_limit   = 1000
+
+  policy_xml = file("./api_product/gpd-reporting-orgs-enrollment-service/_base_policy.xml")
+}
+
+#########
+## API ##
+#########
+
+resource "azurerm_api_management_api_version_set" "api_gpd_enrollment_api" {
+
+  name                = format("%s-reporting-orgs-enrollment-service-api", var.env_short)
+  resource_group_name = local.pagopa_apim_rg
+  api_management_name = local.pagopa_apim_name
+  display_name        = local.apim_reporting-orgs-enrollment_service_api.display_name
+  versioning_scheme   = "Segment"
+}
+
+
+module "apim_api_gpd_enrollment_api_v1" {
+  source = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=v4.0.0"
+
+  name                  = format("%s-reporting-orgs-enrollment-service-api", local.project)
+  api_management_name   = local.pagopa_apim_name
+  resource_group_name   = local.pagopa_apim_rg
+  product_ids           = [module.apim_gpd_enrollment_product.product_id]
+  subscription_required = local.apim_reporting-orgs-enrollment_service_api.subscription_required
+  version_set_id        = azurerm_api_management_api_version_set.api_gpd_enrollment_api.id
+  api_version           = "v1"
+
+  description  = local.apim_reporting-orgs-enrollment_service_api.description
+  display_name = local.apim_reporting-orgs-enrollment_service_api.display_name
+  path         = local.apim_reporting-orgs-enrollment_service_api.path
+  protocols    = ["https"]
+  service_url  = local.apim_reporting-orgs-enrollment_service_api.service_url
+
+  content_format = "openapi"
+  content_value = templatefile("./api/gpd-reporting-orgs-enrollment-service/v1/_openapi.json.tpl", {
+    host = local.apim_hostname
+  })
+
+  xml_content = templatefile("./api/gpd-reporting-orgs-enrollment-service/v1/_base_policy.xml", {
+    hostname = local.gps_hostname
+  })
+}

--- a/src/domains/gps-app/README.md
+++ b/src/domains/gps-app/README.md
@@ -16,11 +16,13 @@
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_apim_api_gpd_enrollment_api_v1"></a> [apim\_api\_gpd\_enrollment\_api\_v1](#module\_apim\_api\_gpd\_enrollment\_api\_v1) | git::https://github.com/pagopa/azurerm.git//api_management_api | v4.0.0 |
 | <a name="module_apim_api_gpd_payments_rest_external_api_v1"></a> [apim\_api\_gpd\_payments\_rest\_external\_api\_v1](#module\_apim\_api\_gpd\_payments\_rest\_external\_api\_v1) | git::https://github.com/pagopa/azurerm.git//api_management_api | v2.1.13 |
 | <a name="module_apim_api_gpd_payments_rest_internal_api"></a> [apim\_api\_gpd\_payments\_rest\_internal\_api](#module\_apim\_api\_gpd\_payments\_rest\_internal\_api) | git::https://github.com/pagopa/azurerm.git//api_management_api | v2.1.13 |
 | <a name="module_apim_api_gps_api_v1"></a> [apim\_api\_gps\_api\_v1](#module\_apim\_api\_gps\_api\_v1) | git::https://github.com/pagopa/azurerm.git//api_management_api | v2.18.3 |
 | <a name="module_apim_api_gps_donation_api_v1"></a> [apim\_api\_gps\_donation\_api\_v1](#module\_apim\_api\_gps\_donation\_api\_v1) | git::https://github.com/pagopa/azurerm.git//api_management_api | v2.18.3 |
 | <a name="module_apim_api_gps_enrollments_api_v1"></a> [apim\_api\_gps\_enrollments\_api\_v1](#module\_apim\_api\_gps\_enrollments\_api\_v1) | git::https://github.com/pagopa/azurerm.git//api_management_api | v2.18.3 |
+| <a name="module_apim_gpd_enrollment_product"></a> [apim\_gpd\_enrollment\_product](#module\_apim\_gpd\_enrollment\_product) | git::https://github.com/pagopa/azurerm.git//api_management_product | v4.0.0 |
 | <a name="module_apim_gpd_payments_rest_external_product"></a> [apim\_gpd\_payments\_rest\_external\_product](#module\_apim\_gpd\_payments\_rest\_external\_product) | git::https://github.com/pagopa/azurerm.git//api_management_product | v2.18.3 |
 | <a name="module_apim_gpd_payments_rest_internal_product"></a> [apim\_gpd\_payments\_rest\_internal\_product](#module\_apim\_gpd\_payments\_rest\_internal\_product) | git::https://github.com/pagopa/azurerm.git//api_management_product | v2.18.3 |
 | <a name="module_apim_gpd_payments_soap_product"></a> [apim\_gpd\_payments\_soap\_product](#module\_apim\_gpd\_payments\_soap\_product) | git::https://github.com/pagopa/azurerm.git//api_management_product | v2.18.3 |
@@ -35,6 +37,7 @@
 | Name | Type |
 |------|------|
 | [azurerm_api_management_api.apim_api_gpd_payments_soap_api_v1](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api) | resource |
+| [azurerm_api_management_api_version_set.api_gpd_enrollment_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |
 | [azurerm_api_management_api_version_set.api_gpd_payments_rest_external_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |
 | [azurerm_api_management_api_version_set.api_gpd_payments_rest_internal_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |
 | [azurerm_api_management_api_version_set.api_gpd_payments_soap_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_api_version_set) | resource |

--- a/src/domains/gps-app/api/gpd-reporting-orgs-enrollment-service/v1/_base_policy.xml
+++ b/src/domains/gps-app/api/gpd-reporting-orgs-enrollment-service/v1/_base_policy.xml
@@ -1,0 +1,15 @@
+<policies>
+<inbound>
+  <base />
+  <set-backend-service base-url="https://${hostname}/pagopa-gpd-reporting-orgs-enrollment"/>
+</inbound>
+<outbound>
+  <base />
+</outbound>
+<backend>
+  <base />
+</backend>
+<on-error>
+  <base />
+</on-error>
+</policies>

--- a/src/domains/gps-app/api/gpd-reporting-orgs-enrollment-service/v1/_openapi.json.tpl
+++ b/src/domains/gps-app/api/gpd-reporting-orgs-enrollment-service/v1/_openapi.json.tpl
@@ -1,0 +1,548 @@
+{
+	"openapi": "3.0.1",
+	"info": {
+		"title": "PagoPA API - Reporting Organizations Enrollments",
+		"description": "Reporting orgs enrollment project",
+		"termsOfService": "https://www.pagopa.gov.it/",
+		"version": "0.0.1"
+	},
+	"servers": [
+		{
+			"url": "${host}/gps/gpd-reporting-orgs-enrollment-service/v1",
+			"description": "Generated server url"
+		}
+	],
+	"paths": {
+		"/info": {
+			"get": {
+				"tags": [
+					"Home"
+				],
+				"summary": "health check",
+				"description": "Return OK if application is started",
+				"operationId": "healthCheck",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AppInfo"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemJson"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"403": {
+						"description": "Forbidden",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"429": {
+						"description": "Too many requests",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Service unavailable",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemJson"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"ApiKey": []
+					}
+				]
+			},
+			"parameters": [
+				{
+					"name": "X-Request-Id",
+					"in": "header",
+					"description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+					"schema": {
+						"type": "string"
+					}
+				}
+			]
+		},
+		"/organizations": {
+			"get": {
+				"tags": [
+					"Reporting Organizations Enrollments API"
+				],
+				"summary": "The organization get all enrollments of creditor institutions.",
+				"operationId": "getOrganizations",
+				"responses": {
+					"200": {
+						"description": "Obtained all enrollments.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "array",
+									"items": {
+										"$ref": "#/components/schemas/OrganizationModelResponse"
+									}
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Wrong or missing function key.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Service unavailable.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemJson"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"ApiKey": []
+					}
+				]
+			},
+			"parameters": [
+				{
+					"name": "X-Request-Id",
+					"in": "header",
+					"description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+					"schema": {
+						"type": "string"
+					}
+				}
+			]
+		},
+		"/organizations/{organizationFiscalCode}": {
+			"get": {
+				"tags": [
+					"Reporting Organizations Enrollments API"
+				],
+				"summary": "The organization get the single enrollment for the creditor institution.",
+				"operationId": "getOrganization",
+				"parameters": [
+					{
+						"name": "organizationFiscalCode",
+						"in": "path",
+						"description": "The fiscal code of the Organization.",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Obtained single enrollment.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/OrganizationModelResponse"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Wrong or missing function key.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Not found the enroll service.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemJson"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Service unavailable.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemJson"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"ApiKey": []
+					}
+				]
+			},
+			"post": {
+				"tags": [
+					"Reporting Organizations Enrollments API"
+				],
+				"summary": "The organization creates a creditor institution.",
+				"operationId": "createOrganization",
+				"parameters": [
+					{
+						"name": "organizationFiscalCode",
+						"in": "path",
+						"description": "The fiscal code of the Organization.",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Request created.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/OrganizationModelResponse"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Wrong or missing function key.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"409": {
+						"description": "The organization to create already exists.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemJson"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Service unavailable.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemJson"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"ApiKey": []
+					}
+				]
+			},
+			"delete": {
+				"tags": [
+					"Reporting Organizations Enrollments API"
+				],
+				"summary": "The organization deletes the creditor institution.",
+				"operationId": "removeOrganization",
+				"parameters": [
+					{
+						"name": "organizationFiscalCode",
+						"in": "path",
+						"description": "The fiscal code of the Organization.",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Request deleted.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Wrong or missing function key.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"404": {
+						"description": "Not found the creditor institution.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemJson"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Service unavailable.",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ProblemJson"
+								}
+							}
+						}
+					}
+				},
+				"security": [
+					{
+						"ApiKey": []
+					}
+				]
+			},
+			"parameters": [
+				{
+					"name": "X-Request-Id",
+					"in": "header",
+					"description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+					"schema": {
+						"type": "string"
+					}
+				}
+			]
+		}
+	},
+	"components": {
+		"schemas": {
+			"OrganizationModelResponse": {
+				"type": "object",
+				"properties": {
+					"organizationFiscalCode": {
+						"type": "string"
+					},
+					"organizationOnboardingDate": {
+						"type": "string"
+					}
+				}
+			},
+			"ProblemJson": {
+				"type": "object",
+				"properties": {
+					"title": {
+						"type": "string",
+						"description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+					},
+					"status": {
+						"maximum": 600,
+						"minimum": 100,
+						"type": "integer",
+						"description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+						"format": "int32",
+						"example": 200
+					},
+					"detail": {
+						"type": "string",
+						"description": "A human readable explanation specific to this occurrence of the problem.",
+						"example": "There was an error processing the request"
+					}
+				}
+			},
+			"AppInfo": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"version": {
+						"type": "string"
+					},
+					"environment": {
+						"type": "string"
+					}
+				}
+			}
+		},
+		"securitySchemes": {
+			"ApiKey": {
+				"type": "apiKey",
+				"description": "The API key to access this function app.",
+				"name": "Ocp-Apim-Subscription-Key",
+				"in": "header"
+			}
+		}
+	}
+}

--- a/src/domains/gps-app/api_product/gpd-reporting-orgs-enrollment-service/_base_policy.xml
+++ b/src/domains/gps-app/api_product/gpd-reporting-orgs-enrollment-service/_base_policy.xml
@@ -1,0 +1,14 @@
+<policies>
+    <inbound>
+        <base />
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/domains/gps-common/02_security.tf
+++ b/src/domains/gps-common/02_security.tf
@@ -83,6 +83,38 @@ resource "azurerm_key_vault_secret" "ai_connection_string" {
   key_vault_id = module.key_vault.id
 }
 
+#tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
+resource "azurerm_key_vault_secret" "storage_reporting_connection_string" {
+  # refers to pagopa<env>flowsa primary key
+  name         = format("gpd-reporting-flow-%s-sa-connection-string", var.env_short)
+  value        = "<TO_UPDATE_MANUALLY_BY_PORTAL>"
+  content_type = "text/plain"
+
+  key_vault_id = module.key_vault.id
+
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
+#tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
+resource "azurerm_key_vault_secret" "gpd_reporting_enrollment_subscription_key" {
+  name         = format("gpd-%s-reporting-enrollment-subscription-key", var.env_short)
+  value        = "<TO_UPDATE_MANUALLY_BY_PORTAL>"
+  content_type = "text/plain"
+
+  key_vault_id = module.key_vault.id
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}
+
 resource "azurerm_key_vault_secret" "storage_connection_string" {
   name         = format("gpd-payments-%s-sa-connection-string", var.env_short)
   value        = module.payments_receipt_sa.primary_connection_string

--- a/src/domains/gps-common/03_storage_account.tf
+++ b/src/domains/gps-common/03_storage_account.tf
@@ -1,3 +1,7 @@
+##################
+## GPD PAYMENTS ##
+##################
+
 # storage
 module "payments_receipt_sa" {
   source = "git::https://github.com/pagopa/azurerm.git//storage_account?ref=v2.18.10"

--- a/src/domains/gps-common/README.md
+++ b/src/domains/gps-common/README.md
@@ -35,7 +35,9 @@
 | [azurerm_key_vault_secret.gpd_iuv_generator_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.gpd_payments_rest_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.gpd_payments_soap_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.gpd_reporting_enrollment_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.storage_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.storage_reporting_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.payments_gpd_inconsistency_error](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_private_dns_a_record.ingress](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/private_dns_a_record) | resource |
 | [azurerm_resource_group.gps_rg](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/resource_group) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Add apim for [gpd-reporting-orgs-enrollment](https://github.com/pagopa/pagopa-reporting-orgs-enrollment)
- Add storage connection string in key vault
- Add subscription key in key vault
- Add `/gps/gpd-reporting-orgs-enrollment/.*` among gateway deny-path because the APIs are only for internal use

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
