### PR TITLE
feat: NOD-162: Allineamento liquibase per hook commit 647938

### DIFF
--- a/src/psql/nodo/liquibase/changelog/cfg/3.14.0/db.changelog-20230223101500_update_conf_keys.xml
+++ b/src/psql/nodo/liquibase/changelog/cfg/3.14.0/db.changelog-20230223101500_update_conf_keys.xml
@@ -1,0 +1,13 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+  <changeSet author="liquibase" id="202302231022">
+    <update tableName="CONFIGURATION_KEYS">
+      <column name="CONFIG_VALUE" value="AD,BBT,BP,OBEP,PO,JIF,MYBK,BPAY,PPAL"/>
+      <where>CONFIG_KEY = 'closePaymentV2DenyListTipoVersamento'</where>
+    </update>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/psql/nodo/liquibase/changelog/cfg/db.changelog-master-3.14.0.xml
+++ b/src/psql/nodo/liquibase/changelog/cfg/db.changelog-master-3.14.0.xml
@@ -8,5 +8,6 @@
   <include file="./db.changelog-master-3.10.0.xml"/>
 
   <include file="./${version}/db.changelog-20230314090150_target_columns.xml"                    labels="${version}"/>
+  <include file="./${version}/db.changelog-20230223101500_update_conf_keys.xml"                  labels="${version}"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Aggiunto file liquibase per l'alter di un record per la tabella di configurazione CONFIGURATION_KEYS sul nodo come da hook ricevuto su Slack.


### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Arrivato un hook di modifica il giorno **22/03/2023** alle **09:58** su canale _Slack_ dedicato _pagopa-nodo4-hook_

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
