### PR TITLE
PAGOPA-814 feat: Enable `p` nodo monitoring apim and update allow path

### DIFF
--- a/src/core/api/nodopagamenti_api/monitoring/v1/_NodoDeiPagamenti.openapi.json.tpl
+++ b/src/core/api/nodopagamenti_api/monitoring/v1/_NodoDeiPagamenti.openapi.json.tpl
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.1",
   "info": {
-    "title": "_NodoDeiPagamenti",
+    "title": "_NodoDeiPagamenti ${service}",
     "description": "Api and Models",
     "version": "1.0"
   },

--- a/src/core/api_config.tf
+++ b/src/core/api_config.tf
@@ -103,7 +103,7 @@ module "api_config_app_service" {
     AFM_UTILS_HOST             = var.env_short == "p" ? "https://api.platform.pagopa.it/afm/utils/v1" : format("https://api.%s.platform.pagopa.it/afm/utils/v1", lower(var.tags["Environment"]))
     AFM_UTILS_SUBSCRIPTION_KEY = azurerm_key_vault_secret.apiconfig_afm_utils_subscription_key.value
 
-    NODO_MONITORING_HOST = var.env_short == "p" ? "https://api.platform.pagopa.it/nodo/monitoring/v1" : format("https://api.%s.platform.pagopa.it/nodo/monitoring/v1", lower(var.tags["Environment"]))
+    NODO_MONITORING_HOST = var.env_short == "p" ? "https://api.platform.pagopa.it/nodo-monitoring/monitoring/v1" : format("https://api.%s.platform.pagopa.it/nodo/monitoring/v1", lower(var.tags["Environment"]))
 
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
     WEBSITES_PORT                       = 8080

--- a/src/core/apim_nodo_services.tf
+++ b/src/core/apim_nodo_services.tf
@@ -664,7 +664,6 @@ resource "azurerm_api_management_api_version_set" "nodo_monitoring_api" {
 }
 
 module "apim_nodo_monitoring_api" {
-  count  = var.env_short != "p" ? 1 : 0
   source = "git::https://github.com/pagopa/azurerm.git//api_management_api?ref=v1.0.90"
 
   name                  = format("%s-nodo-monitoring-api", var.env_short)
@@ -673,7 +672,7 @@ module "apim_nodo_monitoring_api" {
   product_ids           = [module.apim_nodo_dei_pagamenti_product.product_id]
   subscription_required = local.apim_nodo_monitoring_api.subscription_required
 
-  version_set_id = azurerm_api_management_api_version_set.nodo_monitoring_api[0].id
+  version_set_id = azurerm_api_management_api_version_set.nodo_monitoring_api.id
   api_version    = "v1"
 
   description  = local.apim_nodo_monitoring_api.description

--- a/src/core/apim_nodo_services.tf
+++ b/src/core/apim_nodo_services.tf
@@ -656,8 +656,6 @@ locals {
 }
 
 resource "azurerm_api_management_api_version_set" "nodo_monitoring_api" {
-  count = var.env_short != "p" ? 1 : 0
-
   name                = format("%s-nodo-monitoring-api", var.env_short)
   resource_group_name = azurerm_resource_group.rg_api.name
   api_management_name = module.apim.name

--- a/src/core/apim_nodo_services.tf
+++ b/src/core/apim_nodo_services.tf
@@ -647,9 +647,10 @@ module "apim_nodo_per_pm_api_v2" {
 ######################
 locals {
   apim_nodo_monitoring_api = {
-    display_name          = "Nodo monitoring "
-    description           = "Nodo monitoring"
-    path                  = "nodo/monitoring"
+    display_name = "Nodo monitoring "
+    description  = "Nodo monitoring"
+    # path                  = "nodo/monitoring"
+    path                  = "nodo-monitoring/monitoring"
     subscription_required = var.nodo_pagamenti_subkey_required
     service_url           = null
   }
@@ -684,7 +685,8 @@ module "apim_nodo_monitoring_api" {
 
   content_format = "openapi"
   content_value = templatefile("./api/nodopagamenti_api/monitoring/v1/_NodoDeiPagamenti.openapi.json.tpl", {
-    host = azurerm_api_management_custom_domain.api_custom_domain.proxy[0].host_name
+    host    = azurerm_api_management_custom_domain.api_custom_domain.proxy[0].host_name
+    service = module.apim_nodo_dei_pagamenti_product.product_id
   })
 
   xml_content = templatefile("./api/nodopagamenti_api/monitoring/v1/_base_policy.xml.tpl", {

--- a/src/core/apim_nodo_services_dev.tf
+++ b/src/core/apim_nodo_services_dev.tf
@@ -631,7 +631,8 @@ module "apim_nodo_monitoring_api_dev" {
 
   content_format = "openapi"
   content_value = templatefile("./api/nodopagamenti_api/monitoring/v1/_NodoDeiPagamenti.openapi.json.tpl", {
-    host = azurerm_api_management_custom_domain.api_custom_domain.proxy[0].host_name
+    host    = azurerm_api_management_custom_domain.api_custom_domain.proxy[0].host_name
+    service = module.apim_nodo_dei_pagamenti_product_dev[0].product_id
   })
 
   xml_content = templatefile("./api/nodopagamenti_api/monitoring/v1/_base_policy.xml.tpl", {

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -141,6 +141,7 @@ app_gateway_allowed_paths_pagopa_onprem_only = {
     "/web-bo/.*",
     "/bo-nodo/.*",
     "/pp-admin-panel/.*",
+    "/nodo/monitoring.*",
     "/nodo-ndp/monitoring/.*",
     "/nodo-replica-ndp/monitoring/.*",
     "/wfesp-ndp/.*",
@@ -462,7 +463,7 @@ pagopa_proxy_size           = "P1v3"
 # TODO this is dev value ... replace with uat value.
 nodo_ip_filter = "10.79.20.32"
 
-# redis apim 
+# redis apim
 redis_cache_params = {
   public_access = false
   capacity      = 0

--- a/src/core/env/prod/terraform.tfvars
+++ b/src/core/env/prod/terraform.tfvars
@@ -141,7 +141,7 @@ app_gateway_allowed_paths_pagopa_onprem_only = {
     "/web-bo/.*",
     "/bo-nodo/.*",
     "/pp-admin-panel/.*",
-    "/nodo/monitoring.*",
+    "/nodo-monitoring/monitoring/.*",
     "/nodo-ndp/monitoring/.*",
     "/nodo-replica-ndp/monitoring/.*",
     "/wfesp-ndp/.*",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- enable nodo_monitoring_api in `p` environment
- update `app_gateway_allowed_paths_pagopa_onprem_only`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

These changes have the purpose of enabling the node monitoring endpoint in production too.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
