### PR TITLE
feat: update buyerbanks function runtime version

### DIFF
--- a/src/core/buyerbanks_function.tf
+++ b/src/core/buyerbanks_function.tf
@@ -39,7 +39,7 @@ module "buyerbanks_function" {
   runtime_version                          = "~4"
   always_on                                = true
   os_type                                  = "linux"
-  linux_fx_version                         = "NODE|14"
+  linux_fx_version                         = "NODE|18"
   application_insights_instrumentation_key = azurerm_application_insights.application_insights.instrumentation_key
 
   app_service_plan_name = format("%s-plan-fnbuyerbanks", local.project)
@@ -62,7 +62,7 @@ module "buyerbanks_function" {
 
   app_settings = {
     FUNCTIONS_WORKER_RUNTIME          = "node"
-    WEBSITE_NODE_DEFAULT_VERSION      = "14.16.0"
+    WEBSITE_NODE_DEFAULT_VERSION      = "18.16.0"
     FUNCTIONS_WORKER_PROCESS_COUNT    = 4
     NODE_ENV                          = var.env_short == "p" ? "production" : "uat"
     BUYERBANKS_SA_CONNECTION_STRING   = module.buyerbanks_storage.primary_connection_string


### PR DESCRIPTION
Related function [PR](https://github.com/pagopa/pagopa-functions-buyerbank/pull/42) 
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Update node version to 18 for checkout buyerbanks function
<!--- Describe your changes in detail -->

### Motivation and context
This runtime modification is needed since node 14 has reached end of life
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
