### PR TITLE
[PAGOPA-925] fix: resolved bug on APIM-Redis connectivity

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -430,6 +430,7 @@
 | [azurerm_api_management_product_api.apim_nodo_dei_pagamenti_product_api](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_product_api) | resource |
 | [azurerm_api_management_product_api.apim_nodo_dei_pagamenti_product_api_auth](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_product_api) | resource |
 | [azurerm_api_management_product_api.apim_nodo_dei_pagamenti_product_api_dev](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_product_api) | resource |
+| [azurerm_api_management_redis_cache.apim_external_cache_redis](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/api_management_redis_cache) | resource |
 | [azurerm_app_service_plan.canoneunico_service_plan](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/app_service_plan) | resource |
 | [azurerm_app_service_plan.gpd_service_plan](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/app_service_plan) | resource |
 | [azurerm_app_service_plan.logic_app_biz_evt_service_plan](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/app_service_plan) | resource |
@@ -542,6 +543,7 @@
 | [azurerm_private_dns_zone_virtual_network_link.privatelink_documents_azure_com_vnet_integration](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.privatelink_postgres_database_azure_com_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.privatelink_redis_cache_windows_net_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.vnet_integration_network_link](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.vnet_link_privatelink_queue_core_windows_net](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.vnet_privatelink_mongo_cosmos_azure_com](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_public_ip.appgateway_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/public_ip) | resource |
@@ -854,7 +856,7 @@
 | <a name="input_law_retention_in_days"></a> [law\_retention\_in\_days](#input\_law\_retention\_in\_days) | The workspace data retention in days | `number` | `30` | no |
 | <a name="input_law_sku"></a> [law\_sku](#input\_law\_sku) | Sku of the Log Analytics Workspace | `string` | `"PerGB2018"` | no |
 | <a name="input_lb_aks"></a> [lb\_aks](#input\_lb\_aks) | IP load balancer AKS Nexi/SIA | `string` | `"0.0.0.0"` | no |
-| <a name="input_location"></a> [location](#input\_location) | n/a | `string` | `"westeurope"` | no |
+| <a name="input_location"></a> [location](#input\_location) | One of westeurope, northeurope | `string` | `"westeurope"` | no |
 | <a name="input_lock_enable"></a> [lock\_enable](#input\_lock\_enable) | Apply locks to block accidentally deletions. | `bool` | `false` | no |
 | <a name="input_logic_app_biz_evt_plan_kind"></a> [logic\_app\_biz\_evt\_plan\_kind](#input\_logic\_app\_biz\_evt\_plan\_kind) | App service plan kind | `string` | `"Linux"` | no |
 | <a name="input_logic_app_biz_evt_plan_sku_size"></a> [logic\_app\_biz\_evt\_plan\_sku\_size](#input\_logic\_app\_biz\_evt\_plan\_sku\_size) | App service plan sku size | `string` | `"WS1"` | no |

--- a/src/core/api/gpd_api/debt-position-services/v1/_base_policy.xml
+++ b/src/core/api/gpd_api/debt-position-services/v1/_base_policy.xml
@@ -19,10 +19,10 @@
         <set-variable name="application_domain" value="gpd" />
         <choose>
             <!-- Making sure that will excludes all APIs that does not includes CI fiscal code -->
-          <when condition="@(context.Request.MatchedParameters.ContainsKey("organizationfiscalcode"))">
-            <set-variable name="authorization_entity" value="@(context.Request.MatchedParameters["organizationfiscalcode"])" />
-            <include-fragment fragment-id="authorizer" />
-          </when>
+            <when condition="@(context.Request.MatchedParameters.ContainsKey("organizationfiscalcode") && !context.Request.Headers.GetValueOrDefault("Ocp-Apim-Subscription-Key", "").Equals(""))">
+                <set-variable name="authorization_entity" value="@(context.Request.MatchedParameters["organizationfiscalcode"])" />
+                <include-fragment fragment-id="authorizer" />
+            </when>
         </choose>
     </inbound>
     <outbound>

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -76,6 +76,10 @@ apim_publisher_name = "pagoPA Platform UAT"
 apim_sku            = "Developer_1"
 apim_alerts_enabled = false
 
+# redis private endpoint
+redis_private_endpoint_enabled = true
+redis_cache_enabled            = true
+
 # app_gateway
 app_gateway_api_certificate_name        = "api-uat-platform-pagopa-it"
 app_gateway_prf_certificate_name        = "api-prf-platform-pagopa-it"

--- a/src/core/redis_cache.tf
+++ b/src/core/redis_cache.tf
@@ -9,7 +9,7 @@ module "redis_snet" {
   name                                           = format("%s-redis-snet", local.project)
   address_prefixes                               = var.cidr_subnet_redis
   resource_group_name                            = azurerm_resource_group.rg_vnet.name
-  virtual_network_name                           = module.vnet.name
+  virtual_network_name                           = module.vnet.name # module.vnet_integration.name ???
   enforce_private_link_endpoint_network_policies = !var.redis_cache_params.public_access
 }
 
@@ -67,11 +67,12 @@ resource "azurerm_private_dns_zone_virtual_network_link" "vnet_integration_netwo
   virtual_network_id    = module.vnet_integration.id
 }
 
+# Already apply forcing redis_connection_string on apim_module
 resource "azurerm_api_management_redis_cache" "apim_external_cache_redis" {
   name              = "apim-external-cache-redis"
   api_management_id = module.apim.id
   connection_string = module.redis.primary_connection_string
   description       = "APIM external cache Redis"
   redis_cache_id    = module.redis.id
-  cache_location    = "westeurope"
+  cache_location    = var.location
 }

--- a/src/core/redis_cache.tf
+++ b/src/core/redis_cache.tf
@@ -59,3 +59,19 @@ module "redis" {
 
   tags = var.tags
 }
+
+resource "azurerm_private_dns_zone_virtual_network_link" "vnet_integration_network_link" {
+  name                  = format("%s-vnet-integration", local.project)
+  resource_group_name   = azurerm_resource_group.rg_vnet.name
+  private_dns_zone_name = data.azurerm_private_dns_zone.privatelink_redis_azure_com.name
+  virtual_network_id    = module.vnet_integration.id
+}
+
+resource "azurerm_api_management_redis_cache" "apim_external_cache_redis" {
+  name              = "apim-external-cache-redis"
+  api_management_id = module.apim.id
+  connection_string = module.redis.primary_connection_string
+  description       = "APIM external cache Redis"
+  redis_cache_id    = module.redis.id
+  cache_location    = "westeurope"
+}

--- a/src/core/variables.tf
+++ b/src/core/variables.tf
@@ -1,6 +1,7 @@
 variable "location" {
-  type    = string
-  default = "westeurope"
+  type        = string
+  description = "One of westeurope, northeurope"
+  default     = "westeurope"
 }
 
 variable "prefix" {


### PR DESCRIPTION
During the testing phase in UAT environment of the `pagopa-platform-authorizer` service, it was found that APIM is unable to communicate properly with an external Redis cache. This is caused by a misconfiguration of the Redis' private DNS zone that did not allow connection between APIM (present in `vnet-integration` VNET) and Redis itself (present in `vnet` core VNET).
In order to resolve this issue, it was made an update either on APIM and on external cache, adding two new resources:
 - one for permitting the connection between Redis' private DNS zone and the `vnet-integration` Virtual network 
 - one for permitting the generation of an explicit link between APIM and Redis, due to the fact that the default one does not work correctly on APIM uses.

In future, when a well-known [bug on APIM](https://learn.microsoft.com/en-us/answers/questions/1190454/how-to-read-from-apim-policy-an-external-redis-cac?page=1&orderby=Helpful&comment=answer-1188540#newest-answer-comment) will be resolved, the position of the Redis resource can be moved from `vnet-integration` VNET to `vnet` core VNET in order to move the responsibility to the last one. 

### List of changes
 - Added `azurerm_private_dns_zone_virtual_network_link` resource for generating a new link between vnet-integration network and private DNS zone.
 - Added `azurerm_api_management_redis_cache` resource for generating a new link between APIM and Redis external cache.

### Motivation and context
This fix is needed in order to resolve the connectivity issue between APIM and Redis cache.

### Type of changes
- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?
- [X] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [X] No

### Other information
The apply on environment was made using the following commands:
```
sh terraform.sh apply <ENV> \
-target=azurerm_private_dns_zone_virtual_network_link.vnet_integration_network_link \
-target=azurerm_api_management_redis_cache.apim_external_cache_redis \
-target=module.apim_api_debt_positions_api_v1 \
-target=module.redis
```

---

### If PR is partially applied, why? (reserved to mantainers)
