### PR TITLE
Fix Authorizer whitelisting

### DIFF
--- a/src/domains/shared-app/api/authorizer/authorizer-check.xml
+++ b/src/domains/shared-app/api/authorizer/authorizer-check.xml
@@ -51,9 +51,13 @@
     <!-- Auth phase : Invalidating the client request if not authorized -->
     <choose>
         <when condition="@(context.Variables.ContainsKey("authorizer_domain_in_progress") || !context.Variables.ContainsKey("cached_authorized_entities") || (context.Variables.ContainsKey("cached_authorized_entities") && !((string)context.Variables["cached_authorized_entities"]).Contains((string)context.Variables["auth_entity"])) )">
-            <return-response>
-                <set-status code="403" reason="Forbidden" />
-            </return-response>
+            <choose>
+                <when condition="@(!"*".Equals((string)context.Variables["cached_authorized_entities"]))">
+                    <return-response>
+                        <set-status code="403" reason="Forbidden" />
+                    </return-response>
+                </when>
+            </choose>
         </when>
     </choose>
 

--- a/src/domains/shared-app/api/authorizer/v1/_base_policy.xml
+++ b/src/domains/shared-app/api/authorizer/v1/_base_policy.xml
@@ -68,5 +68,7 @@
   </outbound>
   <on-error>
     <base />
+    <!-- Removing locking state variable -->
+    <cache-remove-value key="@("authorizer_" + context.Variables["domain"] + "_in_progress")" caching-type="internal" />
   </on-error>
 </policies>


### PR DESCRIPTION
With this pull request, a fix on a bug is resolved in order to permits a more wide whitelisting on the subkey related to all entities. Also, a bugfix is made in order to force deletion of pending lock variables. 

### List of changes
 - Added a more wide whitelisting strategy for cross-entity subkeys in Authorizer
 - Resolved bug on Authorizer's insert lock variables

### Motivation and context
These changes are required in order to resolve a blocking bug on UAT and PROD environment.

### Type of changes
- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?
- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
