### PR TITLE
fix: [NOD-261] Removed cache policy on apim

### DIFF
--- a/src/domains/apiconfig-app/api/apiconfig-cache/node_fdr/_base_policy.xml
+++ b/src/domains/apiconfig-app/api/apiconfig-cache/node_fdr/_base_policy.xml
@@ -1,82 +1,15 @@
 <policies>
   <inbound>
     <base />
-    <set-variable name="domain" value="apicfg_" />
-    <!-- database version -->
-    <set-variable name="db_version" value="@(context.Api.Path.Substring(context.Api.Path.LastIndexOf('/')).Trim('/'))" />
-    <set-variable name="cacheBaseUrl" value="https://${hostname}" />
-    <set-variable name="cacheBasePathRegex" value="/stakeholders/(?&apos;stakeholder&apos;.*)/cache/schemas/v1$" />
-    <set-variable name="stakeholder" value="@(Regex.Match(context.Operation.UrlTemplate,(string)context.Variables["cacheBasePathRegex"]).Groups["stakeholder"]?.Value)" />
-    <set-variable name="cacheBasePath" value="@(String.Concat("/stakeholders/",context.Variables["stakeholder"],"/cache/schemas/v1",context.Request.OriginalUrl.QueryString))" />
-    <choose>
-      <!-- if request is a specific one -->
-      <when condition="@(Regex.Match(context.Operation.UrlTemplate,(string)context.Variables["cacheBasePathRegex"]).Success)">
-      <trace source="debug-1" severity="information">Base path regards cache data</trace>
-      <set-variable name="canary" value="@{
-                      return context.Request.Headers.ContainsKey("X-Canary") == true ? "_canary" : "";
-      }" />
-      <set-variable name="cache_key" value="@(String.Concat(context.Variables["domain"], context.Variables["db_version"], "_", context.Variables["stakeholder"] ,"_v1", context.Variables["canary"]))" />
-      <set-variable name="cache_key_in_progress" value="@(String.Concat(context.Variables["cache_key"], "_in_progress"))" />
-      <!-- check if force cache refresh -->
-      <choose>
-        <when condition="@( System.Boolean.Parse( context.Request.Url.Query.GetValueOrDefault("refresh", "false")) )">
-        <!-- execute cache refresh -->
-        <cache-lookup-value key="@((string)context.Variables["cache_key_in_progress"])" default-value="false" variable-name="eval_in_progress" caching-type="internal" />
-        <choose>
-          <!-- if cache generation is in progress then return 503 -->
-          <when condition="@( System.Boolean.Parse( context.Variables.GetValueOrDefault("eval_in_progress", "false")) )">
-          <mock-response status-code="503" content-type="application/json" />
-        </when>
-        <!-- else generate specific cache -->
-        <otherwise>
-          <!-- require cache, so call fragment -->
-          <trace source="cache-fragment-1" severity="information">Cache evaluation not in progress</trace>
-          <include-fragment fragment-id="cache-generation" />
-        </otherwise>
-      </choose>
-    </when>
-    <otherwise>
-      <trace source="debug-2" severity="information">No refresh is required!</trace>
-      <!-- get cache value on Redis-->
-      <cache-lookup-value key="@((string)context.Variables["cache_key"])" variable-name="cache-value" caching-type="external" />
-      <choose>
-        <when condition="@(context.Variables.ContainsKey("cache-value"))">
-        <trace source="debug-3" severity="information">Cache exists!</trace>
-        <return-response response-variable-name="existing context variable">
-          <set-status code="200" reason="OK" />
-          <set-header name="Content-Type" exists-action="override">
-            <value>application/json</value>
-          </set-header>
-          <set-header name="Content-Encoding" exists-action="override">
-            <value>gzip</value>
-          </set-header>
-          <set-body>@(((JObject)context.Variables["cache-value"]).ToString())</set-body>
-        </return-response>
-      </when>
-      <otherwise>
-        <trace source="debug-4" severity="information">Cache not present -&gt; call backend!</trace>
-        <!-- require cache, so call fragment -->
-        <trace source="cache-fragment-2" severity="information">Force refresh called</trace>
-        <include-fragment fragment-id="cache-generation" />
-      </otherwise>
-    </choose>
-  </otherwise>
-</choose>
-  </when>
-  <!-- if request is not a specific one -->
-<otherwise>
-<trace source="debug-5" severity="information">URL not cached, then require to backend</trace>
-<set-backend-service base-url="https://${hostname}" />
-</otherwise>
-  </choose>
+    <set-backend-service base-url="https://${hostname}" />
   </inbound>
-<outbound>
-<base />
-</outbound>
-<backend>
-<base />
-</backend>
-<on-error>
-<base />
-</on-error>
-  </policies>
+  <backend>
+    <base />
+  </backend>
+  <outbound>
+    <base />
+  </outbound>
+  <on-error>
+    <base />
+  </on-error>
+</policies>

--- a/src/domains/apiconfig-app/api/apiconfig-cache/node_fdr/_base_policy_cache_on_apim.xml
+++ b/src/domains/apiconfig-app/api/apiconfig-cache/node_fdr/_base_policy_cache_on_apim.xml
@@ -1,0 +1,94 @@
+<policies>
+  <inbound>
+    <base />
+    <set-variable name="domain" value="apicfg_" />
+    <!-- database version -->
+    <set-variable name="db_version" value="@(context.Api.Path.Substring(context.Api.Path.LastIndexOf('/')).Trim('/'))" />
+    <set-variable name="cacheBaseUrl" value="https://${hostname}" />
+    <set-variable name="cacheBasePathRegex" value="/stakeholders/(?&apos;stakeholder&apos;.*)/cache/schemas/v1$" />
+    <set-variable name="stakeholder" value="@(Regex.Match(context.Operation.UrlTemplate,(string)context.Variables["cacheBasePathRegex"]).Groups["stakeholder"]?.Value)" />
+    <set-variable name="cacheBasePath" value="@(String.Concat("/stakeholders/",context.Variables["stakeholder"],"/cache/schemas/v1",context.Request.OriginalUrl.QueryString))" />
+    <choose>
+      <!-- if request is a specific one -->
+      <when condition="@(Regex.Match(context.Operation.UrlTemplate,(string)context.Variables["cacheBasePathRegex"]).Success)">
+      <trace source="debug-1" severity="information">Base path regards cache data</trace>
+      <set-variable name="canary" value="@{
+                      return context.Request.Headers.ContainsKey("X-Canary") == true ? "_canary" : "";
+      }" />
+      <set-variable name="cache_key" value="@(String.Concat(context.Variables["domain"], context.Variables["db_version"], "_", context.Variables["stakeholder"] ,"_v1", context.Variables["canary"]))" />
+      <set-variable name="cache_key_in_progress" value="@(String.Concat(context.Variables["cache_key"], "_in_progress"))" />
+      <!-- check if force cache refresh -->
+      <choose>
+        <when condition="@( System.Boolean.Parse( context.Request.Url.Query.GetValueOrDefault("refresh", "false")) )">
+        <!-- execute cache refresh -->
+        <cache-lookup-value key="@((string)context.Variables["cache_key_in_progress"])" default-value="false" variable-name="eval_in_progress" caching-type="external" />
+        <choose>
+          <!-- if cache generation is in progress then return 503 -->
+          <when condition="@( System.Boolean.Parse( context.Variables.GetValueOrDefault("eval_in_progress", "false")) )">
+            <mock-response status-code="503" content-type="application/json" />
+          </when>
+        <!-- else generate specific cache -->
+        <otherwise>
+          <!-- require cache, so call fragment -->
+          <trace source="cache-fragment-1" severity="information">Cache evaluation not in progress</trace>
+          <include-fragment fragment-id="cache-generation" />
+        </otherwise>
+      </choose>
+    </when>
+    <otherwise>
+      <trace source="debug-2" severity="information">No refresh is required!</trace>
+      <!-- get cache value on Redis-->
+      <cache-lookup-value key="@((string)context.Variables["cache_key"])" variable-name="cache-value" caching-type="external" />
+      <choose>
+        <when condition="@(context.Variables.ContainsKey("cache-value"))">
+        <trace source="debug-3" severity="information">Cache exists!</trace>
+        <return-response response-variable-name="existing context variable">
+          <set-status code="200" reason="OK" />
+          <set-header name="Content-Type" exists-action="override">
+            <value>application/json</value>
+          </set-header>
+          <set-header name="Content-Encoding" exists-action="override">
+            <value>gzip</value>
+          </set-header>
+          <set-body>@(((JObject)context.Variables["cache-value"]).ToString())</set-body>
+        </return-response>
+      </when>
+      <otherwise>
+        <trace source="debug-4" severity="information">Cache not present -&gt; call backend!</trace>
+
+        <cache-lookup-value key="@((string)context.Variables["cache_key_in_progress"])" default-value="false" variable-name="eval_in_progress" caching-type="external" />
+        <!-- require cache, so call fragment -->
+        <choose>
+          <!-- if cache generation is in progress then return 503 -->
+          <when condition="@( System.Boolean.Parse( context.Variables.GetValueOrDefault("eval_in_progress", "false")) )">
+            <mock-response status-code="503" content-type="application/json" />
+          </when>
+          <!-- else generate specific cache -->
+          <otherwise>
+            <!-- require cache, so call fragment -->
+            <trace source="cache-fragment-1" severity="information">Cache evaluation not in progress</trace>
+            <include-fragment fragment-id="cache-generation" />
+          </otherwise>
+        </choose>
+      </otherwise>
+    </choose>
+  </otherwise>
+</choose>
+  </when>
+  <!-- if request is not a specific one -->
+<otherwise>
+<trace source="debug-5" severity="information">URL not cached, then require to backend</trace>
+<set-backend-service base-url="https://${hostname}" />
+</otherwise>
+  </choose>
+  </inbound>
+<outbound>
+<base />
+</outbound>
+<backend>
+<base />
+</backend>
+<on-error>
+<base />
+</on-error>
+  </policies>

--- a/src/domains/apiconfig-app/api/apiconfig-cache/node_fdr/generate_cache_fragment.xml
+++ b/src/domains/apiconfig-app/api/apiconfig-cache/node_fdr/generate_cache_fragment.xml
@@ -6,49 +6,54 @@
 -->
 <fragment>
   <!-- set cache in progress at least for 15 minutes -->
-  <cache-store-value key="@(context.Variables.GetValueOrDefault("cache_key_in_progress", "cache_key_in_progress"))" value="true" duration="900" caching-type="internal" />
+  <cache-store-value key="@(context.Variables.GetValueOrDefault("cache_key_in_progress", "cache_key_in_progress"))" value="true" duration="900" caching-type="external" />
   <!-- call backend -->
   <choose>
     <when condition="@(context.Request.Headers.ContainsKey("X-Canary") == true)">
-      <send-request mode="new" response-variable-name="cache-response" timeout="120" ignore-error="true">
-        <set-url>@(String.Concat(context.Variables.GetValueOrDefault("cacheBaseUrl"), context.Variables.GetValueOrDefault("cacheBasePath")))</set-url>
-        <set-method>GET</set-method>
-        <set-header name="X-Canary" exists-action="override">
-          <value>@(context.Request.Headers.GetValueOrDefault("X-Canary","none"))</value>
-        </set-header>
-      </send-request>
-    </when>
-    <otherwise>
-      <send-request mode="new" response-variable-name="cache-response" timeout="120" ignore-error="true">
-        <set-url>@(String.Concat(context.Variables.GetValueOrDefault("cacheBaseUrl"), context.Variables.GetValueOrDefault("cacheBasePath")))</set-url>
-        <set-method>GET</set-method>
-      </send-request>
-    </otherwise>
-  </choose>
+    <send-request mode="new" response-variable-name="cache-response" timeout="800" ignore-error="true">
+      <set-url>@(String.Concat(context.Variables.GetValueOrDefault("cacheBaseUrl"), context.Variables.GetValueOrDefault("cacheBasePath")))</set-url>
+      <set-method>GET</set-method>
+      <set-header name="X-Canary" exists-action="override">
+        <value>@(context.Request.Headers.GetValueOrDefault("X-Canary","none"))</value>
+      </set-header>
+      <set-header name="Accept-Encoding" exists-action="override">
+        <value>gzip, deflate, br</value>
+      </set-header>
+    </send-request>
+  </when>
+  <otherwise>
+    <send-request mode="new" response-variable-name="cache-response" timeout="800" ignore-error="true">
+      <set-url>@(String.Concat(context.Variables.GetValueOrDefault("cacheBaseUrl"), context.Variables.GetValueOrDefault("cacheBasePath")))</set-url>
+      <set-method>GET</set-method>
+      <set-header name="Accept-Encoding" exists-action="override">
+        <value>gzip, deflate, br</value>
+      </set-header>
+    </send-request>
+  </otherwise>
+</choose>
   <!-- on response return data -->
-  <trace source="cache-response-status-code" severity="information">@( ( ((IResponse)context.Variables["cache-response"]).StatusCode == 200 ).ToString() )</trace>
-  <choose>
-    <when condition="@(((IResponse)context.Variables["cache-response"]).StatusCode == 200)">
-
-      <!-- set cache data according to the related cache_key for 1 day -->
-      <cache-store-value key="@(context.Variables.GetValueOrDefault("cache_key", "cache_key"))" caching-type="external" value="@(((IResponse)context.Variables["cache-response"]).Body.As<JObject>(preserveContent: true))" duration="86400" />
-      <!-- unset cache in progress -->
-      <cache-remove-value key="@(context.Variables.GetValueOrDefault("cache_key_in_progress", "cache_key_in_progress"))" caching-type="internal" />
-      <return-response response-variable-name="existing context variable">
-        <set-status code="200" reason="OK" />
-        <set-header name="Content-Type" exists-action="override">
-          <value>application/json</value>
-        </set-header>
-        <set-header name="Content-Encoding" exists-action="override">
-          <value>gzip</value>
-        </set-header>
-        <set-body>@(((IResponse)context.Variables["cache-response"]).Body.As<JObject>(preserveContent: true).ToString())</set-body>
-      </return-response>
-    </when>
-    <otherwise>
-      <!-- unset cache in progress -->
-      <cache-remove-value key="@(context.Variables.GetValueOrDefault("cache_key_in_progress", "cache_key_in_progress"))" caching-type="internal" />
-      <mock-response status-code="503" content-type="application/json" />
-    </otherwise>
+<trace source="cache-response-status-code" severity="information">@( ( ((IResponse)context.Variables["cache-response"]).StatusCode == 200 ).ToString() )</trace>
+<choose>
+<when condition="@(((IResponse)context.Variables["cache-response"]).StatusCode == 200)">
+<!-- set cache data according to the related cache_key for 1 day -->
+<cache-store-value key="@(context.Variables.GetValueOrDefault("cache_key", "cache_key"))" caching-type="external" value="@(((IResponse)context.Variables["cache-response"]).Body.As<JObject>(preserveContent: true))" duration="86400" />
+<!-- unset cache in progress -->
+<cache-remove-value key="@(context.Variables.GetValueOrDefault("cache_key_in_progress", "cache_key_in_progress"))" caching-type="external" />
+<return-response response-variable-name="existing context variable">
+  <set-status code="200" reason="OK" />
+  <set-header name="Content-Type" exists-action="override">
+    <value>application/json</value>
+  </set-header>
+  <set-header name="Content-Encoding" exists-action="override">
+    <value>gzip</value>
+  </set-header>
+  <set-body>@(((IResponse)context.Variables["cache-response"]).Body.As<JObject>(preserveContent: true).ToString())</set-body>
+</return-response>
+</when>
+<otherwise>
+<!-- unset cache in progress -->
+<cache-remove-value key="@(context.Variables.GetValueOrDefault("cache_key_in_progress", "cache_key_in_progress"))" caching-type="external" />
+<mock-response status-code="503" content-type="application/json" />
+</otherwise>
   </choose>
-</fragment>
+  </fragment>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- removed base policy for cache
- updated request timeout in fragment
- added gzip encoding for requests in fragment

<!--- Describe your changes in detail -->

### Motivation and context
- problem with huge amount of data to store on redis through apim

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
