### PR TITLE
feat(ecommerce-commons): add sending Azure Monitor diagnostics to AppInsights for eCommerce queues

### DIFF
--- a/src/domains/ecommerce-common/03_storage.tf
+++ b/src/domains/ecommerce-common/03_storage.tf
@@ -120,3 +120,27 @@ resource "azurerm_storage_queue" "transactions_dead_letter_queue" {
   name                 = "${local.project}-transactions-dead-letter-queue"
   storage_account_name = module.ecommerce_storage.name
 }
+
+resource "azurerm_monitor_diagnostic_setting" "ecommerce_queue_diagnostics" {
+  name                       = "${module.ecommerce_storage.name}-diagnostics"
+  target_resource_id         = "${module.ecommerce_storage.id}/queueServices/default/"
+  log_analytics_workspace_id = data.azurerm_log_analytics_workspace.log_analytics.id
+
+  enabled_log {
+    category = "StorageWrite"
+
+    retention_policy {
+      enabled = true
+      days    = 7
+    }
+  }
+
+  enabled_log {
+    category = "StorageDelete"
+
+    retention_policy {
+      enabled = true
+      days    = 7
+    }
+  }
+}

--- a/src/domains/ecommerce-common/README.md
+++ b/src/domains/ecommerce-common/README.md
@@ -30,7 +30,9 @@
 | [azurerm_key_vault_access_policy.adgroup_developers_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.azdevops_iac_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_secret.elastic-apm-secret-token](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.notifications_sender](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.personal-data-vault-api-key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_monitor_diagnostic_setting.ecommerce_queue_diagnostics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_private_dns_a_record.ingress](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |
 | [azurerm_private_endpoint.storage_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.cosmosdb_ecommerce_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
<!--- Describe your changes in detail -->
* add sending Azure Monitor diagnostics to AppInsights for eCommerce queues

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->

Azure Storage Queues [don't offer a queue length metric out of the box for a single queue](https://learn.microsoft.com/en-us/answers/questions/980989/how-to-get-metrics-for-individual-queue-in-azure-s).
This PR is necessary to allow sending of monitoring logs for Azure Storage Queues into Azure AppInsights to extract queue length via Kusto queries as a difference of `StorageWrite` and `StorageDelete` operations.
This in turn will allow us to implement monitoring and alerting on single queues :)

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
