### PR TITLE
fix: add missing domains to static analysis github action

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -19,6 +19,8 @@ jobs:
           FOLDERS: >
             src/aks-platform
             src/core
+            src/domains/aca-app
+            src/domains/aca-common
             src/domains/afm-app
             src/domains/afm-common
             src/domains/bizevents-app
@@ -35,6 +37,8 @@ jobs:
             src/domains/selfcare-common
             src/domains/shared-app
             src/domains/shared-common
+            src/domains/wallet-app
+            src/domains/wallet-common
         run: |
           pids=()
 


### PR DESCRIPTION
Depends on https://github.com/pagopa/pagopa-infra/pull/1011
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add missing aca and wallet domains to github static analysis action.
<!--- Describe your changes in detail -->

### Motivation and context
Add missing aca and wallet domains to github static analysis action.
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
