### PR TITLE
[PAGOPA-973] feat: added new API for retrieve segregation codes

### DIFF
--- a/src/domains/apiconfig-app/api/apiconfig-selfcare-integration/v1/_openapi.json.tpl
+++ b/src/domains/apiconfig-app/api/apiconfig-selfcare-integration/v1/_openapi.json.tpl
@@ -4,7 +4,7 @@
     "description" : "Spring application exposes APIs for SelfCare",
     "termsOfService" : "https://www.pagopa.gov.it/",
     "title": "API-Config - ${service}",
-    "version" : "1.3.0"
+    "version" : "1.4.0"
   },
   "servers" : [ {
     "url": "${host}",
@@ -433,6 +433,141 @@
           "Authorization" : [ ]
         } ],
         "summary" : "Get application code associations with creditor institution",
+        "tags" : [ "Creditor Institutions" ]
+      },
+      "parameters" : [ {
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "in" : "header",
+        "name" : "X-Request-Id",
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/creditorinstitutions/{creditorInstitutionCode}/segregationcodes" : {
+      "get" : {
+        "operationId" : "getSegregationCodesFromCreditorInstitution",
+        "parameters" : [ {
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "in" : "path",
+          "name" : "creditorInstitutionCode",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "description" : "The flag that permits to show the codes already used. Default: true",
+          "in" : "query",
+          "name" : "showUsedCodes",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : true
+          }
+        }, {
+          "description" : "The service endpoint, to be used as a search filter to obtain only the segregation codes used by the CI for stations using same endpoint service. Default: null",
+          "in" : "query",
+          "name" : "service",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CIAssociatedCodeList"
+                }
+              }
+            },
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "404" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            },
+            "description" : "Not Found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            },
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ],
+        "summary" : "Get segregation code associations with creditor institution",
         "tags" : [ "Creditor Institutions" ]
       },
       "parameters" : [ {

--- a/src/domains/apiconfig-app/env/weu-prod/terraform.tfvars
+++ b/src/domains/apiconfig-app/env/weu-prod/terraform.tfvars
@@ -35,7 +35,10 @@ tls_cert_check_helm = {
   image_tag     = "v1.3.4"
 }
 
-db_service_name = "NDPSPCP_PP_NODO4_CFG"
+
+# https://pagopa.atlassian.net/wiki/spaces/ACN/pages/525764770/API+Config+Ambienti+DB#On-Premise
+# db_service_name = "NDPSPCP_PP_NODO4_CFG"
+db_service_name = "NDPSPCP_NODO4_CFG"
 db_port         = 1521
 
 # API Config


### PR DESCRIPTION
With this pull request, a new API is added. These APIs permits to execute dedicated queries on segregation codes used by creditor institution for station bindings, needed by SelfCare product according to [doc](https://pagopa.atlassian.net/wiki/spaces/ACN/pages/648413262/Design+Review+SelfCare+Extensions)

#### Note
To apply this change, execute the command:
`sh terraform.sh apply <ENV> -target=module.apim_apiconfig_selfcare_integration_api_v1`

### List of changes
 - Added new API on APIM for `apiconfig-selfcare-integration` product

### Motivation and context
These changes are required in order to add the new API for the APIConfig integration with SelfCare.

### Type of changes
- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?
- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
