### PR TITLE
fix: Update ApiConfig SubKey backend url

### DIFF
--- a/src/domains/apiconfig-app/04_apim_api_config.tf
+++ b/src/domains/apiconfig-app/04_apim_api_config.tf
@@ -171,8 +171,7 @@ module "apim_api_config_auth_api" {
   path         = "apiconfig/auth/api"
   protocols    = ["https"]
 
-  #  service_url = format("https://%s/apiconfig/api/v1", module.api_config_app_service.default_site_hostname)
-  service_url = ""
+  service_url = format("https://%s/apiconfig/api/v1", module.api_config_app_service.default_site_hostname)
 
   content_format = "openapi"
   content_value = templatefile("./api/apiconfig_api/v1/_openapi.json.tpl", {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- fix ApiConfig SubKey backend url given that it was set to null

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
