### PR TITLE
[PAGOPA-1031] Resolving static setting of GPD reporting's KeyVault secrets

### DIFF
--- a/src/domains/gps-common/.terraform.lock.hcl
+++ b/src/domains/gps-common/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   version     = "2.21.0"
   constraints = "2.21.0"
   hashes = [
+    "h1:KbY8dRdbfTwTzEBcdOFdD50JX8CUG5Mni25D2+k1rGc=",
     "h1:qHYbB6LJsYPVUcd7QkZ5tU+IX+10VcUG4NzsmIuWdlE=",
     "zh:18c56e0478e8b3849f6d52f7e0ee495538e7fce66f22fc84a79599615e50ad1c",
     "zh:1b95ba8dddc46c744b2d2be7da6fafaa8ebd8368d46ff77416a95cb7d622251e",
@@ -25,6 +26,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.45.0"
   constraints = ">= 3.30.0, <= 3.45.0, <= 3.53.0"
   hashes = [
+    "h1:VQWxV5+qelZeUCjpdLvZ7iAom4RvG+fVVgK6ELvw/cs=",
     "h1:gQLNY1I5e9kcle1p/VYEWb0eteQ/t5kUfnqVu2/GBNY=",
     "zh:04c5dbb8845366ce5eb0dc2d55e151270cc2c0ace20993867fdae9af43b953ad",
     "zh:2589585da615ccae341400d45d672ee3fae413fdd88449b5befeff12a85a44b2",
@@ -46,6 +48,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = "3.1.1, <= 3.2.1"
   hashes = [
     "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
+    "h1:YvH6gTaQzGdNv+SKTZujU1O0bO+Pw6vJHOPhqgN8XNs=",
     "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
     "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
     "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",

--- a/src/domains/gps-common/02_security.tf
+++ b/src/domains/gps-common/02_security.tf
@@ -102,8 +102,41 @@ resource "azurerm_key_vault_secret" "storage_reporting_connection_string" {
 }
 
 #tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
-resource "azurerm_key_vault_secret" "gpd_reporting_enrollment_subscription_key" {
-  name         = format("gpd-%s-reporting-enrollment-subscription-key", var.env_short)
+resource "azurerm_key_vault_secret" "storage_connection_string" {
+  name         = format("gpd-payments-%s-sa-connection-string", var.env_short)
+  value        = module.payments_receipt_sa.primary_connection_string
+  content_type = "text/plain"
+
+  key_vault_id = module.key_vault.id
+}
+
+#tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
+resource "azurerm_key_vault_secret" "payments_cosmos_connection_string" {
+  name         = format("gpd-payments-%s-cosmos-connection-string", var.env_short)
+  value        = module.gpd_payments_cosmosdb_account.connection_strings[4]
+  content_type = "text/plain"
+
+  key_vault_id = module.key_vault.id
+
+}
+
+#tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
+resource "azurerm_key_vault_secret" "gpd_reporting_batch_connection_string" {
+  name         = format("gpd-%s-reporting-batch-connection-string", var.env_short)
+  value        = module.payments_receipt_sa.primary_connection_string
+  content_type = "text/plain"
+
+  key_vault_id = module.key_vault.id
+}
+
+
+## ########################### ##
+## TODO put it into gps-secret
+## ########################### ##
+
+#tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
+resource "azurerm_key_vault_secret" "monitor_notification_slack_email" {
+  name         = "monitor-notification-slack-email"
   value        = "<TO_UPDATE_MANUALLY_BY_PORTAL>"
   content_type = "text/plain"
 
@@ -117,18 +150,23 @@ resource "azurerm_key_vault_secret" "gpd_reporting_enrollment_subscription_key" 
 }
 
 #tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
-resource "azurerm_key_vault_secret" "storage_connection_string" {
-  name         = format("gpd-payments-%s-sa-connection-string", var.env_short)
-  value        = module.payments_receipt_sa.primary_connection_string
+resource "azurerm_key_vault_secret" "monitor_notification_email" {
+  name         = "monitor-notification-email"
+  value        = "<TO_UPDATE_MANUALLY_BY_PORTAL>"
   content_type = "text/plain"
 
   key_vault_id = module.key_vault.id
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
 }
 
-
 #tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
-resource "azurerm_key_vault_secret" "payments_cosmos_connection_string" {
-  name         = format("gpd-payments-%s-cosmos-connection-string", var.env_short)
+resource "azurerm_key_vault_secret" "gpd_reporting_enrollment_subscription_key" {
+  name         = format("gpd-%s-reporting-enrollment-subscription-key", var.env_short)
   value        = "<TO_UPDATE_MANUALLY_BY_PORTAL>"
   content_type = "text/plain"
 
@@ -248,15 +286,6 @@ resource "azurerm_key_vault_secret" "gpd_payments_soap_subscription_key" {
 }
 
 #tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
-resource "azurerm_key_vault_secret" "gpd_reporting_batch_connection_string" {
-  name         = format("gpd-%s-reporting-batch-connection-string", var.env_short)
-  value        = module.payments_receipt_sa.primary_connection_string
-  content_type = "text/plain"
-
-  key_vault_id = module.key_vault.id
-}
-
-#tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
 resource "azurerm_key_vault_secret" "gpd_reporting_subscription_key" {
   name         = format("gpd-%s-reporting-subscription-key", var.env_short)
   value        = "<TO_UPDATE_MANUALLY_BY_PORTAL>"
@@ -275,36 +304,6 @@ resource "azurerm_key_vault_secret" "gpd_reporting_subscription_key" {
 #tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
 resource "azurerm_key_vault_secret" "gpd-paa-password" {
   name         = format("gpd-%s-paa-password", var.env_short)
-  value        = "<TO_UPDATE_MANUALLY_BY_PORTAL>"
-  content_type = "text/plain"
-
-  key_vault_id = module.key_vault.id
-
-  lifecycle {
-    ignore_changes = [
-      value,
-    ]
-  }
-}
-
-#tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
-resource "azurerm_key_vault_secret" "monitor_notification_slack_email" {
-  name         = "monitor-notification-slack-email"
-  value        = "<TO_UPDATE_MANUALLY_BY_PORTAL>"
-  content_type = "text/plain"
-
-  key_vault_id = module.key_vault.id
-
-  lifecycle {
-    ignore_changes = [
-      value,
-    ]
-  }
-}
-
-#tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
-resource "azurerm_key_vault_secret" "monitor_notification_email" {
-  name         = "monitor-notification-email"
   value        = "<TO_UPDATE_MANUALLY_BY_PORTAL>"
   content_type = "text/plain"
 

--- a/src/domains/gps-common/02_security.tf
+++ b/src/domains/gps-common/02_security.tf
@@ -95,17 +95,10 @@ resource "azurerm_key_vault_secret" "flows_sa_connection_string" {
 resource "azurerm_key_vault_secret" "storage_reporting_connection_string" {
   # refers to pagopa<env>flowsa primary key
   name         = format("gpd-reporting-flow-%s-sa-connection-string", var.env_short)
-  value        = "<TO_UPDATE_MANUALLY_BY_PORTAL>"
+  value        = module.flows.primary_connection_string
   content_type = "text/plain"
 
   key_vault_id = module.key_vault.id
-
-
-  lifecycle {
-    ignore_changes = [
-      value,
-    ]
-  }
 }
 
 #tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
@@ -140,6 +133,12 @@ resource "azurerm_key_vault_secret" "payments_cosmos_connection_string" {
   content_type = "text/plain"
 
   key_vault_id = module.key_vault.id
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
 }
 
 #tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
@@ -251,16 +250,10 @@ resource "azurerm_key_vault_secret" "gpd_payments_soap_subscription_key" {
 #tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
 resource "azurerm_key_vault_secret" "gpd_reporting_batch_connection_string" {
   name         = format("gpd-%s-reporting-batch-connection-string", var.env_short)
-  value        = "<TO_UPDATE_MANUALLY_BY_PORTAL>"
+  value        = module.payments_receipt_sa.primary_connection_string
   content_type = "text/plain"
 
   key_vault_id = module.key_vault.id
-
-  lifecycle {
-    ignore_changes = [
-      value,
-    ]
-  }
 }
 
 #tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret


### PR DESCRIPTION
This PR contains some changes made to KeyVault secrets in order to remove the static assignation to the connection strings used by `reporting orgs enrollment` and `reporting-batch` services and define a dynamic reference to the Storage Account resource.  

#### Notes
The changes were applied executing the following command:  
`sh terraform.sh apply ENV --target=azurerm_key_vault_secret.storage_reporting_connection_string --target=azurerm_key_vault_secret.gpd_reporting_batch_connection_string`

### List of changes
 - Updated secret setting on `gpd-kv`

### Motivation and context
This change is needed in order to permits the correct execution of the API on `reporting orgs enrollment` service

### Type of changes
- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?
- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
