### PR TITLE
[PRDP-48] feat: introducing receipt uat secrets

### DIFF
--- a/src/domains/receipts-secrets/02_security.tf
+++ b/src/domains/receipts-secrets/02_security.tf
@@ -118,3 +118,16 @@ module "letsencrypt_receipt" {
   subscription_name = local.subscription_name
 }
 
+
+# data "azurerm_cosmosdb_account" "pdf_receipts_cosmos_account" {
+#   name                = "pagopa-${var.env_short}-${var.location_short}-${var.domain}-ds-cosmos-account"
+#   resource_group_name = "pagopa-${var.env_short}-${var.location_short}-${var.domain}-rg"
+# }
+
+# #tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret
+# resource "azurerm_key_vault_secret" "cosmos_receipt_connection_string" {
+#   name         = "cosmos-receipt-${var.env_short}-connection-string"
+#   value        = "AccountEndpoint=https://pagopa-${var.env_short}-${var.location_short}-${var.domain}-ds-cosmos-account.documents.azure.com:443/;AccountKey=${data.azurerm_cosmosdb_account.pdf_receipts_cosmos_account.primary_key};"
+#   content_type = "text/plain"
+#   key_vault_id = module.key_vault.id
+# }

--- a/src/domains/receipts-secrets/secret/weu-dev/noedit_secret_enc.json
+++ b/src/domains/receipts-secrets/secret/weu-dev/noedit_secret_enc.json
@@ -1,7 +1,7 @@
 {
 	"ai-d-connection-string": "ENC[AES256_GCM,data:eFg7X1HDzfQ580JmQM+d7rUNkga49sdc7CD7mh5Y/ryTITSOxFryjzBhgPwnprhWzm/kRynjwyhzXwhKy28HveBDnn6zLhq4KvzRMOJc79l6KGskuWsFmU6LzI1Y7fLa+5uvACtVKfvtbqbI4Zd8ya5xQBbI96/c0/eQhogAnR/YWSNJMkPJEMpYSfT3m/zCCDNdZwG/59iYW+LaRnkPdZwVfjIPuhT3I2BUGE9H2eXS+SyrvuttIgTy16BaALkI4hdi,iv:rfsXNVr33HyBGI8FqACyGLN330Gzcvhua4TFFkGp0tg=,tag:K4y7JIOObeKphiih1Owo6A==,type:str]",
 	"receipt-queue-d-connection-string": "ENC[AES256_GCM,data:P5z6jSwQVmnOQj3TMgtYjcbr9E88reZnOFlVACuegmGTNtIhakRyq6KwFG6EflCS1r8jgbwdfcgFeNfUdaPogPtpOpOwDyqIyQk9pUzAf2W1w2wnq1VKz3by6Vf1TVy6uWR4NmXV+fmsuozUL4nAfHy9KNj9ZZ/SDfyjo0IlpCs0LA7A6KSAL62MpLTrfqIbcKhBYcuUEw7H5FWJS6ADaKGmKD6MgBpPjEubIsHp3A3kITHbs/WZWx7Ni0rmQmf2lagG6co=,iv:oNrHfNqmRKLMm4o98Nii1JFbpJ3V5vz3ByBJC48Ap08=,tag:0Ea2lB57enYha2LMpBgZEQ==,type:str]",
-	"cosmos-receipt-d-connection-string": "ENC[AES256_GCM,data:3JwFiXJQSZ0SqhWU3g4FQZKCfxsoDiby5CCZLT3X/3uOSxZd7laO+Wv+nNh6L3ttee5g/JmqSGvGxrmpvfkAbOUP0nHyLxrxymxSn1QNDU1CakQv8rTtimyCj7B1OvcLkIuzSPphEONjfBMwldpvcQrZwCVAc65h1xBn0a7TqFfM9Kgy6MNDukVXD8IWXoHhesVg2wFyI8SmiFqfzDpkLxZ5r/2z0Wlq2WqQ0s5I+8gO9zQSgMj2jk6o3NHo,iv:ED75ICHcSrersk/We2T0QNptN9OYNNTJo54Ks52YZyU=,tag:o2C0Py0EEfW+lUqI6V4NLw==,type:str]",
+	"cosmos-receipt-d-connection-string": "ENC[AES256_GCM,data:vAPx9Of1Dqk6wsaYhO+oQ7pn/HPhPrA0lWRYwleuyCSZAbFU13Dz+vYRJvyCK6oK9dKO/UHSkLQFyghuYAsYfSeDb2Z9Vv9PRF/Qn9lC19i6gwpUVPz5kY9pVINUp7UOU9mZMCIlwYROoIl+3UqqEsJm19M5XuSUjZuHNrlNyl8LqqhoxW+C9MtNydYG/lCehpEgzK0RUcqB3eQHjaYvG9EiKjnnbU2cMgESQYFbKd6jh9o2Q86KU6K5357f,iv:BxVYEXUKBLQaKA4YRDEfqiZF5N+5mSbtBazW72chbWo=,tag:jOAIVUcCLLBwQk1GaD0WBQ==,type:str]",
 	"shared-apim-d-subscription-key": "ENC[AES256_GCM,data:aFeT2Q19/O39pUROrxdW6Tr9Zuoh/KhH5UHSDyyCNE8=,iv:6Oe9xAtUeHsAmkVF/LbTZcYBcShVHIdrDUq7kamIvBc=,tag:Eo+R4ZY2NFlv3rL+TPaUMg==,type:str]",
 	"cosmos-biz-event-d-connection-string": "ENC[AES256_GCM,data:AE6MW5r8YSXW9lWnAumG/HUvVbK1MbxVTBGhRay8XTAxJ9cR+8eZkTdfwOiPzUPVWtU3BEVfp4JS0pAHjM1LJmgHzJfxuXBTeH0LOxmlNIQmaTYWgpqd1SxgVm1ah9BfF6ksjVfbY9DL24tef3dLwRSUygwkU0f4NhkDZL8faibDwbWTVP57rRpspUy1FGJZbAb2AjR8tpTH1Ztt3G0aFaK4TLrtSdQaCa6I7AuhkNXlq4wTXSD1euqV4zgEtg==,iv:5X+w3VXCy+ThjYOz/KjbvOjVNG562nwOm1RB0PhRR7M=,tag:2LCrK/HfZsFWOvdTw4T5DQ==,type:str]",
 	"cosmos-receipt-d-key": "ENC[AES256_GCM,data:WPLhGKS+XpI++KRkrrfaWo7919HEqw4bw04a7RDmre4VnKnuyLXy9dfdH/uccb8BsZ3E3DrjaFSvd6+1Oed33OD4NBa6nKOR/bVFG7HbBTvUQASz6FcgxA==,iv:4aZmqOtZOTrlqZYkcw0JmOatkPZRBOPyNsMRFRxrjxg=,tag:U2daeBA2N4lH5zV8oWkh/g==,type:str]",
@@ -20,8 +20,8 @@
 		],
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2023-06-21T08:04:52Z",
-		"mac": "ENC[AES256_GCM,data:v8prHm8IlS87hAgO85lflRUZIZu/oK+7G87kkoaPV5kFdQ1ZWEOHZDiXyYFVQzf7p+6PMFPkVomsKgardNlhN1t3g1QT50SQeKyzbM4pnCUJ6pTAHzVpGO8jbLu4z5aMSTWFtCROdm+ORZrO4QpvSjunaIANpIAEF/XsdLoICbk=,iv:7rsDTKTv8Ga2cS5BYOrMbxN8S1mPX7xBYFy4znUfhDk=,tag:mvQqkCJWmbGmgDGK8AKifA==,type:str]",
+		"lastmodified": "2023-06-22T13:28:51Z",
+		"mac": "ENC[AES256_GCM,data:jd16FTnKdu24TaqEPnMTSx/9V36MfyC9H+H9T7aoEEXdKcm0gt2LlY+AtrwzUQ8SyehhCdB+R1c6HmajT31nKEyHqpF+oA+OyKL3KkOkemP+PHuvT1i9Zof0EVL+ygkH9/bTRATThBP83bbhf+gPPFJDDG9DthWByKzKr9EbsNM=,iv:VpsUMwIyZWFsTEvd54bsKaSNWYYEpMOUPAlzaF9oNPw=,tag:7Vv8/fofCURa0AYmXWJ4/w==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.7.3"

--- a/src/domains/receipts-secrets/secret/weu-uat/noedit_secret_enc.json
+++ b/src/domains/receipts-secrets/secret/weu-uat/noedit_secret_enc.json
@@ -1,5 +1,11 @@
 {
 	"ai-u-connection-string": "ENC[AES256_GCM,data:TaMBMeQ9xA5CRdkKdMrKiSjWoLM8/Xlo5O0YM3MnHLAkjafZWramACwfnsNkWX+tYDQexrtPOjUjuJHg9DSabE3AFSTJE3CIL0JGTHHSK0eM1fN8piPjkMMOE4JBaKyOVXaVKDXxYhhzhh7S6sHW0HW4c9dyRkrj2jKeRJDeWG8XwP3eAzoNLNAk+DCLe1cWA7pOZtU5xOq/2wbBF0P2AObbkOzylfaPhbHNnJtgCaomNvGIx0PZ7MMaHl373jSlWXwD,iv:2iXVG5i5UxS2uAYJbQPpjSBa3uUZ7G9gLM85XwcDqLA=,tag:bHoDjjqTvPOndfbyStSVag==,type:str]",
+	"cosmos-receipt-u-connection-string": "ENC[AES256_GCM,data:wM/fSdt1EGLmHI3/hIjCFuMlC2Oi5XUoAY9SMcTO1doo7Bjtq3HjWtHBHNcmRTdgEFGcEpTMKo/idEMzJiHYZGgp61vQ/j23fqIznQjMXymgEt5Om8IIhyjBkhN53fR+LP311Am6KSZ2afPtGIHIxccuNyIEOWOYpuPzUcykA5x+4cEfER7JpmmYNfzT3XBYYnfgXaiaNioHIpJt1xrdzv1/PhokbnTsyLVU31zb5xyqmQgGeLOKsoJjdTkG,iv:eSJqDyKuJD7JueD2p4OTVDJy6Pmez3tegbS8qQ32cDQ=,tag:R7I9U2qGPc26LcLOEcmMWA==,type:str]",
+	"receipt-queue-u-connection-string": "ENC[AES256_GCM,data:Zzg7tlMfiqBH6ZJCKT39596cGP3eTXE0Kk1hLGfQoolHedNQV69XE+2/IbjdnI3rJr5en7nwK3wXmQtX5JiCFxb3j8dX71lOhrVuSBGUumLE9U9OS3vK0dsMfDMof+bpOIMER9wPVz88oUmrrR0GraN7TsDExmcObtHk0/7P6DZ/J0/cFwrpCFHV63HXnx6s4wjbghJ9DYeZE4+1fi7JeNfM5QUhJjhiUjLgrlUOdSs7p+gzEhHNJ+ZuWiY0k6S34B4Kxrs=,iv:+rJqsbEvh0WJHesGZc6ICZiKwgjmCBBf3OvDKHKvAZU=,tag:iG1yU5cViW1sxqu3e9o/Ig==,type:str]",
+	"cosmos-receipt-u-key": "ENC[AES256_GCM,data:WrY6SVwwSA3vvhNPKYQMdtbzz90PVoCspOyvEi4pz/qgQXf4v1t4JgzGrxnPu8Mn/nEv/y+PPt4nRINRl76p1/XrOhvLgXGjrbRHR/6ldspsvXIbb1X10A==,iv:UmWa4dM7noIRiqA+sWgyt81tJaC7PjkPn+SnT1zYdZs=,tag:rwTZluJKX345vEn9HZCC7Q==,type:str]",
+	"blob-storage-u-connection-string": "ENC[AES256_GCM,data:Jdm5QfNS2hC3mHbsz0u1cC8o9pUIfVp4PBjJtjCJ6FBjdXxsHeYVkE6ksr9WToupoaRMQL3lHpP9TQZdu4eQhscuzCj9U/9mYpIFGxSizxQ/CMbEJDskmJVus5VjtmhzEs9ygWQkXhKRLgydey5zcc4LSiSPwW/v1Z8Z06dxegdNo9vu+eDwVcEEusPiWWyZdqhN6lHU7wY4SPiSbGtGu0DyMtZCW9a9VTokPhqgQZTGSQ18Ge1GmTdYiedzHjUvaOKTnjY=,iv:32iQoSbaLdpVK5yqXLGGgy5C6IbqB5MxRpS0K6hT6GI=,tag:SXbCTVZHIU+VQoEMzy5MLw==,type:str]",
+	"cosmos-biz-event-u-connection-string": "ENC[AES256_GCM,data:N1u0OXKCdH3WqpkJsqV68QkBe+wFEP6JRTf8JzTFzf1kZhPyBGHxpqeRNgzdOYm9Pz1Bvs7HJSgYwMlp/6HamzXLiaRkvYlbbhEXLSDPL8CYr9J6GEtshvvn8/ISRMdU4vu4JzoR46wGoPoI8Ix4Y/AjSCDIWJWaoHFkoU8epDp8hvjItNSY4d0iqJ8g7gGmc4dXYx0LrSI1UYIyDMCoaYuMLqSsgT1fjQ1R3f4/66sIYxPHQ/u/B+3sUFHKKA==,iv:JIga1XARNEJDOTA4dNT+byx5SzoK0JO7E49EhVQiPYo=,tag:0nYWcmalyhVPvmYTmG96kw==,type:str]",
+	"shared-apim-u-subscription-key": "ENC[AES256_GCM,data:EbteVt71tyLj4NPBacfkXwDVR9NzJg7exRdkLbMVyT0=,iv:vPyradYZ3dzoNhWszwdi2MV33xN5zTLd4I4U7G2Ra/o=,tag:Bab+kBCQ59OxbjGhH2tA/A==,type:str]",
 	"sops": {
 		"kms": null,
 		"gcp_kms": null,
@@ -14,8 +20,8 @@
 		],
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2023-06-12T11:54:54Z",
-		"mac": "ENC[AES256_GCM,data:wZwzJAnBw2qqfA4sp2wGxoB06o9m81t8xr6nwdYUW+2kIO8K0hQTHgZYUUUqj3vbqSydVGp2ZsWcI77pBKLuIGI5CFr+sXOLO4WnL2cA9/cEAXGf3q8O8VAcSE2EMXWZHP9ImqR4f/Z+IgEbtzKnUyYADiWZH6v9BV0GltWNfV0=,iv:GNLMsYHYhqcX3WW4ACoxM0XbiACF4gzPa+/WG4uWjvg=,tag:BatM599qA0H6wGNwtI8DGw==,type:str]",
+		"lastmodified": "2023-06-22T10:28:36Z",
+		"mac": "ENC[AES256_GCM,data:ZFbwRaCqpFcrGpjwm5BepZc1GZVzAECt+CV9lHBQrrsUYSKEoSgSEtMRFH9ztQ6XB9VXf7WDPhss7DQEryVZBaw8dthWXbH5wnIiOFDW38M2C1LrACdV9OJ26mLN3lFlULkHkYqC8cqwrxuYQ9iIPtISXOVdwrCN5pamm/A1S+Y=,iv:hUZ73IAIlKckpAOnXEqP7R5d/rx+FIJMoEZnYSUfdtg=,tag:ed/EtG5Y37g7YryaqfETXQ==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.7.3"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Updated sops secrets for uat keyvault in receipts domain

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Updating uat keyvault secrets for receipt domain in order to enable deployment of related components on the AKS cluster

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
