### PR TITLE
[PRDP-43] feat: update receipt domain with notifier components

### DIFF
--- a/src/domains/receipts-common/.terraform.lock.hcl
+++ b/src/domains/receipts-common/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   version     = "2.21.0"
   constraints = "2.21.0"
   hashes = [
+    "h1:akcofWscEl0ecIbf7lyEqRvPfOdA5q75EZvK8uSum1c=",
     "h1:qHYbB6LJsYPVUcd7QkZ5tU+IX+10VcUG4NzsmIuWdlE=",
     "zh:18c56e0478e8b3849f6d52f7e0ee495538e7fce66f22fc84a79599615e50ad1c",
     "zh:1b95ba8dddc46c744b2d2be7da6fafaa8ebd8368d46ff77416a95cb7d622251e",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = ">= 3.30.0, <= 3.53.0"
   hashes = [
     "h1:ocOIwGJG+K9hb22GdXhTdDiewSdeo9YO3BZ8cm8fUiE=",
+    "h1:vXyTtRE9MC/6pNTxrvYTJRwxQVsLxZdopz/xLXT18Ts=",
     "zh:078ece8318ad7d6c1cd2e5f2044188e74af63921b93223c7f8d477539fa91888",
     "zh:1bdc98ff8c2d3f3e81a746762e03d39794b2f5c90dc478cdb23dcc3d3f9947b6",
     "zh:20b51cfc0ffc4ff368e6eb2eaece0b6bb99ade09e4b91b3444b50e94fc54c119",
@@ -45,6 +47,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version     = "3.1.1"
   constraints = "3.1.1"
   hashes = [
+    "h1:1J3nqAREzuaLE7x98LEELCCaMV6BRiawHSg9MmFvfQo=",
     "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
     "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
     "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",

--- a/src/domains/receipts-common/03_cosmosdb.tf
+++ b/src/domains/receipts-common/03_cosmosdb.tf
@@ -77,6 +77,12 @@ locals {
       default_ttl        = var.receipts_datastore_cosmos_db_params.container_default_ttl
       autoscale_settings = { max_throughput = (var.env_short != "p" ? 6000 : 20000) }
     },
+    {
+      name               = "receipts-io-messages",
+      partition_key_path = "/messageId",
+      default_ttl        = var.receipts_datastore_cosmos_db_params.container_default_ttl
+      autoscale_settings = { max_throughput = (var.env_short != "p" ? 6000 : 20000) }
+    },
   ]
 }
 

--- a/src/domains/receipts-common/03_storage.tf
+++ b/src/domains/receipts-common/03_storage.tf
@@ -91,6 +91,11 @@ resource "azurerm_storage_queue" "queue-receipt-waiting-4-gen" {
   storage_account_name = module.receipts_datastore_fn_sa.name
 }
 
+resource "azurerm_storage_queue" "queue-receipt-io-notifier-error" {
+  name                 = "${local.project}-queue-receipt-io-notifier-error"
+  storage_account_name = module.receipts_datastore_fn_sa.name
+}
+
 ## blob container attachments
 resource "azurerm_storage_container" "blob-receipt-st-attach" {
   name                  = "${local.project}-azure-blob-receipt-st-attach"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Introducing queue-receipt-io-notifier-error definition in receipt-commons

According to [doc](https://pagopa.atlassian.net/wiki/spaces/PPR/pages/723976457/ReceiptNotifierService#Vista-statica-delle-componenti)

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Updating receipt domain infrastructure to include elements for the notifier component

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
