### PR TITLE
[PAGOPA-1073] feat: Exposing /info API for Status Page

### DIFF
--- a/src/domains/shared-app/04_apim_statuspage.tf
+++ b/src/domains/shared-app/04_apim_statuspage.tf
@@ -48,6 +48,11 @@ data "azurerm_linux_function_app" "api_config" {
   resource_group_name = format("%s-%s-api-config-rg", var.prefix, var.env_short)
 }
 
+data "azurerm_function_app" "authorizer" {
+  name                = format("%s-%s-%s-shared-authorizer-fn", var.prefix, var.env_short, var.location_short)
+  resource_group_name = format("%s-%s-%s-shared-rg", var.prefix, var.env_short, var.location_short)
+}
+
 data "azurerm_linux_function_app" "gpd" {
   name                = format("%s-%s-app-gpd", var.prefix, var.env_short)
   resource_group_name = format("%s-%s-gpd-rg", var.prefix, var.env_short)
@@ -91,6 +96,7 @@ module "apim_api_statuspage_api_v1" {
       "apiconfigcacheo"       = format("%s/api-config-cache/o", format(local.aks_path, "apiconfig"))
       "apiconfigcachep"       = format("%s/api-config-cache/p", format(local.aks_path, "apiconfig"))
       "apiconfigselfcare"     = format("%s/pagopa-api-config-selfcare-integration", format(local.aks_path, "apiconfig"))
+      "authorizer"            = format("%s/", data.azurerm_function_app.authorizer.default_hostname)
       "bizevents"             = format("%s/pagopa-biz-events-service", format(local.aks_path, "bizevents"))
       "bizeventsdatastoreneg" = format("%s/pagopa-negative-biz-events-datastore-service", format(local.aks_path, "bizevents"))
       "bizeventsdatastorepos" = format("%s/pagopa-biz-events-datastore-service", format(local.aks_path, "bizevents"))
@@ -101,7 +107,7 @@ module "apim_api_statuspage_api_v1" {
       "gps"                   = format("%s/pagopa-spontaneous-payments-service", format(local.aks_path, "gps"))
       "gpsdonation"           = format("%s/pagopa-gps-donation-service", format(local.aks_path, "gps"))
       "mockec"                = var.env_short != "p" ? format("%s/", data.azurerm_linux_function_app.mockec[0].default_hostname) : "NA"
-      "mocker"                = var.env_short != "p" ? format("%s/mocker", format(local.aks_path, "mocker")) : "NA"
+      "mocker"                = var.env_short != "p" ? format("%s/pagopa-mocker/mocker", format(local.aks_path, "mock")) : "NA"
       "pdfengine"             = format("%s/pagopa-pdf-engine", format(local.aks_path, "shared"))
       "receiptpdfdatastore"   = format("%s/pagopa-receipt-pdf-datastore", format(local.aks_path, "receipts"))
     }), "\"", "\\\"")

--- a/src/domains/shared-app/api/enrolled-orgs/v1/_openapi.json.tpl
+++ b/src/domains/shared-app/api/enrolled-orgs/v1/_openapi.json.tpl
@@ -11,6 +11,46 @@
     }
   ],
   "paths": {
+		"/info": {
+			"get": {
+				"tags": [
+					"Home"
+				],
+				"summary": "health check",
+				"description": "Return OK if application is started",
+				"operationId": "healthCheck",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"headers": {
+							"X-Request-Id": {
+								"description": "This header identifies the call",
+								"schema": {
+									"type": "string"
+								}
+							}
+						},
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/AppInfo"
+								}
+							}
+						}
+					}
+				}
+			},
+			"parameters": [
+				{
+					"name": "X-Request-Id",
+					"in": "header",
+					"description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+					"schema": {
+						"type": "string"
+					}
+				}
+			]
+		},
     "/organizations/domains/{domain}": {
       "get": {
         "tags": [
@@ -146,6 +186,20 @@
           },
           "segregation_code": {
             "type": "string"
+          }
+        }
+      },
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "version" : {
+            "type" : "string"
+          },
+          "environment" : {
+            "type" : "string"
           }
         }
       }


### PR DESCRIPTION
This PR contains changes made in order to include Authorizer as service shown in Status Page.

### List of changes
 - Updated API called by Status Page
 - Updated `/info` API in platform-authorizer

### Motivation and context
This update is made in order to add a new state on Status page for Authorizer

### Type of changes
- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
