### PR TITLE
[PAGOPA-1075] feat: add enhancement for Status Page

### DIFF
--- a/src/domains/canoneunico/02_function.tf
+++ b/src/domains/canoneunico/02_function.tf
@@ -5,9 +5,9 @@ module "canoneunico_function" {
   resource_group_name                      = azurerm_resource_group.canoneunico_rg.name
   name                                     = "${local.project}-fn-canoneunico"
   location                                 = var.location
-  health_check_path                        = "info"
+  health_check_path                        = "/api/info"
   subnet_id                                = module.canoneunico_function_snet.id
-  runtime_version                          = "~3"
+  runtime_version                          = var.canoneunico_runtime_version
   always_on                                = var.canoneunico_function_always_on
   application_insights_instrumentation_key = data.azurerm_application_insights.application_insights.instrumentation_key
   app_service_plan_id                      = azurerm_app_service_plan.canoneunico_service_plan.id

--- a/src/domains/canoneunico/99_variables.tf
+++ b/src/domains/canoneunico/99_variables.tf
@@ -103,6 +103,12 @@ variable "canoneunico_function_always_on" {
   default     = false
 }
 
+variable "canoneunico_runtime_version" {
+  type        = string
+  description = "Version for the Azure function runtime"
+  default     = "~4"
+}
+
 variable "canoneunico_enable_versioning" {
   type        = bool
   description = "Enable sa versioning"

--- a/src/domains/canoneunico/env/dev/terraform.tfvars
+++ b/src/domains/canoneunico/env/dev/terraform.tfvars
@@ -23,7 +23,7 @@ acr_enabled = true
 
 # docker image
 image_name = "canone-unico"
-image_tag  = "0.0.16"
+image_tag  = "latest"
 
 # canone unico
 canoneunico_plan_sku_tier = "Standard"

--- a/src/domains/canoneunico/env/prod/terraform.tfvars
+++ b/src/domains/canoneunico/env/prod/terraform.tfvars
@@ -36,6 +36,8 @@ canoneunico_function_autoscale_default = 1
 
 canoneunico_queue_message_delay = 3600 // in seconds = 1h
 
+canoneunico_runtime_version = "~3"
+
 # storage
 storage_queue_private_endpoint_enabled = true
 storage_account_info = {

--- a/src/domains/canoneunico/env/uat/terraform.tfvars
+++ b/src/domains/canoneunico/env/uat/terraform.tfvars
@@ -24,7 +24,7 @@ acr_enabled = true
 
 # docker image
 image_name = "canone-unico"
-image_tag  = "0.0.16"
+image_tag  = "latest"
 
 # canone unico
 canoneunico_plan_sku_tier = "Standard"

--- a/src/domains/shared-app/04_apim_statuspage.tf
+++ b/src/domains/shared-app/04_apim_statuspage.tf
@@ -53,6 +53,26 @@ data "azurerm_function_app" "authorizer" {
   resource_group_name = format("%s-%s-%s-shared-rg", var.prefix, var.env_short, var.location_short)
 }
 
+data "azurerm_function_app" "canone_unico" {
+  name                = format("%s-%s-fn-canoneunico", var.prefix, var.env_short)
+  resource_group_name = format("%s-%s-canoneunico-rg", var.prefix, var.env_short)
+}
+
+data "azurerm_function_app" "reporting_analysis" {
+  name                = format("%s-%s-%s-fn-gpd-analysis", var.prefix, var.env_short, var.location_short)
+  resource_group_name = format("%s-%s-%s-gps-gpd-rg", var.prefix, var.env_short, var.location_short)
+}
+
+data "azurerm_function_app" "reporting_batch" {
+  name                = format("%s-%s-%s-fn-gpd-batch", var.prefix, var.env_short, var.location_short)
+  resource_group_name = format("%s-%s-%s-gps-gpd-rg", var.prefix, var.env_short, var.location_short)
+}
+
+data "azurerm_function_app" "reporting_service" {
+  name                = format("%s-%s-%s-fn-gpd-service", var.prefix, var.env_short, var.location_short)
+  resource_group_name = format("%s-%s-%s-gps-gpd-rg", var.prefix, var.env_short, var.location_short)
+}
+
 data "azurerm_linux_function_app" "gpd" {
   name                = format("%s-%s-app-gpd", var.prefix, var.env_short)
   resource_group_name = format("%s-%s-gpd-rg", var.prefix, var.env_short)
@@ -100,13 +120,18 @@ module "apim_api_statuspage_api_v1" {
       "bizevents"             = format("%s/pagopa-biz-events-service", format(local.aks_path, "bizevents"))
       "bizeventsdatastoreneg" = format("%s/pagopa-negative-biz-events-datastore-service", format(local.aks_path, "bizevents"))
       "bizeventsdatastorepos" = format("%s/pagopa-biz-events-datastore-service", format(local.aks_path, "bizevents"))
+      "canoneunico"           = format("%s/", data.azurerm_function_app.canone_unico.default_hostname)
       "fdrndpnew"             = format("%s/pagopa-fdr-service", format(local.aks_path, "fdr"))
       "gpd"                   = format("%s/", data.azurerm_linux_function_app.gpd.default_hostname)
       "gpdpayments"           = format("%s/pagopa-gpd-payments", format(local.aks_path, "gps"))
       "gpdenrollment"         = format("%s/pagopa-gpd-reporting-orgs-enrollment", format(local.aks_path, "gps"))
+      "gpdreportinganalysis"  = format("%s/", data.azurerm_function_app.reporting_analysis.default_hostname)
+      "gpdreportingbatch"     = format("%s/api/", data.azurerm_function_app.reporting_batch.default_hostname)
+      "gpdreportingservice"   = format("%s/api/", data.azurerm_function_app.reporting_service.default_hostname)
       "gps"                   = format("%s/pagopa-spontaneous-payments-service", format(local.aks_path, "gps"))
       "gpsdonation"           = format("%s/pagopa-gps-donation-service", format(local.aks_path, "gps"))
       "mockec"                = var.env_short != "p" ? format("%s/", data.azurerm_linux_function_app.mockec[0].default_hostname) : "NA"
+      "mockconfig"            = var.env_short != "p" ? format("%s/pagopa-mock-config-be", format(local.aks_path, "mock")) : "NA"
       "mocker"                = var.env_short != "p" ? format("%s/pagopa-mocker/mocker", format(local.aks_path, "mock")) : "NA"
       "pdfengine"             = format("%s/pagopa-pdf-engine", format(local.aks_path, "shared"))
       "receiptpdfdatastore"   = format("%s/pagopa-receipt-pdf-datastore", format(local.aks_path, "receipts"))


### PR DESCRIPTION
This PR contains changes made in order to include several application as service shown in Status Page.
Also, an update on Canone Unico was made in order to update the health check endpoint access and to update the function runtime version from v3 to v4. 

#### Notes:
The updates made on Canone Unico function were not applied on UAT yet.

### List of changes
 - Added status indicator for biz-event-datastore services
 - Added status indicator for gpd-reporting services
 - Added status indicator for canone-unico service
 - Update Canone Unico runtime version 

### Motivation and context
These changes are required in order to add new service status indicators on Status Page.

### Type of changes
- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?
- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
