### PR TITLE
[PAGOPA-1104] fix: resolved bug on authorization string check

### DIFF
--- a/src/domains/shared-app/api/authorizer/authorizer-check.xml
+++ b/src/domains/shared-app/api/authorizer/authorizer-check.xml
@@ -7,7 +7,7 @@
     <trace source="authorizer-check" severity="information">authorizer-check</trace>
     <!-- Saving information from request -->
     <set-variable name="domain" value="@((string)context.Variables["application_domain"])" /> <!-- ex. gpd -->
-    <set-variable name="auth_entity" value="@((string)context.Variables["authorization_entity"])" /> <!-- ex. ec 77777777777  -->
+    <set-variable name="auth_entity" value="@("#"+(string)context.Variables["authorization_entity"]+"#")" /> <!-- ex. ec #77777777777#  -->
     <set-variable name="subkey" value="@(context.Request.Headers.GetValueOrDefault("Ocp-Apim-Subscription-Key", ""))" />
     <set-variable name="authorization_cache_key" value="@("authorizer_"+(string)context.Variables["domain"] + "_" + (string)context.Variables["subkey"])" />
 

--- a/src/domains/shared-app/api/authorizer/v1/_base_policy.xml
+++ b/src/domains/shared-app/api/authorizer/v1/_base_policy.xml
@@ -7,7 +7,10 @@
     <set-variable name="must_add_in_progress" value="@(context.Request.Url.Query.GetValueOrDefault("add_in_progress", "true"))" />
     <set-variable name="request" value="@(context.Request.Body.As<JObject>(preserveContent: true))" />
     <set-variable name="domain_key" value="@(((JObject) context.Variables["request"])["key"].ToString())" />
-    <set-variable name="autorized_entities" value="@(((JObject) context.Variables["request"])["value"].ToString())" />
+    <set-variable name="autorized_entities" value="@{
+      string[] entities = ((JObject) context.Variables["request"])["value"].ToString().Split(',');
+      return new System.Text.StringBuilder().Append("#").Append(string.Join("#", entities)).Append("#").ToString();
+    }" />
 
     <!-- Look up for authorized-DOMAIN_in_progress variable -->
     <choose>


### PR DESCRIPTION
This PR contains several changes made on APIM policy XMLs in order to improve the security for the platform Authorization. Before this update, it was possible for someone to use a substring of the stored entity for pass the check of the platform Authorization fragment. This could cause security issues due to the fact that an attacker can use this exploit to use APIs on which it was not authorized.

#### Notes
Before applying this updates, it is necessary to delete all the _cached authorization_ (using Redis client) because this new logic will cause the existing one to be obsolete and no more usable.
To Apply this changes, it was executed the following command:
```
sh terraform.sh apply ENV \
--target=apim_api_authorizer_api_v1.azurerm_api_management_api_policy \
--target=azapi_resource.authorizer_fragment 
```

### List of changes
 - Updated API logic, adding escaping characters to the auth entity value
 - Updated fragment policy, adding escaping character evaluation to the object to be cached 

### Motivation and context
This changes are required in order to resolve the security issue previously described.

### Type of changes
- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?
- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
