### PR TITLE
bug:[PAGOPA-1125] unique iban

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # see https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file
 
-* @pagopa/infrastructure-admins @pagopa/pagopa-admins @pagopa/pagopa-team-core
+* @pagopa/infrastructure-admins @pagopa/pagopa-team-core @pagopa/pagopa-team-touchpoint
 
-/src/domains/selfcare-common @pagopa/infrastructure-admins @pagopa/pagopa-admins @pagopa/pagopa-team-core @andrea-putzu
-/src/domains/selfcare-app @pagopa/infrastructure-admins @pagopa/pagopa-admins @pagopa/pagopa-team-core @andrea-putzu
+/src/domains/selfcare-common @pagopa/infrastructure-admins @pagopa/pagopa-team-core @pagopa/pagopa-team-touchpoint @andrea-putzu
+/src/domains/selfcare-app @pagopa/infrastructure-admins @pagopa/pagopa-team-core @pagopa/pagopa-team-touchpoint @andrea-putzu

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # see https://help.github.com/en/articles/about-code-owners#example-of-a-codeowners-file
 
-* @pagopa/infrastructure-admins @pagopa/pagopa-admins @pagopa/pagopa-tech
+* @pagopa/infrastructure-admins @pagopa/pagopa-admins @pagopa/pagopa-team-core
 
-/src/domains/selfcare-common @pagopa/infrastructure-admins @pagopa/pagopa-admins @pagopa/pagopa-tech @andrea-putzu
-/src/domains/selfcare-app @pagopa/infrastructure-admins @pagopa/pagopa-admins @pagopa/pagopa-tech @andrea-putzu
+/src/domains/selfcare-common @pagopa/infrastructure-admins @pagopa/pagopa-admins @pagopa/pagopa-team-core @andrea-putzu
+/src/domains/selfcare-app @pagopa/infrastructure-admins @pagopa/pagopa-admins @pagopa/pagopa-team-core @andrea-putzu

--- a/src/psql/nodo/liquibase/changelog/cfg/3.22.0/db.changelog-20230705163700_update_database_object.xml
+++ b/src/psql/nodo/liquibase/changelog/cfg/3.22.0/db.changelog-20230705163700_update_database_object.xml
@@ -29,7 +29,7 @@
 	   SELECT mas.fk_pa,
        det.iban          AS iban_accredito,
        mas.validity_date AS data_inizio_validita,
-       null              AS data_pubblicazione,
+	   TO_TIMESTAMP(null, 'YYYY/MM/DD HH:MI:SS' ) AS data_pubblicazione,
        det.fiscal_code   AS ragione_sociale,
        NULL              AS id_merchant,
        NULL              AS id_banca_seller,

--- a/src/psql/nodo/liquibase/changelog/cfg/3.22.0/db.changelog-20230705163700_update_database_object.xml
+++ b/src/psql/nodo/liquibase/changelog/cfg/3.22.0/db.changelog-20230705163700_update_database_object.xml
@@ -63,5 +63,11 @@ FROM   ((iban_master mas
 			onUpdate="RESTRICT" referencedColumnNames="obj_id"
 			referencedTableName="ica_binary_file" validate="true" />
 	</changeSet>
+	
+	<changeSet author="liquibase" id="202307311500">
+		<addUniqueConstraint columnNames="iban"
+			constraintName="IBAN_UNIQUE" deferrable="false"
+			initiallyDeferred="false" tableName="iban" validate="true" />
+	</changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- added unique constraint on iban column in the iban table
- added fix on pubblication_date foreseen in task [PAGOPA-1107](https://pagopa.atlassian.net/browse/PAGOPA-1107)

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

- in the iban table, each registered iban must be unique
- the datatype in the IBAN_VALIDI_PER_PA must be TIMESTAMP

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->


[PAGOPA-1107]: https://pagopa.atlassian.net/browse/PAGOPA-1107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ