### PR TITLE
feat(nodo-app): Add response time alert for each operation [PAGOPA-1207] 

### DIFF
--- a/src/domains/nodo-app/00_alert.tf
+++ b/src/domains/nodo-app/00_alert.tf
@@ -17,6 +17,7 @@ locals {
       operationId_s : "63ff73adea7c4a1860530e3a",
       primitiva : "nodoChiediElencoFlussiRendicontazione",
       sub_service : "node-for-pa",
+      response_time : 20
     },
     {
       operationId_s : "63ff73adea7c4a1860530e3b",
@@ -28,6 +29,7 @@ locals {
       operationId_s : "63b6e2da2a92e811a8f338f8",
       primitiva : "nodoChiediElencoFlussiRendicontazione",
       sub_service : "nodo-per-pa",
+      response_time : 20
     },
     {
       operationId_s : "63b6e2da2a92e811a8f338f9",
@@ -43,6 +45,7 @@ locals {
       operationId_s : "63e5d8212a92e80448d38dfe",
       primitiva : "nodoChiediListaPendentiRPT",
       sub_service : "nodo-per-pa",
+      response_time : 20,
     },
     {
       operationId_s : "63e5d8212a92e80448d38dff",
@@ -89,6 +92,7 @@ locals {
       operationId_s : "63b6e2da2a92e811a8f338fd",
       primitiva : "nodoInviaRT",
       sub_service : "nodo-per-psp",
+      response_time : 20
     },
     {
       operationId_s : "63b6e2da2a92e811a8f338fe",
@@ -238,6 +242,7 @@ locals {
       operationId_s : "61e9633dea7c4a07cc7d480d",
       primitiva : "nodoChiediElencoFlussiRendicontazione",
       sub_service : "nodo-per-pa",
+      response_time : 20
     },
     {
       operationId_s : "61e9633dea7c4a07cc7d480e",
@@ -253,6 +258,7 @@ locals {
       operationId_s : "62189aea2a92e81fa4f15ec5",
       primitiva : "nodoChiediListaPendentiRPT",
       sub_service : "nodo-per-pa",
+      response_time : 20
     },
     {
       operationId_s : "62189aea2a92e81fa4f15ec6",
@@ -356,8 +362,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alert-nodo-responsetime"
   data_source_id = data.azurerm_api_management.apim.id
   description    = "Response time ${each.value.primitiva} ${each.value.sub_service} nodoapi-responsetime https://portal.azure.com/#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourcegroups/dashboards/providers/microsoft.portal/dashboards/cbc97060-c05b-48b5-9962-2b229eaa53de and https://portal.azure.com/#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourcegroups/dashboards/providers/microsoft.portal/dashboards/2b9b319b-5e7d-4efe-aaba-613daef8e9fc"
   enabled        = true
-  query = (<<-QUERY
-let threshold = 8000;
+  query = format(<<-QUERY
+let threshold = '%s';
 AzureDiagnostics
 | where url_s matches regex "/nodo/${each.value.sub_service}/"
 | where operationId_s matches regex "${each.value.operationId_s}"
@@ -366,19 +372,18 @@ AzureDiagnostics
     duration_percentile_95=percentiles(DurationMs, 95)
     by bin(TimeGenerated, 5m)
 | where duration_percentile_95 > threshold
-  QUERY
-  )
+QUERY
+  , lookup(each.value, "response_time", "") != "" ? each.value.response_time : 8000)
 
   # https://learn.microsoft.com/en-us/azure/azure-monitor/best-practices-alerts#alert-severity
   # Sev 2	Warning	A problem that doesn't include any current loss in availability or performance, although it has the potential to lead to more severe problems if unaddressed.
   severity    = 2
   frequency   = 5
-  time_window = 5
+  time_window = 10
   trigger {
     operator  = "GreaterThanOrEqual"
-    threshold = 1
+    threshold = 2
   }
-
 }
 
 
@@ -440,8 +445,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alert-nodo-auth-response
   data_source_id = data.azurerm_api_management.apim.id
   description    = "Response time ${each.value.primitiva} ${each.value.sub_service} nodo-auth-api-responsetime https://portal.azure.com/#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourcegroups/dashboards/providers/microsoft.portal/dashboards/cbc97060-c05b-48b5-9962-2b229eaa53de and https://portal.azure.com/#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourcegroups/dashboards/providers/microsoft.portal/dashboards/2b9b319b-5e7d-4efe-aaba-613daef8e9fc"
   enabled        = true
-  query = (<<-QUERY
-let threshold = 8000;
+  query = format(<<-QUERY
+let threshold = '%s';
 AzureDiagnostics
 | where url_s matches regex "/nodo-auth/${each.value.sub_service}/"
 | where operationId_s matches regex "${each.value.operationId_s}"
@@ -450,19 +455,18 @@ AzureDiagnostics
     duration_percentile_95=percentiles(DurationMs, 95)
     by bin(TimeGenerated, 5m)
 | where duration_percentile_95 > threshold
-  QUERY
-  )
+QUERY
+  , lookup(each.value, "response_time", "") != "" ? each.value.response_time : 8000)
 
   # https://learn.microsoft.com/en-us/azure/azure-monitor/best-practices-alerts#alert-severity
   # Sev 2	Warning	A problem that doesn't include any current loss in availability or performance, although it has the potential to lead to more severe problems if unaddressed.
   severity    = 2
   frequency   = 5
-  time_window = 5
+  time_window = 10
   trigger {
     operator  = "GreaterThanOrEqual"
-    threshold = 1
+    threshold = 2
   }
-
 }
 
 resource "azurerm_monitor_scheduled_query_rules_alert" "alert-nodo-auth-availability" {
@@ -503,5 +507,4 @@ AzureDiagnostics
     operator  = "GreaterThanOrEqual"
     threshold = 1
   }
-
 }

--- a/src/domains/nodo-app/00_alert.tf
+++ b/src/domains/nodo-app/00_alert.tf
@@ -17,7 +17,7 @@ locals {
       operationId_s : "63ff73adea7c4a1860530e3a",
       primitiva : "nodoChiediElencoFlussiRendicontazione",
       sub_service : "node-for-pa",
-      response_time : 20
+      response_time : 20000
     },
     {
       operationId_s : "63ff73adea7c4a1860530e3b",
@@ -29,7 +29,7 @@ locals {
       operationId_s : "63b6e2da2a92e811a8f338f8",
       primitiva : "nodoChiediElencoFlussiRendicontazione",
       sub_service : "nodo-per-pa",
-      response_time : 20
+      response_time : 20000
     },
     {
       operationId_s : "63b6e2da2a92e811a8f338f9",
@@ -45,7 +45,7 @@ locals {
       operationId_s : "63e5d8212a92e80448d38dfe",
       primitiva : "nodoChiediListaPendentiRPT",
       sub_service : "nodo-per-pa",
-      response_time : 20,
+      response_time : 20000,
     },
     {
       operationId_s : "63e5d8212a92e80448d38dff",
@@ -92,7 +92,7 @@ locals {
       operationId_s : "63b6e2da2a92e811a8f338fd",
       primitiva : "nodoInviaRT",
       sub_service : "nodo-per-psp",
-      response_time : 20
+      response_time : 20000
     },
     {
       operationId_s : "63b6e2da2a92e811a8f338fe",
@@ -242,7 +242,7 @@ locals {
       operationId_s : "61e9633dea7c4a07cc7d480d",
       primitiva : "nodoChiediElencoFlussiRendicontazione",
       sub_service : "nodo-per-pa",
-      response_time : 20
+      response_time : 20000
     },
     {
       operationId_s : "61e9633dea7c4a07cc7d480e",
@@ -258,7 +258,7 @@ locals {
       operationId_s : "62189aea2a92e81fa4f15ec5",
       primitiva : "nodoChiediListaPendentiRPT",
       sub_service : "nodo-per-pa",
-      response_time : 20
+      response_time : 20000
     },
     {
       operationId_s : "62189aea2a92e81fa4f15ec6",
@@ -363,7 +363,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alert-nodo-responsetime"
   description    = "Response time ${each.value.primitiva} ${each.value.sub_service} nodoapi-responsetime https://portal.azure.com/#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourcegroups/dashboards/providers/microsoft.portal/dashboards/cbc97060-c05b-48b5-9962-2b229eaa53de and https://portal.azure.com/#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourcegroups/dashboards/providers/microsoft.portal/dashboards/2b9b319b-5e7d-4efe-aaba-613daef8e9fc"
   enabled        = true
   query = format(<<-QUERY
-let threshold = '%s';
+let threshold = %d;
 AzureDiagnostics
 | where url_s matches regex "/nodo/${each.value.sub_service}/"
 | where operationId_s matches regex "${each.value.operationId_s}"
@@ -446,7 +446,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alert-nodo-auth-response
   description    = "Response time ${each.value.primitiva} ${each.value.sub_service} nodo-auth-api-responsetime https://portal.azure.com/#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourcegroups/dashboards/providers/microsoft.portal/dashboards/cbc97060-c05b-48b5-9962-2b229eaa53de and https://portal.azure.com/#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourcegroups/dashboards/providers/microsoft.portal/dashboards/2b9b319b-5e7d-4efe-aaba-613daef8e9fc"
   enabled        = true
   query = format(<<-QUERY
-let threshold = '%s';
+let threshold = %d;
 AzureDiagnostics
 | where url_s matches regex "/nodo-auth/${each.value.sub_service}/"
 | where operationId_s matches regex "${each.value.operationId_s}"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Add the option to customize the response time for each alert that refers to an operation;
- Update the trigger logic, which means that alerts are triggered when the following events occur: 2 thresholds exceeded in a 10-minute time window, calculated over a 5-minute interval.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->


For some operations having a response time greater than the one defined by default can be considered a normal behavior.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
