### PR TITLE
feat: Add nodo alerts on fault code [PAGOPA-1207]

### DIFF
--- a/src/domains/nodo-app/00_alert_faultcode.tf
+++ b/src/domains/nodo-app/00_alert_faultcode.tf
@@ -4,6 +4,8 @@
 ## NB: In this case the fault code PPT_ERRORE_EMESSO_DA_PAA is considered as 'Success', because there is a dedicated alert for this type of error.
 ## Excluding this type of fault from OK group would complicate the definition of the general alert for fault codes like this.
 resource "azurerm_monitor_scheduled_query_rules_alert" "alert-fault-code-availability" {
+  count = var.env_short == "p" ? 1 : 0
+
   resource_group_name = "dashboards"
   name                = "pagopa-${var.env_short}-node-for-psp-api-fault-code-availability"
   location            = var.location
@@ -17,7 +19,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "alert-fault-code-availab
   description    = "Availability Fault Code on activatePaymentNotice operation of node-for-psp API <grafana-dashboard-on-application-code>" #todo
   enabled        = true
   query = (<<-QUERY
-let threshold = 0.97;
+let threshold = 0.95;
 requests
 | extend xml_resp = replace_regex(replace_regex(replace_regex(tostring(customDimensions["Response-Body"]), '</.{0,10}?:', '</'), '<.{0,10}?:', '<'), 'activatePaymentNoticeRes|sendPaymentOutcomeRes|verificaBollettinoRes|verifyPaymentNoticeRes|nodoVerificaRPT', 'primitiva')
 | extend json_resp=parse_xml(xml_resp)
@@ -48,58 +50,60 @@ by bin(timestamp, 5m)
   }
 }
 
-## If the number of fault codes of type PPT_ERRORE_EMESSO_DA_PAA increases, the alert is triggered. The alert takes into account how many PSPs are impacted.
-resource "azurerm_monitor_scheduled_query_rules_alert" "alert-fault-pa-error-availability" {
-  resource_group_name = "dashboards"
-  name                = "pagopa-${var.env_short}-node-for-psp-api-errore-pa-availability"
-  location            = var.location
+# TODO REFINE 
 
-  action {
-    action_group           = [data.azurerm_monitor_action_group.email.id, data.azurerm_monitor_action_group.slack.id, data.azurerm_monitor_action_group.opsgenie.id]
-    email_subject          = "Email Header"
-    custom_webhook_payload = "{}"
-  }
-  data_source_id = data.azurerm_application_insights.application_insights.id
-  description    = "Availability Fault Code PPT_ERRORE_EMESSO_DA_PAA node-for-psp <grafana-dashboard-on-application-code>" #todo
-  enabled        = true
-  query = (<<-QUERY
-let threshold = 0.80;
-let affected_psp = 5;
-requests
-| extend xml_resp = replace_regex(replace_regex(replace_regex(tostring(customDimensions["Response-Body"]), '</.{0,10}?:', '</'), '<.{0,10}?:', '<'), 'activatePaymentNoticeRes|sendPaymentOutcomeRes|verificaBollettinoRes|verifyPaymentNoticeRes|nodoVerificaRPT', 'primitiva')
-| extend json_resp=parse_xml(xml_resp)
-| extend xml_req = replace_regex(replace_regex(replace_regex(tostring(customDimensions["Request-Body"]), '</.{0,10}?:', '</'), '<.{0,10}?:', '<'), 'activatePaymentNoticeReq|sendPaymentOutcomeReq|verificaBollettinoReq|verifyPaymentNoticeReq|nodoVerificaRPT', 'primitiva')
-| extend json_req=parse_xml(xml_req)
-| extend operation = case(
-operation_Name == "p-node-for-psp-api;rev=1 - 61dedafc2a92e81a0c7a58fc", "activatePaymentNotice",
-"unknown")
-| extend idPSP = tostring(json_req["Envelope"]["Body"]["primitiva"].idPSP)
-| extend idBrokerPSP = case (
-strlen(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP) == 9, strcat("00", tostring(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP)),
-strlen(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP) == 10, strcat("0", tostring(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP)),
-tostring(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP))
-| extend resp_outcome = tostring(json_resp["Envelope"]["Body"]["primitiva"]["outcome"])
-| extend faultCode= tostring(json_resp["Envelope"]["Body"]["primitiva"]["fault"]["faultCode"])
-| where cloud_RoleName == "pagopa-p-apim West Europe"
-| where operation_Name == "p-node-for-psp-api;rev=1 - 61dedafc2a92e81a0c7a58fc" // activatePaymentNotice v1 legacy
-| summarize
-Total=count(),
-Success=countif(resp_outcome == "OK" or faultCode != "PPT_ERRORE_EMESSO_DA_PAA")
-by bin(timestamp, 5m), idPSP
-| extend availability=toreal(Success) / Total
-| where availability < threshold
-| summarize PSP=count() by bin(timestamp, 5m)
-| where PSP > affected_psp
-  QUERY
-  )
+# ## If the number of fault codes of type PPT_ERRORE_EMESSO_DA_PAA increases, the alert is triggered. The alert takes into account how many PSPs are impacted.
+# resource "azurerm_monitor_scheduled_query_rules_alert" "alert-fault-pa-error-availability" {
+#   resource_group_name = "dashboards"
+#   name                = "pagopa-${var.env_short}-node-for-psp-api-errore-pa-availability"
+#   location            = var.location
 
-  # https://learn.microsoft.com/en-us/azure/azure-monitor/best-practices-alerts#alert-severity
-  # Sev 1	Error	Degradation of performance or loss of availability of some aspect of an application or service. Requires attention but not immediate
-  severity    = 1
-  frequency   = 5
-  time_window = 10
-  trigger {
-    operator  = "GreaterThanOrEqual"
-    threshold = 2
-  }
-}
+#   action {
+#     action_group           = [data.azurerm_monitor_action_group.email.id, data.azurerm_monitor_action_group.slack.id, data.azurerm_monitor_action_group.opsgenie.id]
+#     email_subject          = "Email Header"
+#     custom_webhook_payload = "{}"
+#   }
+#   data_source_id = data.azurerm_application_insights.application_insights.id
+#   description    = "Availability Fault Code PPT_ERRORE_EMESSO_DA_PAA node-for-psp <grafana-dashboard-on-application-code>" #todo
+#   enabled        = true
+#   query = (<<-QUERY
+# let threshold = 0.80;
+# let affected_psp = 5;
+# requests
+# | extend xml_resp = replace_regex(replace_regex(replace_regex(tostring(customDimensions["Response-Body"]), '</.{0,10}?:', '</'), '<.{0,10}?:', '<'), 'activatePaymentNoticeRes|sendPaymentOutcomeRes|verificaBollettinoRes|verifyPaymentNoticeRes|nodoVerificaRPT', 'primitiva')
+# | extend json_resp=parse_xml(xml_resp)
+# | extend xml_req = replace_regex(replace_regex(replace_regex(tostring(customDimensions["Request-Body"]), '</.{0,10}?:', '</'), '<.{0,10}?:', '<'), 'activatePaymentNoticeReq|sendPaymentOutcomeReq|verificaBollettinoReq|verifyPaymentNoticeReq|nodoVerificaRPT', 'primitiva')
+# | extend json_req=parse_xml(xml_req)
+# | extend operation = case(
+# operation_Name == "p-node-for-psp-api;rev=1 - 61dedafc2a92e81a0c7a58fc", "activatePaymentNotice",
+# "unknown")
+# | extend idPSP = tostring(json_req["Envelope"]["Body"]["primitiva"].idPSP)
+# | extend idBrokerPSP = case (
+# strlen(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP) == 9, strcat("00", tostring(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP)),
+# strlen(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP) == 10, strcat("0", tostring(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP)),
+# tostring(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP))
+# | extend resp_outcome = tostring(json_resp["Envelope"]["Body"]["primitiva"]["outcome"])
+# | extend faultCode= tostring(json_resp["Envelope"]["Body"]["primitiva"]["fault"]["faultCode"])
+# | where cloud_RoleName == "pagopa-p-apim West Europe"
+# | where operation_Name == "p-node-for-psp-api;rev=1 - 61dedafc2a92e81a0c7a58fc" // activatePaymentNotice v1 legacy
+# | summarize
+# Total=count(),
+# Success=countif(resp_outcome == "OK" or faultCode != "PPT_ERRORE_EMESSO_DA_PAA")
+# by bin(timestamp, 5m), idPSP
+# | extend availability=toreal(Success) / Total
+# | where availability < threshold
+# | summarize PSP=count() by bin(timestamp, 5m)
+# | where PSP > affected_psp
+#   QUERY
+#   )
+
+#   # https://learn.microsoft.com/en-us/azure/azure-monitor/best-practices-alerts#alert-severity
+#   # Sev 1	Error	Degradation of performance or loss of availability of some aspect of an application or service. Requires attention but not immediate
+#   severity    = 1
+#   frequency   = 5
+#   time_window = 10
+#   trigger {
+#     operator  = "GreaterThanOrEqual"
+#     threshold = 2
+#   }
+# }

--- a/src/domains/nodo-app/00_alert_faultcode.tf
+++ b/src/domains/nodo-app/00_alert_faultcode.tf
@@ -1,0 +1,105 @@
+## Responses that return OK and those with one of these error codes
+## ["PPT_PAGAMENTO_IN_CORSO","PPT_PAGAMENTO_DUPLICATO", "PPT_STAZIONE_INT_PA_TIMEOUT","PPT_ATTIVAZIONE_IN_CORSO", "PPT_ERRORE_EMESSO_DA_PAA"]
+## are considered positive. The others are considered failure.
+## NB: In this case the fault code PPT_ERRORE_EMESSO_DA_PAA is considered as 'Success', because there is a dedicated alert for this type of error.
+## Excluding this type of fault from OK group would complicate the definition of the general alert for fault codes like this.
+resource "azurerm_monitor_scheduled_query_rules_alert" "alert-fault-code-availability" {
+  resource_group_name = "dashboards"
+  name                = "pagopa-${var.env_short}-node-for-psp-api-fault-code-availability"
+  location            = var.location
+
+  action {
+    action_group           = [data.azurerm_monitor_action_group.email.id, data.azurerm_monitor_action_group.slack.id, data.azurerm_monitor_action_group.opsgenie.id]
+    email_subject          = "Email Header"
+    custom_webhook_payload = "{}"
+  }
+  data_source_id = data.azurerm_application_insights.application_insights.id
+  description    = "Availability Fault Code on activatePaymentNotice operation of node-for-psp API <grafana-dashboard-on-application-code>" #todo
+  enabled        = true
+  query = (<<-QUERY
+let threshold = 0.97;
+requests
+| extend xml_resp = replace_regex(replace_regex(replace_regex(tostring(customDimensions["Response-Body"]), '</.{0,10}?:', '</'), '<.{0,10}?:', '<'), 'activatePaymentNoticeRes|sendPaymentOutcomeRes|verificaBollettinoRes|verifyPaymentNoticeRes|nodoVerificaRPT', 'primitiva')
+| extend json_resp=parse_xml(xml_resp)
+| extend resp_outcome = tostring(json_resp["Envelope"]["Body"]["primitiva"]["outcome"])
+| extend faultCode= tostring(json_resp["Envelope"]["Body"]["primitiva"]["fault"]["faultCode"])
+| extend originalFaultCode = case(
+json_resp["Envelope"]["Body"]["primitiva"]["fault"]["originalFaultCode"] != "", tostring(json_resp["Envelope"]["Body"]["primitiva"]["fault"]["originalFaultCode"]),
+extract("FaultCode PA: ([A-Z_]+)", 1, tostring(json_resp["Envelope"]["Body"]["primitiva"]["fault"]["description"])))
+| where cloud_RoleName == "pagopa-p-apim West Europe"
+| where operation_Name == "p-node-for-psp-api;rev=1 - 61dedafc2a92e81a0c7a58fc" // activatePaymentNotice v1 legacy
+| summarize
+Total=count(),
+Success=countif(resp_outcome == "OK" or faultCode in ("PPT_PAGAMENTO_IN_CORSO","PPT_PAGAMENTO_DUPLICATO", "PPT_STAZIONE_INT_PA_TIMEOUT","PPT_ATTIVAZIONE_IN_CORSO", "PPT_ERRORE_EMESSO_DA_PAA"))
+by bin(timestamp, 5m)
+| extend availability=toreal(Success) / Total
+| where availability < threshold
+  QUERY
+  )
+
+  # https://learn.microsoft.com/en-us/azure/azure-monitor/best-practices-alerts#alert-severity
+  # Sev 1	Error	Degradation of performance or loss of availability of some aspect of an application or service. Requires attention but not immediate
+  severity    = 1
+  frequency   = 5
+  time_window = 10
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 2
+  }
+}
+
+## If the number of fault codes of type PPT_ERRORE_EMESSO_DA_PAA increases, the alert is triggered. The alert takes into account how many PSPs are impacted.
+resource "azurerm_monitor_scheduled_query_rules_alert" "alert-fault-pa-error-availability" {
+  resource_group_name = "dashboards"
+  name                = "pagopa-${var.env_short}-node-for-psp-api-errore-pa-availability"
+  location            = var.location
+
+  action {
+    action_group           = [data.azurerm_monitor_action_group.email.id, data.azurerm_monitor_action_group.slack.id, data.azurerm_monitor_action_group.opsgenie.id]
+    email_subject          = "Email Header"
+    custom_webhook_payload = "{}"
+  }
+  data_source_id = data.azurerm_application_insights.application_insights.id
+  description    = "Availability Fault Code PPT_ERRORE_EMESSO_DA_PAA node-for-psp <grafana-dashboard-on-application-code>" #todo
+  enabled        = true
+  query = (<<-QUERY
+let threshold = 0.80;
+let affected_psp = 5;
+requests
+| extend xml_resp = replace_regex(replace_regex(replace_regex(tostring(customDimensions["Response-Body"]), '</.{0,10}?:', '</'), '<.{0,10}?:', '<'), 'activatePaymentNoticeRes|sendPaymentOutcomeRes|verificaBollettinoRes|verifyPaymentNoticeRes|nodoVerificaRPT', 'primitiva')
+| extend json_resp=parse_xml(xml_resp)
+| extend xml_req = replace_regex(replace_regex(replace_regex(tostring(customDimensions["Request-Body"]), '</.{0,10}?:', '</'), '<.{0,10}?:', '<'), 'activatePaymentNoticeReq|sendPaymentOutcomeReq|verificaBollettinoReq|verifyPaymentNoticeReq|nodoVerificaRPT', 'primitiva')
+| extend json_req=parse_xml(xml_req)
+| extend operation = case(
+operation_Name == "p-node-for-psp-api;rev=1 - 61dedafc2a92e81a0c7a58fc", "activatePaymentNotice",
+"unknown")
+| extend idPSP = tostring(json_req["Envelope"]["Body"]["primitiva"].idPSP)
+| extend idBrokerPSP = case (
+strlen(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP) == 9, strcat("00", tostring(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP)),
+strlen(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP) == 10, strcat("0", tostring(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP)),
+tostring(json_req["Envelope"]["Body"]["primitiva"].idBrokerPSP))
+| extend resp_outcome = tostring(json_resp["Envelope"]["Body"]["primitiva"]["outcome"])
+| extend faultCode= tostring(json_resp["Envelope"]["Body"]["primitiva"]["fault"]["faultCode"])
+| where cloud_RoleName == "pagopa-p-apim West Europe"
+| where operation_Name == "p-node-for-psp-api;rev=1 - 61dedafc2a92e81a0c7a58fc" // activatePaymentNotice v1 legacy
+| summarize
+Total=count(),
+Success=countif(resp_outcome == "OK" or faultCode != "PPT_ERRORE_EMESSO_DA_PAA")
+by bin(timestamp, 5m), idPSP
+| extend availability=toreal(Success) / Total
+| where availability < threshold
+| summarize PSP=count() by bin(timestamp, 5m)
+| where PSP > affected_psp
+  QUERY
+  )
+
+  # https://learn.microsoft.com/en-us/azure/azure-monitor/best-practices-alerts#alert-severity
+  # Sev 1	Error	Degradation of performance or loss of availability of some aspect of an application or service. Requires attention but not immediate
+  severity    = 1
+  frequency   = 5
+  time_window = 10
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 2
+  }
+}

--- a/src/domains/nodo-app/04_apim_nodo_services_ndp.tf
+++ b/src/domains/nodo-app/04_apim_nodo_services_ndp.tf
@@ -499,7 +499,7 @@ module "apim_nodo_per_pm_api_v1_ndp" {
 
   content_format = "swagger-json"
   content_value = templatefile("./api/nodopagamenti_api/nodoPerPM/v1/_swagger.json.tpl", {
-    host = local.apim_hostname
+    host    = local.apim_hostname
     service = module.apim_nodo_dei_pagamenti_product_ndp.product_id
   })
 

--- a/src/domains/nodo-app/04_apim_nodo_services_ndp_replica.tf
+++ b/src/domains/nodo-app/04_apim_nodo_services_ndp_replica.tf
@@ -465,7 +465,7 @@ module "apim_nodo_per_pm_api_v1_replica_ndp" {
 
   content_format = "swagger-json"
   content_value = templatefile("./api/nodopagamenti_api_replica/nodoPerPM/v1/_swagger.json.tpl", {
-    host = local.apim_hostname
+    host    = local.apim_hostname
     service = module.apim_nodo_dei_pagamenti_product_replica_ndp[0].product_id
   })
 

--- a/src/domains/nodo-app/05_fn_ndp_re_to_datastore.tf
+++ b/src/domains/nodo-app/05_fn_ndp_re_to_datastore.tf
@@ -58,7 +58,7 @@ locals {
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
     WEBSITE_ENABLE_SYNC_UPDATE_SITE     = true
 
-    DOCKER_REGISTRY_SERVER_URL      = local.docker_settings.DOCKER_REGISTRY_SERVER_URL
+    DOCKER_REGISTRY_SERVER_URL = local.docker_settings.DOCKER_REGISTRY_SERVER_URL
 
     COSMOS_CONN_STRING        = "AccountEndpoint=https://${local.project}-re-cosmos-nosql-account.documents.azure.com:443/;AccountKey=${data.azurerm_cosmosdb_account.nodo_re_cosmosdb_nosql.primary_key}"
     COSMOS_DB_NAME            = "nodo_re"

--- a/src/domains/nodo-app/05_fn_ndp_re_to_tablestorage.tf
+++ b/src/domains/nodo-app/05_fn_ndp_re_to_tablestorage.tf
@@ -28,7 +28,7 @@ locals {
     WEBSITES_ENABLE_APP_SERVICE_STORAGE = false
     WEBSITE_ENABLE_SYNC_UPDATE_SITE     = true
 
-    DOCKER_REGISTRY_SERVER_URL      = local.ts_docker_settings.DOCKER_REGISTRY_SERVER_URL
+    DOCKER_REGISTRY_SERVER_URL = local.ts_docker_settings.DOCKER_REGISTRY_SERVER_URL
 
     EVENTHUB_CONN_STRING = data.azurerm_eventhub_authorization_rule.pagopa-evh-ns01_nodo-dei-pagamenti-re_nodo-dei-pagamenti-re-to-tablestorage-rx.primary_connection_string
 

--- a/src/domains/nodo-app/README.md
+++ b/src/domains/nodo-app/README.md
@@ -86,6 +86,8 @@
 | [azurerm_api_management_api_operation_policy.close_payment_api_v1_replica_ndp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.nm3_activate_v2_verify_policy_ndp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_operation_policy.nm3_activate_verify_policy_ndp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
+| [azurerm_api_management_api_operation_policy.parked_list_api_v1_ndp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
+| [azurerm_api_management_api_operation_policy.parked_list_api_v1_replica_ndp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_operation_policy) | resource |
 | [azurerm_api_management_api_policy.apim_node_for_io_policy_ndp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_policy) | resource |
 | [azurerm_api_management_api_policy.apim_node_for_io_policy_replica_ndp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_policy) | resource |
 | [azurerm_api_management_api_policy.apim_node_for_psp_policy_ndp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_policy) | resource |
@@ -138,6 +140,7 @@
 | [azurerm_monitor_autoscale_setting.vmss-scale](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_autoscale_setting) | resource |
 | [azurerm_monitor_metric_alert.aks_nodo_moetrics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.aks_nodo_moetrics_error](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert.alert-fault-code-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.alert-nodo-auth-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.alert-nodo-auth-responsetime](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.alert-nodo-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Two alerts on fault code was added:
- In the first one responses that return OK and those with one of these error codes ["PPT_PAGAMENTO_IN_CORSO","PPT_PAGAMENTO_DUPLICATO", "PPT_STAZIONE_INT_PA_TIMEOUT","PPT_ATTIVAZIONE_IN_CORSO", "PPT_ERRORE_EMESSO_DA_PAA"] are considered positive. The others are considered failure. The alert is triggered based on availability threshold.
- The second monitors PPT_ERRORE_EMESSO_DA_PAA error type only and is based on 2 thresholds: the availability theshold and the number of PSP impacted.


### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
