### PR TITLE
fix: Upd profile scaling to forwarder app service

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -406,6 +406,8 @@
 | [azurerm_monitor_autoscale_setting.node_forwarder_app_service_autoscale](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/monitor_autoscale_setting) | resource |
 | [azurerm_monitor_autoscale_setting.reporting_fdr_function](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/monitor_autoscale_setting) | resource |
 | [azurerm_monitor_diagnostic_setting.activity_log](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/monitor_diagnostic_setting) | resource |
+| [azurerm_monitor_metric_alert.app_service_over_cpu_usage](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/monitor_metric_alert) | resource |
+| [azurerm_monitor_metric_alert.app_service_over_mem_usage](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.snat_connection_over_10K](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.buyerbanks_update_alert](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.fdr_parsing_0_flows_alert](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/monitor_scheduled_query_rules_alert) | resource |

--- a/src/core/node_forwarder.tf
+++ b/src/core/node_forwarder.tf
@@ -142,6 +142,7 @@ resource "azurerm_monitor_autoscale_setting" "node_forwarder_app_service_autosca
   target_resource_id  = module.node_forwarder_app_service.plan_id
   enabled             = var.node_forwarder_autoscale_enabled
 
+  # default profile on REQUESTs
   profile {
     name = "default"
 
@@ -195,16 +196,6 @@ resource "azurerm_monitor_autoscale_setting" "node_forwarder_app_service_autosca
       }
     }
 
-  }
-  profile {
-    name = "response-time"
-
-    capacity {
-      default = 5
-      minimum = 3
-      maximum = 10
-    }
-
     # Supported metrics for Microsoft.Web/sites 
     # 👀 https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-metrics
     rule {
@@ -250,7 +241,73 @@ resource "azurerm_monitor_autoscale_setting" "node_forwarder_app_service_autosca
         cooldown  = "PT20M"
       }
     }
+
   }
+
+  # addded profile on CPU avg
+  # profile {
+  #   name = "response-time"
+
+  #   capacity {
+  #     default = 5
+  #     minimum = 3
+  #     maximum = 10
+  #   }
+
+  #   # Supported metrics for Microsoft.Web/sites 
+  #   # 👀 https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-metrics
+  #   rule {
+  #     metric_trigger {
+  #       metric_name              = "HttpResponseTime"
+  #       metric_resource_id       = module.node_forwarder_app_service.id
+  #       metric_namespace         = "microsoft.web/sites"
+  #       time_grain               = "PT1M"
+  #       statistic                = "Average"
+  #       time_window              = "PT5M"
+  #       time_aggregation         = "Average"
+  #       operator                 = "GreaterThan"
+  #       threshold                = 3 #sec
+  #       divide_by_instance_count = false
+  #     }
+
+  #     scale_action {
+  #       direction = "Increase"
+  #       type      = "ChangeCount"
+  #       value     = "2"
+  #       cooldown  = "PT5M"
+  #     }
+  #   }
+
+  #   rule {
+  #     metric_trigger {
+  #       metric_name              = "HttpResponseTime"
+  #       metric_resource_id       = module.node_forwarder_app_service.id
+  #       metric_namespace         = "microsoft.web/sites"
+  #       time_grain               = "PT1M"
+  #       statistic                = "Average"
+  #       time_window              = "PT5M"
+  #       time_aggregation         = "Average"
+  #       operator                 = "LessThan"
+  #       threshold                = 2 #sec
+  #       divide_by_instance_count = false
+  #     }
+
+  #     scale_action {
+  #       direction = "Decrease"
+  #       type      = "ChangeCount"
+  #       value     = "1"
+  #       cooldown  = "PT20M"
+  #     }
+  #   }
+
+  #   recurrence {
+  #     timezone = "E. Europe Standard Time"
+  #     days     = ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"]
+  #     hours    = [6]
+  #     minutes  = [0]
+  #   }
+
+  # }
 
 }
 

--- a/src/core/node_forwarder.tf
+++ b/src/core/node_forwarder.tf
@@ -147,7 +147,7 @@ resource "azurerm_monitor_autoscale_setting" "node_forwarder_app_service_autosca
 
     capacity {
       default = 5
-      minimum = 1
+      minimum = 3
       maximum = 10
     }
 
@@ -194,8 +194,66 @@ resource "azurerm_monitor_autoscale_setting" "node_forwarder_app_service_autosca
         cooldown  = "PT20M"
       }
     }
+
   }
+  profile {
+    name = "response-time"
+
+    capacity {
+      default = 5
+      minimum = 3
+      maximum = 10
+    }
+
+    # Supported metrics for Microsoft.Web/sites 
+    # 👀 https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-metrics
+    rule {
+      metric_trigger {
+        metric_name              = "HttpResponseTime"
+        metric_resource_id       = module.node_forwarder_app_service.id
+        metric_namespace         = "microsoft.web/sites"
+        time_grain               = "PT1M"
+        statistic                = "Average"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "GreaterThan"
+        threshold                = 3 #sec
+        divide_by_instance_count = false
+      }
+
+      scale_action {
+        direction = "Increase"
+        type      = "ChangeCount"
+        value     = "2"
+        cooldown  = "PT5M"
+      }
+    }
+
+    rule {
+      metric_trigger {
+        metric_name              = "HttpResponseTime"
+        metric_resource_id       = module.node_forwarder_app_service.id
+        metric_namespace         = "microsoft.web/sites"
+        time_grain               = "PT1M"
+        statistic                = "Average"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "LessThan"
+        threshold                = 2 #sec
+        divide_by_instance_count = false
+      }
+
+      scale_action {
+        direction = "Decrease"
+        type      = "ChangeCount"
+        value     = "1"
+        cooldown  = "PT20M"
+      }
+    }
+  }
+
 }
+
 
 # KV placeholder for CERT and KEY certificate
 #tfsec:ignore:azure-keyvault-ensure-secret-expiry tfsec:ignore:azure-keyvault-content-type-for-secret

--- a/src/core/node_forwarder.tf
+++ b/src/core/node_forwarder.tf
@@ -388,4 +388,81 @@ AzureDiagnostics
 
 }
 
+#################################
+# Alert on mem or cpu avr 
+#################################
+resource "azurerm_monitor_metric_alert" "app_service_over_cpu_usage" {
+  count               = var.env_short == "p" ? 1 : 0
+  resource_group_name = "dashboards"
+  name                = "pagopa-${var.env_short}-pagopa-node-forwarder-cpu-usage-over-80"
+
+  scopes      = [module.node_forwarder_app_service.plan_id]
+  description = "Forwarder CPU usage greater than 80% - https://portal.azure.com/#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/pagopa-p-opex_pagopa-node-forwarder"
+  severity    = 3
+  frequency   = "PT5M"
+  window_size = "PT5M"
+
+  target_resource_type     = "microsoft.web/serverfarms"
+  target_resource_location = var.location
+
+
+  criteria {
+    metric_namespace       = "microsoft.web/serverfarms"
+    metric_name            = "CpuPercentage"
+    aggregation            = "Average"
+    operator               = "GreaterThan"
+    threshold              = "80"
+    skip_metric_validation = false
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.slack.id
+  }
+  action {
+    action_group_id = azurerm_monitor_action_group.email.id
+  }
+  action {
+    action_group_id = azurerm_monitor_action_group.new_conn_srv_opsgenie[0].id
+  }
+
+  tags = var.tags
+}
+
+resource "azurerm_monitor_metric_alert" "app_service_over_mem_usage" {
+  count               = var.env_short == "p" ? 1 : 0
+  resource_group_name = "dashboards"
+  name                = "pagopa-${var.env_short}-pagopa-node-forwarder-mem-usage-over-80"
+
+  scopes      = [module.node_forwarder_app_service.plan_id]
+  description = "Forwarder MEM usage greater than 80% - https://portal.azure.com/#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourceGroups/dashboards/providers/Microsoft.Portal/dashboards/pagopa-p-opex_pagopa-node-forwarder"
+  severity    = 3
+  frequency   = "PT5M"
+  window_size = "PT5M"
+
+  target_resource_type     = "microsoft.web/serverfarms"
+  target_resource_location = var.location
+
+
+  criteria {
+    metric_namespace       = "microsoft.web/serverfarms"
+    metric_name            = "MemoryPercentage"
+    aggregation            = "Average"
+    operator               = "GreaterThan"
+    threshold              = "80"
+    skip_metric_validation = false
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.slack.id
+  }
+  action {
+    action_group_id = azurerm_monitor_action_group.email.id
+  }
+  action {
+    action_group_id = azurerm_monitor_action_group.new_conn_srv_opsgenie[0].id
+  }
+
+  tags = var.tags
+}
+
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- add additional autoscaling forwarder based on `HttpResponseTime` avg ( `+2` istances if greater than `3sec` )
- add alert on CPU avg forwarder grater than 80%
- add alert on MEM avg forwarder grater than 80%

<img width="904" alt="image" src="https://github.com/pagopa/pagopa-infra/assets/36746022/71728e2a-0b70-4f02-8a17-57fb32108ae3">

```
sh terraform.sh apply <ENV>  \
-target=azurerm_monitor_autoscale_setting.node_forwarder_app_service_autoscale \
-target=azurerm_monitor_metric_alert.app_service_over_cpu_usage \
-target=azurerm_monitor_metric_alert.app_service_over_mem_usage
```

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

ℹ️  https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-multiprofile?tabs=templates#multiple-contiguous-profiles

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
