### PR TITLE
fix(npg): [CHK-1997] operation time parsing

### DIFF
--- a/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
@@ -61,7 +61,10 @@
                         string operationTime = (string)operation["operationTime"];
                         string timestampOperation = null;
                         if(operationTime != null) {
-                            timestampOperation = operationTime.Replace(' ','T') + "+02:00";
+                            DateTime npgDateTime = DateTime.Parse(operationTime).Replace(" ","T");
+                            DateTime utcDateTime = TimeZoneInfo.ConvertTimeToUtc(npgDateTime, zone);
+                            DateTimeOffset dateTimeOffset = new DateTimeOffset(utcDateTime);
+                            timestampOperation = dateTimeOffset.ToString("o", CultureInfo.InvariantCulture);
                         }
                         JObject outcomeGateway = new JObject();
                         outcomeGateway["paymentGatewayType"] = "NPG";

--- a/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
@@ -61,10 +61,11 @@
                         string operationTime = (string)operation["operationTime"];
                         string timestampOperation = null;
                         if(operationTime != null) {
-                            DateTime npgDateTime = DateTime.Parse(operationTime).Replace(" ","T");
+                            DateTime npgDateTime = DateTime.Parse(operationTime.Replace(" ","T"));
+                            TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Rome");
                             DateTime utcDateTime = TimeZoneInfo.ConvertTimeToUtc(npgDateTime, zone);
                             DateTimeOffset dateTimeOffset = new DateTimeOffset(utcDateTime);
-                            timestampOperation = dateTimeOffset.ToString("o", CultureInfo.InvariantCulture);
+                            timestampOperation = dateTimeOffset.ToString("o");
                         }
                         JObject outcomeGateway = new JObject();
                         outcomeGateway["paymentGatewayType"] = "NPG";

--- a/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
@@ -8,11 +8,11 @@
         <set-variable name="paymentMethodId" value="@(context.Request.Url.Query.GetValueOrDefault("paymentMethodId",""))" />
         <set-variable name="npgNotificationRequestBody" value="@((JObject)context.Request.Body.As<JObject>(true))" />
         <!-- end policy variables -->
-        <!-- start request validation-->
+        <!-- start request validation
         <validate-content unspecified-content-type-action="prevent" max-size="102400" size-exceeded-action="prevent" errors-variable-name="requestBodyValidation">
            <content type="application/json" validate-as="json" action="prevent" />
         </validate-content>
-        <!-- end request validation -->
+         end request validation -->
         <!-- payment method verify session -->
         <send-request mode="new" response-variable-name="paymentMethodSessionVerificationResponse" timeout="10" ignore-error="true">
             <set-url>@(String.Format((string)context.Variables["paymentMethodBackendUri"]+"/payment-methods/{0}/sessions/{1}/transactionId", (string)context.Variables["paymentMethodId"], (string)context.Variables["orderId"]))</set-url>

--- a/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
@@ -58,11 +58,10 @@
                             rrn = (string)additionalData["rrn"];
                         }
                         string paymentEndToEndId = (string)operation["paymentEndToEndId"];
-                        string eventTime = (string)requestBody["eventTime"];
+                        string operationTime = (string)operation["operationTime"];
                         string timestampOperation = null;
-                        if(eventTime != null) {
-                            DateTime dt = new DateTime(1970, 1, 1, 0, 0, 0, 0).AddSeconds(Double.Parse(eventTime));
-                            timestampOperation = dt.ToString("o") + "Z";
+                        if(operationTime != null) {
+                            timestampOperation = operationTime.Replace(' ','T') + "+02:00";
                         }
                         JObject outcomeGateway = new JObject();
                         outcomeGateway["paymentGatewayType"] = "NPG";

--- a/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
@@ -62,7 +62,7 @@
                         string timestampOperation = null;
                         if(operationTime != null) {
                             DateTime npgDateTime = DateTime.Parse(operationTime.Replace(" ","T"));
-                            TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById("Europe/Rome");
+                            TimeZoneInfo zone = TimeZoneInfo.FindSystemTimeZoneById("Central European Standard Time");
                             DateTime utcDateTime = TimeZoneInfo.ConvertTimeToUtc(npgDateTime, zone);
                             DateTimeOffset dateTimeOffset = new DateTimeOffset(utcDateTime);
                             timestampOperation = dateTimeOffset.ToString("o");

--- a/src/domains/ecommerce-app/api/npg-notification/_openapi.json.tpl
+++ b/src/domains/ecommerce-app/api/npg-notification/_openapi.json.tpl
@@ -67,8 +67,7 @@
             "description": "Event identifier"
           },
           "eventTime": {
-            "type": "integer",
-            "format": "int64",
+            "type": "string",
             "description": "Event timestamp in ISO 8601 format"
           },
           "securityToken": {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

1. Fix operation timestamp parsing for NPG POST notification:
date is passed without timezone information but NPG b.e. set it in Italy timezone.
This pr add date parsing converting input date to UTC set timezone information in request passed to transactions-service.
2. Remove request validation: optional values are serialized as null into received request but request validation task fails for those fields making request validation fail also for valid requests
<!--- Describe your changes in detail -->

### Motivation and context
Those modifications are needed in order to properly parse NPG input date and request body
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
