### PR TITLE
[NOD-501] feat: added product for apiconfig-testing-support APIs

### DIFF
--- a/src/domains/apiconfig-app/04_apim_product_apiconfig-testing-support.tf
+++ b/src/domains/apiconfig-app/04_apim_product_apiconfig-testing-support.tf
@@ -1,0 +1,24 @@
+module "apim_apiconfig_testing_support_product" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_product?ref=v5.1.0"
+
+  product_id   = local.apiconfig_testing_support_locals.product_id
+  display_name = local.apiconfig_testing_support_locals.display_name
+  description  = local.apiconfig_testing_support_locals.description
+
+  api_management_name = local.pagopa_apim_name
+  resource_group_name = local.pagopa_apim_rg
+
+  published             = true
+  subscription_required = local.apiconfig_testing_support_locals.subscription_required
+  approval_required     = false
+  subscriptions_limit   = local.apiconfig_testing_support_locals.subscription_limit
+
+  policy_xml = file("./api_product/apiconfig-testing-support/_base_policy.xml")
+}
+
+resource "azurerm_api_management_product_group" "access_control_developers_for_testing_support" {
+  product_id          = module.apim_apiconfig_testing_support_product.product_id
+  group_name          = data.azurerm_api_management_group.group_developers.name
+  api_management_name = local.pagopa_apim_name
+  resource_group_name = local.pagopa_apim_rg
+}

--- a/src/domains/apiconfig-app/04_apim_product_apiconfig-testing-support.tf
+++ b/src/domains/apiconfig-app/04_apim_product_apiconfig-testing-support.tf
@@ -1,4 +1,5 @@
 module "apim_apiconfig_testing_support_product" {
+  count  = var.env_short != "p" ? 1 : 0
   source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_product?ref=v5.1.0"
 
   product_id   = local.apiconfig_testing_support_locals.product_id
@@ -17,8 +18,10 @@ module "apim_apiconfig_testing_support_product" {
 }
 
 resource "azurerm_api_management_product_group" "access_control_developers_for_testing_support" {
-  product_id          = module.apim_apiconfig_testing_support_product.product_id
+  count               = var.env_short != "p" ? 1 : 0
+  product_id          = module.apim_apiconfig_testing_support_product[0].product_id
   group_name          = data.azurerm_api_management_group.group_developers.name
   api_management_name = local.pagopa_apim_name
   resource_group_name = local.pagopa_apim_rg
 }
+

--- a/src/domains/apiconfig-app/99_locals.tf
+++ b/src/domains/apiconfig-app/99_locals.tf
@@ -95,6 +95,16 @@ locals {
 
     pagopa_tenant_id = data.azurerm_client_config.current.tenant_id
   }
+
+  apiconfig_testing_support_locals = {
+    product_id            = "apiconfig-testing-support"
+    display_name          = "API Config Testing Support"
+    description           = "APIs for testing flow on ApiConfig and Nodo"
+    subscription_required = true
+    subscription_limit    = 1000
+
+    pagopa_tenant_id = data.azurerm_client_config.current.tenant_id
+  }
   apim_x_node_product_id = "apim_for_node"
 
   apiconfig_cache_alert = {

--- a/src/domains/apiconfig-app/README.md
+++ b/src/domains/apiconfig-app/README.md
@@ -30,6 +30,7 @@
 | <a name="module_apim_api_config_product"></a> [apim\_api\_config\_product](#module\_apim\_api\_config\_product) | git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_product | v6.4.1 |
 | <a name="module_apim_apiconfig_cache_product"></a> [apim\_apiconfig\_cache\_product](#module\_apim\_apiconfig\_cache\_product) | git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_product | v6.4.1 |
 | <a name="module_apim_apiconfig_selfcare_integration_product"></a> [apim\_apiconfig\_selfcare\_integration\_product](#module\_apim\_apiconfig\_selfcare\_integration\_product) | git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_product | v5.1.0 |
+| <a name="module_apim_apiconfig_testing_support_product"></a> [apim\_apiconfig\_testing\_support\_product](#module\_apim\_apiconfig\_testing\_support\_product) | git::https://github.com/pagopa/terraform-azurerm-v3.git//api_management_product | v5.1.0 |
 | <a name="module_pod_identity"></a> [pod\_identity](#module\_pod\_identity) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_pod_identity | v4.1.17 |
 | <a name="module_tls_checker"></a> [tls\_checker](#module\_tls\_checker) | git::https://github.com/pagopa/terraform-azurerm-v3.git//tls_checker | v6.2.1 |
 
@@ -49,6 +50,7 @@
 | [azurerm_api_management_group.apiconfig_grp](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_group) | resource |
 | [azurerm_api_management_product_group.access_control_developers_for_cache](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product_group) | resource |
 | [azurerm_api_management_product_group.access_control_developers_for_selfcare_integration](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product_group) | resource |
+| [azurerm_api_management_product_group.access_control_developers_for_testing_support](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product_group) | resource |
 | [azurerm_key_vault_secret.aks_apiserver_url](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.apiconfig_client_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.azure_devops_sa_cacrt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |

--- a/src/domains/apiconfig-app/api_product/apiconfig-testing-support/_base_policy.xml
+++ b/src/domains/apiconfig-app/api_product/apiconfig-testing-support/_base_policy.xml
@@ -1,0 +1,14 @@
+<policies>
+  <inbound>
+    <base />
+  </inbound>
+  <outbound>
+    <base />
+  </outbound>
+  <backend>
+    <base />
+  </backend>
+  <on-error>
+    <base />
+  </on-error>
+</policies>


### PR DESCRIPTION
This PR contains the new definition of an APIM product that will be associated to the APIs defined for the `pagopa-api-config-testing-support` repository.

```
sh terraform.sh apply ENV \
    --target=azurerm_api_management_product_group.access_control_developers_for_testing_support \
    --target=module.apim_apiconfig_testing_support_product
```

### List of changes
 - Added APIM product for API

### Motivation and context
This change is required in order to expose the APIs of the defined service in APIM.

### Type of changes
- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?
- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
