### PR TITLE
feat(openapi): add post sessions

### DIFF
--- a/src/domains/ecommerce-app/api/ecommerce-io/v1/_openapi.json.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-io/v1/_openapi.json.tpl
@@ -32,6 +32,14 @@
         "url": "https://pagopa.atlassian.net/wiki/spaces/I/pages/611745793/-servizio+payment+requests+service",
         "description": "Technical specifications"
       }
+    },
+    {
+      "name": "ecommerce-sessions",
+      "description": "Api's for initiate a payment session",
+      "externalDocs": {
+        "url": "https://TODO",
+        "description": "Technical specifications"
+      }
     }
   ],
   "servers": [
@@ -44,6 +52,52 @@
     "description": "Design review"
   },
   "paths": {
+    "/sessions": {
+      "post": {
+        "summary": "Create a new payment session token",
+        "description": "Api used to create a payment session token from wallet token",
+        "tags": [
+          "ecommerce-sessions"
+        ],
+        "security": [
+          {
+            "walletToken": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "New transaction successfully created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NewSessionTokenResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Generic error during session token creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/payment-requests/{rpt_id}": {
       "get": {
         "summary": "Verify single payment notice",
@@ -52,6 +106,11 @@
           "ecommerce-payment-requests"
         ],
         "operationId": "getPaymentRequestInfo",
+        "security": [
+          {
+            "eCommerceSessionToken": []
+          }
+        ],
         "parameters": [
           {
             "in": "path",
@@ -146,6 +205,11 @@
         "operationId": "newTransaction",
         "summary": "Make a new transaction",
         "description": "Create a new transaction activating the payments notice by meaning of 'Nodo' ActivatePaymentNotice primitive",
+        "security": [
+          {
+            "eCommerceSessionToken": []
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -156,17 +220,6 @@
           },
           "required": true
         },
-        "parameters": [
-          {
-            "in": "query",
-            "name": "recaptchaResponse",
-            "description": "Recaptcha response",
-            "schema": {
-              "type": "string"
-            },
-            "required": true
-          }
-        ],
         "responses": {
           "200": {
             "description": "New transaction successfully created",
@@ -260,7 +313,7 @@
         ],
         "security": [
           {
-            "eCommerceToken": []
+            "eCommerceSessionToken": []
           }
         ],
         "summary": "Get transaction information",
@@ -329,7 +382,7 @@
         ],
         "security": [
           {
-            "eCommerceToken": []
+            "eCommerceSessionToken": []
           }
         ],
         "summary": "Performs the transaction cancellation",
@@ -404,7 +457,7 @@
         ],
         "security": [
           {
-            "eCommerceToken": []
+            "eCommerceSessionToken": []
           }
         ],
         "requestBody": {
@@ -522,7 +575,7 @@
         ],
         "security": [
           {
-            "eCommerceToken": []
+            "eCommerceSessionToken": []
           }
         ],
         "requestBody": {
@@ -1524,6 +1577,20 @@
           "DISABLED",
           "INCOMING"
         ]
+      },
+      "NewSessionTokenResponse": {
+        "type": "object",
+        "title": "NewSessionTokenResponse",
+        "description": "New session token response body",
+        "properties": {
+          "sessionToken": {
+            "description": "Session token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "sessionToken"
+        ]
       }
     },
     "requestBodies": {
@@ -1579,11 +1646,15 @@
       }
     },
     "securitySchemes": {
-      "eCommerceToken": {
+      "eCommerceSessionToken": {
         "type": "http",
         "scheme": "bearer",
-        "bearerFormat": "JWT",
-        "description": "JWT token received into POST transaction response body (authToken field) "
+        "description": "JWT session token taken from /sessions response body"
+      },
+      "walletToken": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Wallet token associated to the user"
       }
     }
   }

--- a/src/domains/ecommerce-app/api/ecommerce-io/v1/_openapi.json.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-io/v1/_openapi.json.tpl
@@ -56,6 +56,7 @@
       "post": {
         "summary": "Create a new payment session token",
         "description": "Api used to create a payment session token from wallet token",
+        "operationId": "newSessionToken",
         "tags": [
           "ecommerce-sessions"
         ],
@@ -1161,9 +1162,6 @@
               "CHECKOUT_CART",
               "UNKNOWN"
             ]
-          },
-          "authToken": {
-            "type": "string"
           },
           "idCart": {
             "description": "Cart identifier provided by creditor institution",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Modified eCommerce for IO opeapi:

- Add `POST /sessions` api to generate session token to be used to perform all other calls
- Add Authorization Bearer session token protection for all other api

<!--- Describe your changes in detail -->

### Motivation and context
Modified eCommerce for IO opeapi:

- Add `POST /sessions` api to generate session token to be used to perform all other calls
- Add Authorization Bearer session token protection for all other api
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
