### PR TITLE
CHK-2072 fix: aca openapi fields max size

### DIFF
--- a/src/domains/aca-app/api/aca/v1/_openapi.json.tpl
+++ b/src/domains/aca-app/api/aca/v1/_openapi.json.tpl
@@ -230,8 +230,7 @@
           },
           "entityFiscalCode": {
             "type": "string",
-            "minLength": 16,
-            "maxLength": 16
+            "minLength": 2
           },
           "entityFullName": {
             "type": "string",
@@ -261,7 +260,7 @@
         "description": "Amount for payments, in euro cents",
         "type": "integer",
         "minimum": 0,
-        "maximum": 99999999
+        "maximum": 99999999999
       },
       "ProblemJson": {
         "type": "object",

--- a/src/domains/aca-app/api/aca/v1/_openapi.json.tpl
+++ b/src/domains/aca-app/api/aca/v1/_openapi.json.tpl
@@ -257,7 +257,7 @@
         }
       },
       "AmountEuroCents": {
-        "description": "Amount for payments, in eurocents",
+        "description": "Amount for payments, in euro cents",
         "type": "integer",
         "minimum": 0,
         "maximum": 99999999999

--- a/src/domains/aca-app/api/aca/v1/_openapi.json.tpl
+++ b/src/domains/aca-app/api/aca/v1/_openapi.json.tpl
@@ -257,7 +257,7 @@
         }
       },
       "AmountEuroCents": {
-        "description": "Amount for payments, in euro cents",
+        "description": "Amount for payments, in eurocents",
         "type": "integer",
         "minimum": 0,
         "maximum": 99999999999


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Fix ACA openapi, modified fields maxSize for entityFiscalCode and AmountEuroCents
<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
