### PR TITLE
fix: [CHK-2090] get transaction policy payment token

### DIFF
--- a/src/domains/ecommerce-app/api/ecommerce-io/v1/get_transaction.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-io/v1/get_transaction.xml.tpl
@@ -26,6 +26,8 @@
         </send-request>
         <set-variable name="pagopaProxyCcpResponseHttpResponseCode" value="@((int)((IResponse)context.Variables["pagopaProxyCcpResponse"]).StatusCode)" />
         <set-variable name="pagopaProxyResponseBody" value="@(((IResponse)context.Variables["pagopaProxyCcpResponse"]).Body.As<JObject>())" />
+        <cache-lookup-value key="@($"ecommerce:{context.Variables["requestTransactionId"]}-rptId")" variable-name="cacheRptId" caching-type="internal" /> 
+        <cache-lookup-value key="@($"ecommerce:{context.Variables["requestTransactionId"]}-amount")" variable-name="cacheAmount" caching-type="internal" /> 
         <choose>
             <when condition="@((int)context.Variables["pagopaProxyCcpResponseHttpResponseCode"] == 200)">
                 <send-request ignore-error="true" timeout="10" response-variable-name="pmActionsCheckResponse">
@@ -42,8 +44,8 @@
                         eCommerceResponseBody["status"] = "ACTIVATED";
                         eCommerceResponseBody["clientId"] = "IO";
                         JObject payment = new JObject();
-                        //payment["rptId"] = "TODO";
-                        //payment["amount"] = 0;
+                        payment["rptId"] = (string) context.Variables["cacheRptId"];
+                        payment["amount"] = (int) context.Variables["cacheAmount"];
                         payment["paymentToken"] = (string) ((JObject) context.Variables["pagopaProxyResponseBody"])["idPagamento"];
                         JArray payments = new JArray();
                         payments.Add(payment);

--- a/src/domains/ecommerce-app/api/ecommerce-io/v1/get_transaction.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-io/v1/get_transaction.xml.tpl
@@ -24,20 +24,53 @@
                 <value>CLIENT_IO</value>
             </set-header>
         </send-request>
+        <set-variable name="pagopaProxyCcpResponseHttpResponseCode" value="@((int)((IResponse)context.Variables["pagopaProxyCcpResponse"]).StatusCode)" />
+        <set-variable name="pagopaProxyResponseBody" value="@(((IResponse)context.Variables["pagopaProxyCcpResponse"]).Body.As<JObject>())" />
         <choose>
-            <when condition="@(((int)((IResponse)context.Variables["pagopaProxyCcpResponse"]).StatusCode) == 200)">
-                <set-variable name="eCommerceStatus" value="ACTIVATED" />
+            <when condition="@((int)context.Variables["pagopaProxyCcpResponseHttpResponseCode"] == 200)">
                 <send-request ignore-error="true" timeout="10" response-variable-name="pmActionsCheckResponse">
-                    <set-url>@("{{pm-host}}/pp-restapi-CD/v1/payments/" + ((IResponse)context.Variables["pagopaProxyCcpResponse"]).Body.As
-                        <JObject>()["idPagamento"] + "/actions/check")</set-url>
+                    <set-url>@("{{pm-host}}/pp-restapi-CD/v1/payments/" + ((JObject)context.Variables["pagopaProxyResponseBody"])["idPagamento"] + "/actions/check")</set-url>
                     <set-method>GET</set-method>
                 </send-request>
+                <return-response>
+                    <set-header name="Content-Type" exists-action="override">
+                            <value>application/json</value>
+                    </set-header>
+                    <set-body>@{
+                        JObject eCommerceResponseBody = new JObject();
+                        eCommerceResponseBody["transactionId"] = (string) context.Variables["requestTransactionId"];
+                        eCommerceResponseBody["status"] = "ACTIVATED";
+                        eCommerceResponseBody["clientId"] = "IO";
+                        JObject payment = new JObject();
+                        //payment["rptId"] = "TODO";
+                        //payment["amount"] = 0;
+                        payment["paymentToken"] = (string) ((JObject) context.Variables["pagopaProxyResponseBody"])["idPagamento"];
+                        JArray payments = new JArray();
+                        payments.Add(payment);
+                        eCommerceResponseBody["payments"] = payments;
+                        return eCommerceResponseBody.ToString();
+                        }
+                    </set-body>
+                </return-response>
             </when>
-            <when condition="@(((int)((IResponse)context.Variables["pagopaProxyCcpResponse"]).StatusCode) == 404)">
-                <set-variable name="eCommerceStatus" value="ACTIVATION_REQUESTED" />
+            <when condition="@((int)context.Variables["pagopaProxyCcpResponseHttpResponseCode"] == 404)">
+                <return-response>
+                    <set-header name="Content-Type" exists-action="override">
+                            <value>application/json</value>
+                        </set-header>
+                    <set-body>@{
+                        JObject eCommerceResponseBody = new JObject();
+                        eCommerceResponseBody["transactionId"] = (string) context.Variables["requestTransactionId"];
+                        eCommerceResponseBody["status"] = "ACTIVATION_REQUESTED";
+                        eCommerceResponseBody["payments"] = new JArray();
+                        eCommerceResponseBody["clientId"] = "IO";
+                        return eCommerceResponseBody.ToString();
+                        }
+                    </set-body>
+                </return-response>
             </when>
             <otherwise>
-                <return-response response-variable-name="existing context variable">
+                <return-response>
                     <set-status code="404" reason="Not found" />
                     <set-header name="Content-Type" exists-action="override">
                         <value>application/json</value>
@@ -55,20 +88,6 @@
 
     <outbound>
         <base />
-
-        <set-status code="200" reason="OK" />
-        <set-body>
-            @{
-                JObject eCommerceResponseBody = new JObject();
-                eCommerceResponseBody["transactionId"] = (string) context.Variables["requestTransactionId"];
-                eCommerceResponseBody["status"] = (string) context.Variables["eCommerceStatus"];
-                eCommerceResponseBody["payments"] = new JArray();
-                eCommerceResponseBody["clientId"] = "IO";
-
-                return eCommerceResponseBody.ToString();
-            }
-        </set-body>
-
     </outbound>
 
     <backend>

--- a/src/domains/ecommerce-app/api/ecommerce-io/v1/get_transaction.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-io/v1/get_transaction.xml.tpl
@@ -65,7 +65,12 @@
                         eCommerceResponseBody["transactionId"] = (string) context.Variables["requestTransactionId"];
                         eCommerceResponseBody["status"] = "ACTIVATION_REQUESTED";
                         eCommerceResponseBody["payments"] = new JArray();
-                        eCommerceResponseBody["clientId"] = "IO";
+                        JObject payment = new JObject();
+                        payment["rptId"] = (string) context.Variables["cacheRptId"];
+                        payment["amount"] = (int) context.Variables["cacheAmount"];
+                        JArray payments = new JArray();
+                        payments.Add(payment);
+                        eCommerceResponseBody["payments"] = payments;
                         return eCommerceResponseBody.ToString();
                         }
                     </set-body>

--- a/src/domains/ecommerce-app/api/ecommerce-io/v1/post_transactions.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-io/v1/post_transactions.xml.tpl
@@ -7,7 +7,6 @@
         <set-variable name="body" value="@(context.Request.Body.As<JObject>(preserveContent: true))" />
         <set-variable name="rptId" value="@(((JObject) context.Variables["body"])["paymentNotices"][0]["rptId"].ToObject<string>())" />
         <set-variable name="amount" value="@(((JObject) context.Variables["body"])["paymentNotices"][0]["amount"].Value<int>())" />
-
         <choose>
             <when condition="@(!context.Request.Headers.ContainsKey("Authorization"))">
                 <return-response>
@@ -48,6 +47,8 @@
             </when>
         </choose>
         <set-variable name="ccp" value="@(Guid.NewGuid().ToString("N"))" />
+        <cache-store-value key="@($"ecommerce:{context.Variables["ccp"]}-rptId")"  value="@(((string) context.Variables["rptId"]))" duration="900" caching-type="internal" />
+        <cache-store-value key="@($"ecommerce:{context.Variables["ccp"]}-amount")" value="@(((int) context.Variables["amount"]))" duration="900" caching-type="internal" /> 
         <set-body>
           @{
             JObject pagopaProxyBody = new JObject();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

1. Save transaction `rptId`and `amount` into internal Redis cache during POST `transaction` policy execution
2. Retrieve `rptId`and `amount` from Redis cache during GET `transaction` used to populate response body
3. Add payment token into payments.payment returned object for taken from proxy `idPagamento` response field

<!--- Describe your changes in detail -->

### Motivation and context
Payment token is used for populate fees call.
Rpt id and amount are required fields and here have been added in order to correctly populate response body
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
