### PR TITLE
[CHK-2168] Add 401 to webview api response codes

### DIFF
--- a/src/domains/wallet-app/api/webview-payment-wallet/v1/_openapi.json.tpl
+++ b/src/domains/wallet-app/api/webview-payment-wallet/v1/_openapi.json.tpl
@@ -67,6 +67,16 @@
               }
             }
           },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Wallet not found",
             "content": {
@@ -149,6 +159,16 @@
           },
           "400": {
             "description": "Invalid input id",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/domains/wallet-app/api/webview-payment-wallet/v1/_openapi.json.tpl
+++ b/src/domains/wallet-app/api/webview-payment-wallet/v1/_openapi.json.tpl
@@ -234,6 +234,16 @@
               }
             }
           },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Wallet not found",
             "content": {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Add 401 as possible response codes to:

- `/wallets/{walletId}/sessions/{orderId}/validations`
- `/wallets/{walletId}/sessions`
- `/wallets/{walletId}/outcomes`

The base policy returns 401 if jwt validation fails.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
