### PR TITLE
[CHK-2228] feat: redefine npg notification url

### DIFF
--- a/src/domains/ecommerce-app/04_apim_ecommerce_npg_notification.tf
+++ b/src/domains/ecommerce-app/04_apim_ecommerce_npg_notification.tf
@@ -65,3 +65,17 @@ resource "azurerm_api_management_api_operation_policy" "npg_notifications_policy
     hostname = var.env_short == "p" ? "disabled" : local.ecommerce_hostname
   })
 }
+
+data "azurerm_key_vault_secret" "ecommerce_sessions_jwt_secret" {
+  name         = "sessions-jwt-secret"
+  key_vault_id = data.azurerm_key_vault.kv.id
+}
+
+resource "azurerm_api_management_named_value" "ecommerce_jwt_signing_key" {
+  name                = "ecommerce-jwt-signing-key"
+  api_management_name = local.pagopa_apim_name
+  resource_group_name = local.pagopa_apim_rg
+  display_name        = "ecommerce-jwt-signing-key"
+  value               = data.azurerm_key_vault_secret.ecommerce_sessions_jwt_secret.value
+  secret              = true
+}

--- a/src/domains/ecommerce-app/04_apim_ecommerce_npg_notification.tf
+++ b/src/domains/ecommerce-app/04_apim_ecommerce_npg_notification.tf
@@ -66,16 +66,16 @@ resource "azurerm_api_management_api_operation_policy" "npg_notifications_policy
   })
 }
 
-data "azurerm_key_vault_secret" "ecommerce_sessions_jwt_secret" {
-  name         = "sessions-jwt-secret"
+data "azurerm_key_vault_secret" "npg_notification_jwt_secret" {
+  name         = "npg-notification-signing-key"
   key_vault_id = data.azurerm_key_vault.kv.id
 }
 
-resource "azurerm_api_management_named_value" "ecommerce_jwt_signing_key" {
-  name                = "ecommerce-jwt-signing-key"
+resource "azurerm_api_management_named_value" "npg_notification_jwt_secret" {
+  name                = "npg-notification-jwt-secret"
   api_management_name = local.pagopa_apim_name
   resource_group_name = local.pagopa_apim_rg
-  display_name        = "ecommerce-jwt-signing-key"
-  value               = data.azurerm_key_vault_secret.ecommerce_sessions_jwt_secret.value
+  display_name        = "npg-notification-jwt-secret"
+  value               = data.azurerm_key_vault_secret.npg_notification_jwt_secret.value
   secret              = true
 }

--- a/src/domains/ecommerce-app/README.md
+++ b/src/domains/ecommerce-app/README.md
@@ -87,6 +87,7 @@
 | [azurerm_api_management_named_value.ecommerce-personal-data-vault-api-key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
 | [azurerm_api_management_named_value.ecommerce_checkout_transaction_jwt_signing_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
 | [azurerm_api_management_named_value.ecommerce_io_transaction_jwt_signing_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
+| [azurerm_api_management_named_value.ecommerce_jwt_signing_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
 | [azurerm_api_management_product_api.apim_ecommerce_gec_mock_product_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product_api) | resource |
 | [azurerm_api_management_product_api.apim_ecommerce_nodo_mock_product_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product_api) | resource |
 | [azurerm_api_management_product_api.apim_ecommerce_nodo_per_pm_mock_product_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product_api) | resource |
@@ -114,6 +115,7 @@
 | [azurerm_key_vault_secret.ecommerce_checkout_sessions_jwt_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.ecommerce_io_jwt_signing_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.ecommerce_io_sessions_jwt_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.ecommerce_sessions_jwt_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.personal_data_vault_api_key_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_kubernetes_cluster.aks](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/kubernetes_cluster) | data source |
 | [azurerm_log_analytics_workspace.log_analytics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |

--- a/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
@@ -3,7 +3,7 @@
         <base />
         <!-- start validation policy -->
         <set-variable name="orderId" value="@(context.Request.MatchedParameters["orderId"])" />
-        <validate-jwt query-param-name="sessionToken" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized" require-expiration-time="true" require-signed-tokens="true" output-token-variable-name="jwtToken">
+        <validate-jwt query-parameter-name="sessionToken" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized" require-expiration-time="true" require-signed-tokens="true" output-token-variable-name="jwtToken">
         <issuer-signing-keys>
             <key>{{npg-notification-jwt-secret}}</key>
         </issuer-signing-keys>

--- a/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
@@ -1,11 +1,43 @@
 <policies>
     <inbound>
         <base />
-        <!-- start policy variables -->
+        <!-- start validation policy -->
+        <set-variable name="orderId" value="@(context.Request.MatchedParameters["orderId"])" />
+        <validate-jwt query-param-name="sessionToken" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized" require-expiration-time="true" require-signed-tokens="true" output-token-variable-name="jwtToken">
+        <issuer-signing-keys>
+            <key>{{ecommerce-jwt-signing-key}}</key>
+        </issuer-signing-keys>
+        <required-claims>
+          <claim name="orderId" match="all">
+            <value>@((string)context.Variables.GetValueOrDefault("orderId",""))</value>
+          </claim>
+       </required-claims>
+      </validate-jwt>
+      <!-- end validation policy -->
+      <!-- start policy variables -->
+      <set-variable name="transactionId" value="@{
+            var jwt = (Jwt)context.Variables["jwtToken"];
+            if(jwt.Claims.ContainsKey("transactionId")){
+                return jwt.Claims["transactionId"][0];
+            }
+            return "";
+        }" />
+        <set-variable name="paymentMethodId" value="@{
+            var jwt = (Jwt)context.Variables["jwtToken"];
+            if(jwt.Claims.ContainsKey("paymentMethodId")){
+                return jwt.Claims["paymentMethodId"][0];
+            }
+            return "";
+        }" />
+        <choose>
+            <when condition="@((string)context.Variables["transactionId"] == "" && (string)context.Variables["paymentMethodId"] == "")">
+                <return-response>
+                    <set-status code="500" reason="Mandatory data missing" />
+                </return-response>
+            </when>
+        </choose>
         <set-variable name="paymentMethodBackendUri" value="https://${hostname}/pagopa-ecommerce-payment-methods-service" />
         <set-variable name="transactionServiceBackendUri" value="https://${hostname}/pagopa-ecommerce-transactions-service" />
-        <set-variable name="orderId" value="@(context.Request.MatchedParameters["orderId"])" />
-        <set-variable name="paymentMethodId" value="@(context.Request.Url.Query.GetValueOrDefault("paymentMethodId",""))" />
         <set-variable name="npgNotificationRequestBody" value="@((JObject)context.Request.Body.As<JObject>(true))" />
         <!-- end policy variables -->
         <!-- start request validation
@@ -14,27 +46,31 @@
         </validate-content>
          end request validation -->
         <!-- payment method verify session -->
-        <send-request mode="new" response-variable-name="paymentMethodSessionVerificationResponse" timeout="10" ignore-error="true">
-            <set-url>@(String.Format((string)context.Variables["paymentMethodBackendUri"]+"/payment-methods/{0}/sessions/{1}/transactionId", (string)context.Variables["paymentMethodId"], (string)context.Variables["orderId"]))</set-url>
-            <set-method>GET</set-method>
-            <set-header name="Content-Type" exists-action="override">
-                <value>application/json</value>
-            </set-header>
-            <set-header name="Authorization" exists-action="override">
-                <value> @{
-                        JObject requestBody = (JObject)context.Variables["npgNotificationRequestBody"];
-                        return "Bearer " + (string)requestBody["securityToken"];
-                    }</value>
-            </set-header>
-        </send-request>
         <choose>
-            <when condition="@(((int)((IResponse)context.Variables["paymentMethodSessionVerificationResponse"]).StatusCode) != 200)">
-                <return-response>
-                    <set-status code="500" reason="Error retrieving session" />
-                </return-response>
+            <when condition="@((string)context.Variables["transactionId"] == "")">
+                <send-request mode="new" response-variable-name="paymentMethodSessionVerificationResponse" timeout="10" ignore-error="true">
+                    <set-url>@(String.Format((string)context.Variables["paymentMethodBackendUri"]+"/payment-methods/{0}/sessions/{1}/transactionId", (string)context.Variables["paymentMethodId"], (string)context.Variables["orderId"]))</set-url>
+                    <set-method>GET</set-method>
+                    <set-header name="Content-Type" exists-action="override">
+                        <value>application/json</value>
+                    </set-header>
+                    <set-header name="Authorization" exists-action="override">
+                        <value> @{
+                                JObject requestBody = (JObject)context.Variables["npgNotificationRequestBody"];
+                                return "Bearer " + (string)requestBody["securityToken"];
+                            }</value>
+                    </set-header>
+                </send-request>
+                <choose>
+                    <when condition="@(((int)((IResponse)context.Variables["paymentMethodSessionVerificationResponse"]).StatusCode) != 200)">
+                        <return-response>
+                            <set-status code="500" reason="Error retrieving session" />
+                        </return-response>
+                    </when>
+                </choose>
+                <set-variable name="transactionId" value="@(((string)((IResponse)context.Variables["paymentMethodSessionVerificationResponse"]).Body.As<JObject>(preserveContent: true)["transactionId"]))" />
             </when>
         </choose>
-        <set-variable name="transactionId" value="@(((string)((IResponse)context.Variables["paymentMethodSessionVerificationResponse"]).Body.As<JObject>(preserveContent: true)["transactionId"]))" />
         <!-- end payment method verify session -->
         <!-- send transactions service PATCH request -->
         <send-request mode="new" response-variable-name="transactionServiceAuthorizationPatchResponse" timeout="10" ignore-error="true">

--- a/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
@@ -5,7 +5,7 @@
         <set-variable name="orderId" value="@(context.Request.MatchedParameters["orderId"])" />
         <validate-jwt query-param-name="sessionToken" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized" require-expiration-time="true" require-signed-tokens="true" output-token-variable-name="jwtToken">
         <issuer-signing-keys>
-            <key>{{ecommerce-jwt-signing-key}}</key>
+            <key>{{npg-notification-jwt-secret}}</key>
         </issuer-signing-keys>
         <required-claims>
           <claim name="orderId" match="all">

--- a/src/domains/ecommerce-app/api/npg-notification/_openapi.json.tpl
+++ b/src/domains/ecommerce-app/api/npg-notification/_openapi.json.tpl
@@ -25,12 +25,12 @@
           },
           {
             "in": "query",
-            "name": "paymentMethodId",
+            "name": "sessionToken",
             "schema": {
               "type": "string"
             },
             "required": true,
-            "description": "Payment method ID used for transaction"
+            "description": "Session token used to validate path params"
           }
         ],
         "requestBody": {

--- a/src/domains/ecommerce-common/02_security.tf
+++ b/src/domains/ecommerce-common/02_security.tf
@@ -447,3 +447,16 @@ resource "azurerm_key_vault_secret" "wallet-api-key" {
     ]
   }
 }
+
+
+resource "azurerm_key_vault_secret" "npg_notification_signing_key" {
+  name         = "npg-notification-signing-key"
+  value        = "<TO UPDATE MANUALLY ON PORTAL>"
+  key_vault_id = module.key_vault.id
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}

--- a/src/domains/ecommerce-common/README.md
+++ b/src/domains/ecommerce-common/README.md
@@ -52,6 +52,7 @@
 | [azurerm_key_vault_secret.notifications_service_api_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.npg_api_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.npg_cards_psp_keys](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.npg_notification_signing_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.payment_method_api_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.payment_transactions_gateway_api_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.personal-data-vault-api-key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |


### PR DESCRIPTION
Edit npg notification url spec and policy

### List of changes

- Npg notification url (for all ecommerce transactions) now has `sessionToken` queryParam.
- Added policy jwt validation on sessionToken value.
- Match `orderId` value and get value about `transactionId` and `paymentMethodId`

### Motivation and context

Secure npg notification url
Make it compliant with logged user payment transaction

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
