### PR TITLE
feat: added Selfcare Backoffice (BE and FE) for version info

### DIFF
--- a/src/domains/shared-app/04_apim_statuspage.tf
+++ b/src/domains/shared-app/04_apim_statuspage.tf
@@ -1,3 +1,13 @@
+data "azurerm_storage_account" "pagopa_selfcare_fe_sa" {
+  name                = replace("${var.prefix}-${var.env_short}-selfcare-sa", "-", "")
+  resource_group_name = format("%s-%s-fe-rg", var.prefix, var.env_short)
+}
+
+data "azurerm_storage_account" "pagopa_apiconfig_fe_sa" {
+  name                = replace("${var.prefix}-${var.env_short}-${var.location_short}-apiconfig-sa", "-", "")
+  resource_group_name = format("%s-%s-api-config-rg", var.prefix, var.env_short)
+}
+
 ##############
 ## Products ##
 ##############
@@ -32,8 +42,8 @@ locals {
     service_url           = null
   }
   aks_path           = var.env == "prod" ? "weuprod.%s.internal.platform.pagopa.it" : "weu${var.env}.%s.internal.${var.env}.platform.pagopa.it"
-  fe_backoffice_path = "pagopa${var.env_short}selfcaresa.z6.web.core.windows.net/ui/version.json"
-  fe_apiconfig_path  = "pagopa${var.env_short}apiconfigfesa.z6.web.core.windows.net/ui/version.json"
+  fe_backoffice_path = replace(format("%s/ui/version.json", data.azurerm_storage_account.pagopa_selfcare_fe_sa.primary_web_host), "/{2}", "/")
+  fe_apiconfig_path  = replace(format("%s/ui/version.json", data.azurerm_storage_account.pagopa_apiconfig_fe_sa.primary_web_host), "/{2}", "/")
 }
 
 resource "azurerm_api_management_api_version_set" "api_statuspage_api" {

--- a/src/domains/shared-app/04_apim_statuspage.tf
+++ b/src/domains/shared-app/04_apim_statuspage.tf
@@ -31,7 +31,9 @@ locals {
     subscription_required = false
     service_url           = null
   }
-  aks_path = var.env == "prod" ? "weuprod.%s.internal.platform.pagopa.it" : "weu${var.env}.%s.internal.${var.env}.platform.pagopa.it"
+  aks_path           = var.env == "prod" ? "weuprod.%s.internal.platform.pagopa.it" : "weu${var.env}.%s.internal.${var.env}.platform.pagopa.it"
+  fe_backoffice_path = "pagopa${var.env_short}selfcaresa.z6.web.core.windows.net/ui/version.json"
+  fe_apiconfig_path  = "pagopa${var.env_short}apiconfigfesa.z6.web.core.windows.net/ui/version.json"
 }
 
 resource "azurerm_api_management_api_version_set" "api_statuspage_api" {
@@ -108,6 +110,7 @@ module "apim_api_statuspage_api_v1" {
       "afmmarketplace"        = format("%s/pagopa-afm-marketplace-service", format(local.aks_path, "afm"))
       "afmutils"              = format("%s/pagopa-afm-utils-service", format(local.aks_path, "afm"))
       "apiconfig"             = format("%s/pagopa-api-config-core-service/o", format(local.aks_path, "apiconfig"))
+      "apiconfig-fe"          = format("%s", local.fe_apiconfig_path)
       "apiconfigcacheo"       = format("%s/api-config-cache/o", format(local.aks_path, "apiconfig"))
       "apiconfigcachep"       = format("%s/api-config-cache/p", format(local.aks_path, "apiconfig"))
       "apiconfigselfcare"     = format("%s/pagopa-api-config-selfcare-integration", format(local.aks_path, "apiconfig"))
@@ -116,6 +119,8 @@ module "apim_api_statuspage_api_v1" {
       "bizevents"             = format("%s/pagopa-biz-events-service", format(local.aks_path, "bizevents"))
       "bizeventsdatastoreneg" = format("%s/pagopa-negative-biz-events-datastore-service", format(local.aks_path, "bizevents"))
       "bizeventsdatastorepos" = format("%s/pagopa-biz-events-datastore-service", format(local.aks_path, "bizevents"))
+      "backofficepagopa"      = format("%s/selfcare/pagopa/v1", format(local.aks_path, "selfcare"))
+      "backofficepagopa-fe"   = format("%s", local.fe_backoffice_path)
       "canoneunico"           = format("%s/", data.azurerm_function_app.canone_unico.default_hostname)
       "fdrndpnew"             = format("%s/pagopa-fdr-service", format(local.aks_path, "fdr"))
       "gpd"                   = format("%s/pagopa-gpd-core", format(local.aks_path, "gps"))

--- a/src/domains/shared-app/README.md
+++ b/src/domains/shared-app/README.md
@@ -131,6 +131,8 @@
 | [azurerm_resource_group.monitor_rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.shared_rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.taxonomy_rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/data-sources/resource_group) | data source |
+| [azurerm_storage_account.pagopa_apiconfig_fe_sa](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/data-sources/storage_account) | data source |
+| [azurerm_storage_account.pagopa_selfcare_fe_sa](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.taxonomy_storage_account](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/data-sources/storage_account) | data source |
 | [azurerm_subnet.apim_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/data-sources/subnet) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.40.0/docs/data-sources/subscription) | data source |

--- a/src/domains/shared-app/api/status-page-service/v1/_base_policy.xml
+++ b/src/domains/shared-app/api/status-page-service/v1/_base_policy.xml
@@ -29,11 +29,17 @@
                       return (string)services[context.Variables["product"]];
                   }" />
           <choose>
-            <when condition="@(context.Variables["baseUrl"] != null)">
-            <set-backend-service base-url="@{
-                          var services = JObject.Parse((string)context.Variables["services"]);
-                          return "https://" + (string)services[context.Variables["product"]];
-            }" />
+            <when condition="@(context.Variables["baseUrl"] != null && ((string)context.Variables["product"]).EndsWith("-fe"))">
+              <set-backend-service base-url="@{
+                                var services = JObject.Parse((string)context.Variables["services"]);
+                                return "https://" + (string)services[context.Variables["product"]] + "?";
+              }" />
+            </when>
+            <when condition="@(context.Variables["baseUrl"] != null && !((string)context.Variables["product"]).EndsWith("-fe"))">
+              <set-backend-service base-url="@{
+                                var services = JObject.Parse((string)context.Variables["services"]);
+                                return "https://" + (string)services[context.Variables["product"]];
+              }" />
             </when>
             <otherwise>
               <return-response>


### PR DESCRIPTION
This PR contains the changes applied on pagoPA's Status Page in order to add the info status for SelfCare Backoffice frontend and backend application.
Also, a new procedure for getting the version info for APIConfig frontend application was added and will be integrated as soon as possible from this repository.

### List of changes
 - Added version info for Selfcare Backoffice backend
 - Added version info for Selfcare Backoffice frontend
 - Added version info for APIConfig frontend

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes
- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
