### PR TITLE
feat: Add v2 for bulk API [GPD]

### DIFF
--- a/src/domains/gps-app/04_apim_gpd_core.tf
+++ b/src/domains/gps-app/04_apim_gpd_core.tf
@@ -48,6 +48,31 @@ module "apim_api_gpd_api" {
   xml_content = file("./api/gpd_api/v1/_base_policy.xml")
 }
 
+module "apim_api_gpd_api_v2" {
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3//api_management_api?ref=v6.11.2"
+
+  name                  = format("%s-api-gpd-api", var.env_short)
+  api_management_name   = local.pagopa_apim_name
+  resource_group_name   = local.pagopa_apim_rg
+  product_ids           = [module.apim_gpd_product.product_id]
+  subscription_required = false
+  api_version           = "v2"
+  version_set_id        = azurerm_api_management_api_version_set.api_gpd_api.id
+  service_url           = local.gpd_core_service_url
+
+  description  = "Api Gestione Posizione Debitorie"
+  display_name = "GPD pagoPA"
+  path         = "gpd/api"
+  protocols    = ["https"]
+
+  content_format = "openapi"
+  content_value = templatefile("./api/gpd_api/v2/_openapi.json.tpl", {
+    host = local.apim_hostname
+  })
+
+  xml_content = file("./api/gpd_api/v2/_base_policy.xml")
+}
+
 resource "azurerm_api_management_api_version_set" "api_gpd_api" {
   name                = format("%s-api-gpd-api", var.env_short)
   api_management_name = local.pagopa_apim_name

--- a/src/domains/gps-app/api/gpd_api/v2/_base_policy.xml
+++ b/src/domains/gps-app/api/gpd_api/v2/_base_policy.xml
@@ -1,0 +1,20 @@
+<policies>
+  <inbound>
+    <set-variable name="requestPath" value="@(context.Request.Url.Path)" />
+    <set-variable name="debtpositionsRequestPath" value="@("/pagopa-gpd-core/organizations/" + (string)context.Request.MatchedParameters["organizationfiscalcode"] + "/debtpositions")" />
+    <choose>
+        <when condition="@(((string)context.Variables["requestPath"]).Equals((string)context.Variables["debtpositionsRequestPath"]) && ((string)context.Request.Method).Equals("POST"))">
+            <rewrite-uri template="@("/organizations/" + (string)context.Request.MatchedParameters["organizationfiscalcode"] + "/debtpositions/bulk")" copy-unmatched-params="true" />
+        </when>
+    </choose>
+  </inbound>
+  <outbound>
+    <base />
+  </outbound>
+  <backend>
+    <base />
+  </backend>
+  <on-error>
+    <base />
+  </on-error>
+</policies>

--- a/src/domains/gps-app/api/gpd_api/v2/_openapi.json.tpl
+++ b/src/domains/gps-app/api/gpd_api/v2/_openapi.json.tpl
@@ -1,0 +1,519 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "PagoPA API Debt Position",
+    "description" : "Progetto Gestione Posizioni Debitorie",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.10.0"
+  },
+  "servers" : [ {
+    "url" : "${host}",
+    "description" : "Generated server url"
+  } ],
+  "tags" : [ {
+    "name" : "Debt Positions API"
+  } ],
+  "paths" : {
+    "/organizations/{organizationfiscalcode}/debtpositions" : {
+      "post" : {
+        "tags" : [ "Debt Positions API" ],
+        "summary" : "The Organization creates multiple debt positions.",
+        "operationId" : "createMultiplePositions",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "Organization fiscal code, the fiscal code of the Organization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "toPublish",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/MultiplePaymentPositionModel"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Malformed request.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "201" : {
+            "description" : "Request created.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict: duplicate debt position found.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
+      },
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    },
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "401" : {
+            "description" : "Wrong or missing function key.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          },
+          "200" : {
+            "description" : "OK.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Service unavailable.",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            },
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        }, {
+          "Authorization" : [ ]
+        } ]
+      },
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
+        }
+      } ]
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "MultiplePaymentPositionModel" : {
+        "required" : [ "paymentPositions" ],
+        "type" : "object",
+        "properties" : {
+          "paymentPositions" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentPositionModel"
+            }
+          }
+        }
+      },
+      "PaymentOptionMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        },
+        "description" : "it can added a maximum of 10 key-value pairs for metadata"
+      },
+      "PaymentOptionModel" : {
+        "required" : [ "amount", "dueDate", "isPartialPayment", "iuv" ],
+        "type" : "object",
+        "properties" : {
+          "nav" : {
+            "type" : "string",
+            "readOnly" : true
+          },
+          "iuv" : {
+            "type" : "string"
+          },
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "isPartialPayment" : {
+            "type" : "boolean"
+          },
+          "dueDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "retentionDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "fee" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "notificationFee" : {
+            "type" : "integer",
+            "format" : "int64",
+            "readOnly" : true
+          },
+          "transfer" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferModel"
+            }
+          },
+          "paymentOptionMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionMetadataModel"
+            }
+          }
+        }
+      },
+      "PaymentPositionModel" : {
+        "required" : [ "companyName", "fiscalCode", "fullName", "iupd", "type" ],
+        "type" : "object",
+        "properties" : {
+          "iupd" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "F", "G" ]
+          },
+          "fiscalCode" : {
+            "type" : "string"
+          },
+          "fullName" : {
+            "type" : "string"
+          },
+          "streetName" : {
+            "type" : "string"
+          },
+          "civicNumber" : {
+            "type" : "string"
+          },
+          "postalCode" : {
+            "type" : "string"
+          },
+          "city" : {
+            "type" : "string"
+          },
+          "province" : {
+            "type" : "string"
+          },
+          "region" : {
+            "type" : "string"
+          },
+          "country" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string"
+          },
+          "email" : {
+            "type" : "string"
+          },
+          "phone" : {
+            "type" : "string"
+          },
+          "switchToExpired" : {
+            "type" : "boolean",
+            "description" : "feature flag to enable the debt position to expire after the due date",
+            "example" : false,
+            "default" : false
+          },
+          "companyName" : {
+            "type" : "string"
+          },
+          "officeName" : {
+            "type" : "string"
+          },
+          "validityDate" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "paymentDate" : {
+            "type" : "string",
+            "format" : "date-time",
+            "readOnly" : true
+          },
+          "status" : {
+            "type" : "string",
+            "readOnly" : true,
+            "enum" : [ "DRAFT", "PUBLISHED", "VALID", "INVALID", "EXPIRED", "PARTIALLY_PAID", "PAID", "REPORTED" ]
+          },
+          "paymentOption" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentOptionModel"
+            }
+          }
+        }
+      },
+      "Stamp" : {
+        "required" : [ "hashDocument", "provincialResidence", "stampType" ],
+        "type" : "object",
+        "properties" : {
+          "hashDocument" : {
+            "type" : "string",
+            "description" : "Document hash"
+          },
+          "stampType" : {
+            "maxLength" : 2,
+            "minLength" : 2,
+            "type" : "string",
+            "description" : "The type of the stamp"
+          },
+          "provincialResidence" : {
+            "pattern" : "[A-Z]{2}",
+            "type" : "string",
+            "description" : "The provincial of the residence",
+            "example" : "RM"
+          }
+        },
+        "description" : "mutual exclusive with iban and postalIban"
+      },
+      "TransferMetadataModel" : {
+        "required" : [ "key" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        },
+        "description" : "it can added a maximum of 10 key-value pairs for metadata"
+      },
+      "TransferModel" : {
+        "required" : [ "amount", "category", "idTransfer", "remittanceInformation" ],
+        "type" : "object",
+        "properties" : {
+          "idTransfer" : {
+            "type" : "string",
+            "enum" : [ "1", "2", "3", "4", "5" ]
+          },
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "organizationFiscalCode" : {
+            "type" : "string",
+            "description" : "Fiscal code related to the organization targeted by this transfer.",
+            "example" : "00000000000"
+          },
+          "remittanceInformation" : {
+            "type" : "string"
+          },
+          "category" : {
+            "type" : "string"
+          },
+          "iban" : {
+            "type" : "string",
+            "description" : "mutual exclusive with postalIban and stamp",
+            "example" : "IT0000000000000000000000000"
+          },
+          "postalIban" : {
+            "type" : "string",
+            "description" : "mutual exclusive with iban and stamp",
+            "example" : "IT0000000000000000000000000"
+          },
+          "stamp" : {
+            "$ref" : "#/components/schemas/Stamp"
+          },
+          "transferMetadata" : {
+            "maxItems" : 10,
+            "minItems" : 0,
+            "type" : "array",
+            "description" : "it can added a maximum of 10 key-value pairs for metadata",
+            "items" : {
+              "$ref" : "#/components/schemas/TransferMetadataModel"
+            }
+          }
+        }
+      },
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+          },
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
+          },
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
+          }
+        }
+      },
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "version" : {
+            "type" : "string"
+          },
+          "environment" : {
+            "type" : "string"
+          }
+        }
+      }
+    },
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
+      },
+      "Authorization" : {
+        "type" : "http",
+        "description" : "JWT token get after Azure Login",
+        "scheme" : "bearer",
+        "bearerFormat" : "JWT"
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- `apim_api_gpd_api_v2` with related policy and openAPI has been added.

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

- redirect to new bulk API when calling `POST` `gpd/api/v2/organizations/{organizationFiscalCode}/debtpositions`

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
