### PR TITLE
[CHK-2243] Change var in the CSP'def

### DIFF
--- a/src/domains/wallet-common/05_wallet_cdn.tf
+++ b/src/domains/wallet-common/05_wallet_cdn.tf
@@ -48,7 +48,7 @@ module "wallet_fe_cdn" {
       {
         action = "Overwrite"
         name   = "Content-Security-Policy"
-        value  = format("default-src 'self'; connect-src 'self' https://api.%s.%s *.nexigroup.com;", var.dns_zone_prefix, var.external_domain)
+        value  = format("default-src 'self'; connect-src 'self' https://api.%s.%s *.nexigroup.com;", var.dns_zone_platform, var.external_domain)
       },
       {
         action = "Append"


### PR DESCRIPTION
This PR fix the CSP generated for wallet-fe website.

### List of changes
- Change var def in the CSP from dns_zone_prefix to dns_zone_platform

### Motivation and context

CSP fails if requested using another domain.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
