### PR TITLE
[PRDP-328] fix: Changed consistency level account receipt-datastore to STRONG

### DIFF
--- a/src/domains/receipts-common/env/weu-uat/terraform.tfvars
+++ b/src/domains/receipts-common/env/weu-uat/terraform.tfvars
@@ -34,7 +34,7 @@ receipts_datastore_cosmos_db_params = {
   capabilities = []
   offer_type   = "Standard"
   consistency_policy = {
-    consistency_level       = "BoundedStaleness"
+    consistency_level       = "Strong"
     max_interval_in_seconds = 300
     max_staleness_prefix    = 100000
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Changed consistency level account receipt-datastore to STRONG in UAT

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
[Issue PRDP-328](https://pagopa.atlassian.net/browse/PRDP-328?atlOrigin=eyJpIjoiNTUzYWYwM2EyM2I2NDRhZjk2ZTFkMDY1MWE0YTUxYjUiLCJwIjoiaiJ9)

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
