### PR TITLE
feat: 302 for wallet outcome result

### DIFF
--- a/src/domains/wallet-app/api/payment-wallet/v1/_onboarding_outcome.xml.tpl
+++ b/src/domains/wallet-app/api/payment-wallet/v1/_onboarding_outcome.xml.tpl
@@ -1,7 +1,10 @@
 <policies>
     <inbound>
         <return-response>
-            <set-status code="200" reason="OK" />          
+          <set-status code="302" />
+          <set-header name="location" exists-action="override">
+            <value>@($"iowallet://{context.Request.OriginalUrl.Host}{context.Request.OriginalUrl.Path}{context.Request.OriginalUrl.QueryString}")</value>
+          </set-header>
         </return-response>
     </inbound>
     <outbound>

--- a/src/domains/wallet-app/api/payment-wallet/v1/_openapi.json.tpl
+++ b/src/domains/wallet-app/api/payment-wallet/v1/_openapi.json.tpl
@@ -433,8 +433,16 @@
         "summary": "Redirection URL for onboarding outcome",
         "description": "Return onboarding outcome result as `outcome` query parameter",
         "responses": {
-          "200": {
-            "description": "Onboarding outcome available (see outcome query parameter)"
+          "302": {
+            "description": "Onboarding outcome available (see outcome query parameter)",
+            "headers": {
+              "Location": {
+                "description": "URI with iowallet:// used by client to show result given outocome in query parameter",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       }
@@ -732,14 +740,14 @@
                 "maxLength": 20,
                 "example": "+3938*******202"
               },
-              "instituteCode":{
+              "instituteCode": {
                 "description": "institute code",
                 "type": "string",
                 "minLength": 1,
                 "maxLength": 5,
                 "example": "12345"
               },
-              "bankName":{
+              "bankName": {
                 "description": "bank name",
                 "type": "string",
                 "example": "banca di banca"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- update outcome redirect openapi & policy

### Motivation and context

The goal of this PR is to update outcome redirect for app IO with a dedicate link, the app is listening on:

- `iowallet://*****?outcome=`

so prefix  `iowallet://` instead http protocol.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
