### PR TITLE
[CHK-2379] pod disruption budget set to 3 for all ecommerce services

### DIFF
--- a/src/domains/ecommerce-app/env/weu-prod/terraform.tfvars
+++ b/src/domains/ecommerce-app/env/weu-prod/terraform.tfvars
@@ -50,37 +50,37 @@ dns_zone_checkout = "checkout"
 
 pod_disruption_budgets = {
   "pagopaecommerceeventdispatcherservice" = {
-    minAvailable = 1
+    minAvailable = 3
     matchLabels = {
       "app.kubernetes.io/instance" = "pagopaecommerceeventdispatcherservice"
     }
   },
   "pagopaecommercehelpdeskservice" = {
-    minAvailable = 1
+    minAvailable = 3
     matchLabels = {
       "app.kubernetes.io/instance" = "pagopaecommercehelpdeskservice"
     }
   },
   "pagopaecommercepaymentmethodsservice" = {
-    minAvailable = 1
+    minAvailable = 3
     matchLabels = {
       "app.kubernetes.io/instance" = "pagopaecommercepaymentmethodsservice"
     }
   },
   "pagopaecommercepaymentrequestsservice" = {
-    minAvailable = 1
+    minAvailable = 3
     matchLabels = {
       "app.kubernetes.io/instance" = "pagopaecommercepaymentrequestsservice"
     }
   },
   "pagopaecommercetransactionsservice" = {
-    minAvailable = 1
+    minAvailable = 3
     matchLabels = {
       "app.kubernetes.io/instance" = "pagopaecommercetransactionsservice"
     }
   },
   "pagopanotificationsservice" = {
-    minAvailable = 1
+    minAvailable = 3
     matchLabels = {
       "app.kubernetes.io/instance" = "pagopanotificationsservice"
     }


### PR DESCRIPTION
Set pod disruption budget to 3 to ensure minimum available instances in case of any node goes down

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
