### PR TITLE
fix: Custom roles for IaC

### DIFF
--- a/src/core/01_custom_roles.tf
+++ b/src/core/01_custom_roles.tf
@@ -1,0 +1,35 @@
+resource "azurerm_role_definition" "iac_reader" {
+  name        = "PagoPA Platform ${title(var.env)} IaC Reader"
+  scope       = data.azurerm_subscription.current.id
+  description = "Custom role for pagopa platform team. Infrastructure as Code read-only role"
+
+  permissions {
+    actions = [
+      "Microsoft.Resources/deployments/exportTemplate/action",                           # read arm template deployments
+      "Microsoft.Web/sites/config/list/action",                                          # read app config for function app, app service
+      "Microsoft.Web/sites/slots/config/list/action",                                    # read app config for function app, app service slots
+      "Microsoft.ContainerService/managedClusters/read",                                 # help to generate cluster credentials
+      "Microsoft.ContainerService/managedClusters/listClusterUserCredential/action",     # help to generate cluster credentials
+      "Microsoft.ContainerService/managedClusters/accessProfiles/listCredential/action", # help to generate cluster credentials and read cluster roles
+      "Microsoft.EventHub/namespaces/eventhubs/authorizationRules/listKeys/action",      #help to list key for event hub connection (mandatory for tf:azurerm_eventhub_authorization_rule)
+      "Microsoft.ServiceBus/namespaces/authorizationRules/listKeys/action",              #help to list key for service bus connection
+      "Microsoft.ServiceBus/namespaces/queues/authorizationRules/listKeys/action",
+      "Microsoft.Cache/redis/listKeys/action", # Redis List
+      "Microsoft.Web/sites/host/listkeys/action",
+      "Microsoft.Storage/storageAccounts/listkeys/action",             # terraform get status backend
+      "Microsoft.ContainerRegistry/registries/listCredentials/action", # ACR list
+    ]
+  }
+}
+
+# "PagoPA IaC Reader",
+# "Reader",
+# "Reader and Data Access",
+# "Storage Blob Data Reader",
+# "Storage File Data SMB Share Reader",
+# "Storage Queue Data Reader",
+# "Storage Table Data Reader",
+# "PagoPA Export Deployments Template",
+# "Key Vault Secrets User",
+# "DocumentDB Account Contributor",
+# "API Management Service Contributor",

--- a/src/core/01_custom_roles.tf
+++ b/src/core/01_custom_roles.tf
@@ -4,20 +4,53 @@ resource "azurerm_role_definition" "iac_reader" {
   description = "Custom role for pagopa platform team. Infrastructure as Code read-only role"
 
   permissions {
+
     actions = [
-      "Microsoft.Resources/deployments/exportTemplate/action",                           # read arm template deployments
-      "Microsoft.Web/sites/config/list/action",                                          # read app config for function app, app service
-      "Microsoft.Web/sites/slots/config/list/action",                                    # read app config for function app, app service slots
-      "Microsoft.ContainerService/managedClusters/read",                                 # help to generate cluster credentials
-      "Microsoft.ContainerService/managedClusters/listClusterUserCredential/action",     # help to generate cluster credentials
-      "Microsoft.ContainerService/managedClusters/accessProfiles/listCredential/action", # help to generate cluster credentials and read cluster roles
-      "Microsoft.EventHub/namespaces/eventhubs/authorizationRules/listKeys/action",      #help to list key for event hub connection (mandatory for tf:azurerm_eventhub_authorization_rule)
-      "Microsoft.ServiceBus/namespaces/authorizationRules/listKeys/action",              #help to list key for service bus connection
-      "Microsoft.ServiceBus/namespaces/queues/authorizationRules/listKeys/action",
-      "Microsoft.Cache/redis/listKeys/action", # Redis List
-      "Microsoft.Web/sites/host/listkeys/action",
-      "Microsoft.Storage/storageAccounts/listkeys/action",             # terraform get status backend
-      "Microsoft.ContainerRegistry/registries/listCredentials/action", # ACR list
+      "Microsoft.Resources/deployments/exportTemplate/action", # read arm template deployments
+      "Microsoft.Resources/*/read",                            #resources
+      # "Microsoft.Resources/subscriptions/resourcegroups/read", #resources
+      "Microsoft.Web/sites/config/list/action",       # read app config for function app, app service
+      "Microsoft.Web/sites/slots/config/list/action", # read app config for function app, app service slots
+      "Microsoft.ContainerService/*/read",            # help to generate cluster credentials
+      # "Microsoft.ContainerService/managedClusters/read",                                 # help to generate cluster credentials
+      # "Microsoft.ContainerService/managedClusters/listClusterUserCredential/action",     # help to generate cluster credentials
+      # "Microsoft.ContainerService/managedClusters/accessProfiles/listCredential/action", # help to generate cluster credentials and read cluster roles
+      "Microsoft.EventHub/namespaces/*/listKeys/action", #help to list key for event hub connection (mandatory for tf:azurerm_eventhub_authorization_rule)
+      # "Microsoft.EventHub/namespaces/eventhubs/authorizationRules/listKeys/action",      #help to list key for event hub connection (mandatory for tf:azurerm_eventhub_authorization_rule)
+      "Microsoft.ServiceBus/namespaces/*/listKeys/action", #help to list key for service bus connection
+      # "Microsoft.ServiceBus/namespaces/authorizationRules/listKeys/action",              #help to list key for service bus connection
+      # "Microsoft.ServiceBus/namespaces/queues/authorizationRules/listKeys/action",
+      "Microsoft.Cache/*/listKeys/action", # Redis List
+      # "Microsoft.Cache/redis/listKeys/action", # Redis List
+      "Microsoft.Web/sites/*/listkeys/action",
+      # "Microsoft.Web/sites/host/listkeys/action",
+      "Microsoft.Storage/*/listkeys/action", # terraform get status backend
+      # "Microsoft.Storage/storageAccounts/listkeys/action",             # terraform get status backend
+      # "Microsoft.Storage/storageAccounts/blobServices/read",
+      # "Microsoft.Storage/storageAccounts/fileServices/read",
+      # "Microsoft.Storage/storageAccounts/queueServices/read",
+      "Microsoft.Storage/*/read",
+      # "Microsoft.Storage/storageAccounts/read",
+      "Microsoft.ContainerRegistry/*/listCredentials/action", # ACR list
+      # "Microsoft.ContainerRegistry/registries/listCredentials/action", # ACR list
+      "Microsoft.ApiManagement/*/read",
+      # "Microsoft.ApiManagement/service/read",
+      "Microsoft.KeyVault/*/read", #KeyVault
+      # "Microsoft.KeyVault/vaults/read", #KeyVault
+      "Microsoft.OperationalInsights/*/read",
+      # "Microsoft.OperationalInsights/workspaces/read",
+      "Microsoft.Insights/*/read",
+      # "Microsoft.Insights/actionGroups/read",
+      # "Microsoft.Insights/components/read",
+      # "Microsoft.Insights/metricAlerts/read",
+      "Microsoft.Network/*/read",
+      # "Microsoft.Network/virtualNetworks/read",
+      # "Microsoft.Network/virtualNetworks/subnets/read",
+      "Microsoft.App/*/read", #container app envs
+      # "Microsoft.App/managedEnvironments/read", #container app envs
+      "Microsoft.Security/*/read",
+      # "Microsoft.Security/advancedThreatProtectionSettings/read",
+      "Microsoft.Authorization/*/read",
     ]
   }
 }

--- a/src/core/01_custom_roles.tf
+++ b/src/core/01_custom_roles.tf
@@ -51,18 +51,8 @@ resource "azurerm_role_definition" "iac_reader" {
       "Microsoft.Security/*/read",
       # "Microsoft.Security/advancedThreatProtectionSettings/read",
       "Microsoft.Authorization/*/read",
+      "Microsoft.Compute/*/read"
+      # "Microsoft.Compute/sshPublicKeys/read",
     ]
   }
 }
-
-# "PagoPA IaC Reader",
-# "Reader",
-# "Reader and Data Access",
-# "Storage Blob Data Reader",
-# "Storage File Data SMB Share Reader",
-# "Storage Queue Data Reader",
-# "Storage Table Data Reader",
-# "PagoPA Export Deployments Template",
-# "Key Vault Secrets User",
-# "DocumentDB Account Contributor",
-# "API Management Service Contributor",

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -467,6 +467,7 @@
 | [azurerm_resource_group.rg_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.data_contributor_role](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.iac_reader](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/role_definition) | resource |
 | [azurerm_storage_container.apim_backup](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.banks](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.fdr_rend_flow](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/storage_container) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

Allow to have only a custom role, that permit iac pipelines to do plan without permissions

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
