### PR TITLE
fix: add insertionDate index

### DIFF
--- a/src/domains/ecommerce-common/03_cosmosdb.tf
+++ b/src/domains/ecommerce-common/03_cosmosdb.tf
@@ -131,6 +131,10 @@ locals {
         {
           keys   = ["insertionDate", "queueName"]
           unique = false
+        },
+        {
+          keys   = ["insertionDate"]
+          unique = false
         }
       ]
       shard_key = "_id"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add insertionDate as single index for dead-letter-events collection as compound index seems to not be used in aggregation pipelines queries
<!--- Describe your changes in detail -->

### Motivation and context
This index will be used to make dead-letter-events helpdesk api RU consumption low
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
