### PR TITLE
[CHK-2519] refactor(npg): remap NPG `additionalData.authorizationStatus` to eCommerce `errorCode`

### DIFF
--- a/src/domains/ecommerce-app/api/ecommerce-transaction-auth-requests-service/v1/_openapi.json.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-transaction-auth-requests-service/v1/_openapi.json.tpl
@@ -493,6 +493,10 @@
             "type": "string",
             "description": "Authorization code"
           },
+          "errorCode": {
+            "type": "string",
+            "description": "Error code"
+          },
           "paymentEndToEndId": {
             "description": "Circuit unique transaction ID",
             "type": "string"

--- a/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
@@ -101,10 +101,12 @@
                         string operationId = (string)operation["operationId"];
                         var additionalData = operation["additionalData"];
                         string authorizationCode = null;
+                        string errorCode = null;
                         string rrn = null;
                         if(additionalData.Type != JTokenType.Null){
                             JObject receivedAdditionalData = (JObject)additionalData;
                             authorizationCode = (string)receivedAdditionalData["authorizationCode"];
+                            errorCode = (string)receivedAdditionalData["authorizationStatus"];
                             rrn = (string)receivedAdditionalData["rrn"];
                         }
                         string paymentEndToEndId = (string)operation["paymentEndToEndId"];
@@ -122,6 +124,7 @@
                         outcomeGateway["operationResult"] = operationResult;
                         outcomeGateway["orderId"] = orderId;
                         outcomeGateway["operationId"] = operationId;
+                        outcomeGateway["errorCode"] = errorCode;
                         outcomeGateway["authorizationCode"] = authorizationCode;
                         outcomeGateway["paymentEndToEndId"] = paymentEndToEndId;
                         outcomeGateway["rrn"] = rrn;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
<!--- Describe your changes in detail -->

 * remap NPG `additionalData.authorizationStatus` to eCommerce `errorCode`

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
Needed because of change in NPG API that properly forwards both fields to us

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
