### PR TITLE
[PQI-66] feat: add PDND DataFactory KPI pipeline definitions

### DIFF
--- a/src/domains/observability/04_datafactory_pipeline.tf
+++ b/src/domains/observability/04_datafactory_pipeline.tf
@@ -322,3 +322,339 @@ resource "azurerm_data_factory_trigger_schedule" "Trigger_KPI_FDR_RENDICONTAZION
   pipeline_name = azurerm_data_factory_pipeline.pipeline_KPI_FDR_RENDICONTAZIONI.name
 
 }
+
+########################### KPI PDND TPNP ###########################
+resource "azurerm_data_factory_pipeline" "pipeline_PDND_KPI_TPNP" {
+
+  name            = "PDND_KPI_TPNP_Pipeline"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  variables = {
+    startDate  = "",
+    endDate    = "",
+    item       = "",
+    jsonChunk  = "",
+    jsonResult = ""
+  }
+
+  activities_json = "[${templatefile("datafactory/pipelines/PDND_KPI_TPNP.json", {
+    inputdataset  = "SMO_ReEvent_DataSet"
+  })}]"
+
+#  depends_on = [
+#    azurerm_data_factory_custom_dataset.qi_datasets
+#  ]
+}
+
+resource "azurerm_data_factory_trigger_schedule" "Trigger_PDND_KPI_TPNP" {
+
+  name            = "Trigger_PDND_KPI_TPNP"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  interval  = 1
+  frequency = "Month"
+  activated = true
+  time_zone = "W. Europe Standard Time"
+    schedule {
+      days_of_month = [5]
+      hours         = [8]
+      minutes       = [0]
+  }
+
+  description   = "Trigger for PDND_KPI_TPNP pipeline"
+  pipeline_name = azurerm_data_factory_pipeline.pipeline_PDND_KPI_TPNP.name
+}
+
+########################### KPI PDND DASPO ###########################
+resource "azurerm_data_factory_pipeline" "pipeline_PDND_KPI_DASPO" {
+
+  name            = "PDND_KPI_DASPO_Pipeline"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  variables = {
+    startDate  = "",
+    endDate    = "",
+    item       = "",
+    jsonChunk  = "",
+    jsonResult = ""
+  }
+
+  activities_json = "[${templatefile("datafactory/pipelines/PDND_KPI_DASPO.json", {
+    inputdataset  = "SMO_ReEvent_DataSet"
+  })}]"
+
+#  depends_on = [
+#    azurerm_data_factory_custom_dataset.qi_datasets
+#  ]
+}
+
+resource "azurerm_data_factory_trigger_schedule" "Trigger_PDND_KPI_DASPO" {
+
+  name            = "Trigger_PDND_KPI_DASPO"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  interval  = 1
+  frequency = "Month"
+  activated = true
+  time_zone = "W. Europe Standard Time"
+    schedule {
+      days_of_month = [5]
+      hours         = [8]
+      minutes       = [0]
+  }
+
+  description   = "Trigger for PDND_KPI_DASPO pipeline"
+  pipeline_name = azurerm_data_factory_pipeline.pipeline_PDND_KPI_DASPO.name
+}
+
+########################### KPI PDND LFDR ###########################
+resource "azurerm_data_factory_pipeline" "pipeline_PDND_KPI_LFDR" {
+
+  name            = "PDND_KPI_LFDR_Pipeline"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  variables = {
+    startDate  = "",
+    endDate    = "",
+    item       = "",
+    jsonChunk  = "",
+    jsonResult = ""
+  }
+
+  activities_json = "[${templatefile("datafactory/pipelines/PDND_KPI_LFDR.json", {
+    inputdataset  = "SMO_KPI_RENDICONTAZIONI_DataSet"
+  })}]"
+
+#  depends_on = [
+#    azurerm_data_factory_custom_dataset.qi_datasets
+#  ]
+}
+
+resource "azurerm_data_factory_trigger_schedule" "Trigger_PDND_KPI_LFDR" {
+
+  name            = "Trigger_PDND_KPI_LFDR"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  interval  = 1
+  frequency = "Month"
+  activated = true
+  time_zone = "W. Europe Standard Time"
+    schedule {
+      days_of_month = [5]
+      hours         = [8]
+      minutes       = [0]
+  }
+
+  description   = "Trigger for PDND_KPI_LFDR pipeline"
+  pipeline_name = azurerm_data_factory_pipeline.pipeline_PDND_KPI_LFDR.name
+}
+
+########################### KPI PDND LSPO ###########################
+resource "azurerm_data_factory_pipeline" "pipeline_PDND_KPI_LSPO" {
+
+  name            = "PDND_KPI_LSPO_Pipeline"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  variables = {
+    startDate  = "",
+    endDate    = "",
+    item       = "",
+    jsonChunk  = "",
+    jsonResult = ""
+  }
+
+  activities_json = "[${templatefile("datafactory/pipelines/PDND_KPI_LSPO.json", {
+    inputdataset  = "SMO_ReEvent_DataSet"
+  })}]"
+
+#  depends_on = [
+#    azurerm_data_factory_custom_dataset.qi_datasets
+#  ]
+}
+
+resource "azurerm_data_factory_trigger_schedule" "Trigger_PDND_KPI_LSPO" {
+
+  name            = "Trigger_PDND_KPI_LSPO"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  interval  = 1
+  frequency = "Month"
+  activated = true
+  time_zone = "W. Europe Standard Time"
+    schedule {
+      days_of_month = [5]
+      hours         = [8]
+      minutes       = [0]
+  }
+
+  description   = "Trigger for PDND_KPI_LSPO pipeline"
+  pipeline_name = azurerm_data_factory_pipeline.pipeline_PDND_KPI_LSPO.name
+}
+
+########################### KPI PDND NRFDR ###########################
+resource "azurerm_data_factory_pipeline" "pipeline_PDND_KPI_NRFDR" {
+
+  name            = "PDND_KPI_NRFDR_Pipeline"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  variables = {
+    startDate  = "",
+    endDate    = "",
+    item       = "",
+    jsonChunk  = "",
+    jsonResult = ""
+  }
+
+  activities_json = "[${templatefile("datafactory/pipelines/PDND_KPI_NRFDR.json", {
+    inputdataset  = "SMO_KPI_RENDICONTAZIONI_DataSet"
+  })}]"
+
+#  depends_on = [
+#    azurerm_data_factory_custom_dataset.qi_datasets
+#  ]
+}
+
+resource "azurerm_data_factory_trigger_schedule" "Trigger_PDND_KPI_NRFDR" {
+
+  name            = "Trigger_PDND_KPI_NRFDR"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  interval  = 1
+  frequency = "Month"
+  activated = true
+  time_zone = "W. Europe Standard Time"
+    schedule {
+      days_of_month = [5]
+      hours         = [8]
+      minutes       = [0]
+  }
+
+  description   = "Trigger for PDND_KPI_NRFDR pipeline"
+  pipeline_name = azurerm_data_factory_pipeline.pipeline_PDND_KPI_NRFDR.name
+}
+
+########################### KPI PDND TNSPO ###########################
+resource "azurerm_data_factory_pipeline" "pipeline_PDND_KPI_TNSPO" {
+
+  name            = "PDND_KPI_TNSPO_Pipeline"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  variables = {
+    startDate  = "",
+    endDate    = "",
+    item       = "",
+    jsonChunk  = "",
+    jsonResult = ""
+  }
+
+  activities_json = "[${templatefile("datafactory/pipelines/PDND_KPI_TNSPO.json", {
+    inputdataset  = "SMO_ReEvent_DataSet"
+  })}]"
+
+#  depends_on = [
+#    azurerm_data_factory_custom_dataset.qi_datasets
+#  ]
+}
+
+resource "azurerm_data_factory_trigger_schedule" "Trigger_PDND_KPI_TNSPO" {
+
+  name            = "Trigger_PDND_KPI_TNSPO"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  interval  = 1
+  frequency = "Month"
+  activated = true
+  time_zone = "W. Europe Standard Time"
+    schedule {
+      days_of_month = [5]
+      hours         = [8]
+      minutes       = [0]
+  }
+
+  description   = "Trigger for PDND_KPI_TNSPO pipeline"
+  pipeline_name = azurerm_data_factory_pipeline.pipeline_PDND_KPI_TNSPO.name
+}
+
+########################### KPI PDND WAFDR ###########################
+resource "azurerm_data_factory_pipeline" "pipeline_PDND_KPI_WAFDR" {
+
+  name            = "PDND_KPI_WAFDR_Pipeline"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  variables = {
+    startDate  = "",
+    endDate    = "",
+    item       = "",
+    jsonChunk  = "",
+    jsonResult = ""
+  }
+
+  activities_json = "[${templatefile("datafactory/pipelines/PDND_KPI_WAFDR.json", {
+    inputdataset  = "SMO_KPI_RENDICONTAZIONI_DataSet"
+  })}]"
+
+#  depends_on = [
+#    azurerm_data_factory_custom_dataset.qi_datasets
+#  ]
+}
+
+resource "azurerm_data_factory_trigger_schedule" "Trigger_PDND_KPI_WAFDR" {
+
+  name            = "Trigger_PDND_KPI_WAFDR"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  interval  = 1
+  frequency = "Month"
+  activated = true
+  time_zone = "W. Europe Standard Time"
+    schedule {
+      days_of_month = [5]
+      hours         = [8]
+      minutes       = [0]
+  }
+
+  description   = "Trigger for PDND_KPI_WAFDR pipeline"
+  pipeline_name = azurerm_data_factory_pipeline.pipeline_PDND_KPI_WAFDR.name
+}
+
+########################### KPI PDND WPNFDR ###########################
+resource "azurerm_data_factory_pipeline" "pipeline_PDND_KPI_WPNFDR" {
+
+  name            = "PDND_KPI_WPNFDR_Pipeline"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  variables = {
+    startDate  = "",
+    endDate    = "",
+    item       = "",
+    jsonChunk  = "",
+    jsonResult = ""
+  }
+
+  activities_json = "[${templatefile("datafactory/pipelines/PDND_KPI_WPNFDR.json", {
+    inputdataset  = "SMO_KPI_RENDICONTAZIONI_DataSet"
+  })}]"
+
+#  depends_on = [
+#    azurerm_data_factory_custom_dataset.qi_datasets
+#  ]
+}
+
+resource "azurerm_data_factory_trigger_schedule" "Trigger_PDND_KPI_WPNFDR" {
+
+  name            = "Trigger_PDND_KPI_WPNFDR"
+  data_factory_id = data.azurerm_data_factory.qi_data_factory.id
+
+  interval  = 1
+  frequency = "Month"
+  activated = true
+  time_zone = "W. Europe Standard Time"
+    schedule {
+      days_of_month = [5]
+      hours         = [8]
+      minutes       = [0]
+  }
+
+  description   = "Trigger for PDND_KPI_WPNFDR pipeline"
+  pipeline_name = azurerm_data_factory_pipeline.pipeline_PDND_KPI_WPNFDR.name
+}

--- a/src/domains/observability/datafactory/pipelines/PDND_KPI_DASPO.json
+++ b/src/domains/observability/datafactory/pipelines/PDND_KPI_DASPO.json
@@ -1,0 +1,222 @@
+{
+    "name": "QueryDASPO",
+    "type": "Lookup",
+    "dependsOn": [
+        {
+            "activity": "StartDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "timeout": "0.12:00:00",
+        "retry": 0,
+        "retryIntervalInSeconds": 30,
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "source": {
+            "type": "AzureDataExplorerSource",
+            "query": {
+                "value": "let start=datetime('@{variables('startDate')}');\nlet end=datetime('@{variables('endDate')}');\n \n\nKPI_TPSPO_DASPO\n| where ACTIVATE_REQ between (start .. end)\n| extend _d = parse_json(DETAILED_INFO)\n| extend TOKEN_SCADUTO=toint(_d.TOKEN_SCADUTO)\n| extend SPO_ASSENTE=toint(_d.SPO_ASSENTE)\n| extend TOTALE_CHIAMATE=toint(_d.TOTALE_CHIAMATE)\n| summarize  SPO_ASSENTE=sum(SPO_ASSENTE), TOTALE_CHIAMATE=sum(TOTALE_CHIAMATE) by   PSP,INTERMEDIARIO_PSP\n| join kind=inner PSP on $left.PSP == $right.ID_PSP\n| join kind=inner INTERMEDIARI_PSP on $left.INTERMEDIARIO_PSP == $right.ID_INTERMEDIARIO_PSP\n| extend PERC_KPI=(SPO_ASSENTE * 100.00) / TOTALE_CHIAMATE\n| extend PERC_KPI=round( case(isnan(PERC_KPI), 0.00, PERC_KPI),2)\n| extend KPI_THRESHOLD=2.0\n| extend  KPI_ID=\"DASPO#8\"\n| extend KPI_OUTCOME = iff(PERC_KPI > KPI_THRESHOLD,\"KO\",\"OK\")\n| project KPI_ID, KPI_THRESHOLD, start , end ,ID_PSP,PSP=iif(DESCRIZIONE <> '' , DESCRIZIONE,RAGIONE_SOCIALE) ,ID_INTERMEDIARIO_PSP, INTERMEDIARIO_DESCR, PERC_KPI, TOTALE_CHIAMATE, SPO_ASSENTE,KPI_OUTCOME \n| project  pack_all()\n",
+                "type": "Expression"
+            },
+            "queryTimeout": "01:00:00",
+            "noTruncation": true
+        },
+        "dataset": {
+            "referenceName": "SMO_ReEvent_DataSet",
+            "type": "DatasetReference"
+        },
+        "firstRowOnly": false
+    }
+},
+{
+    "name": "EndDate",
+    "description": "Ricavo la data fine per prendere la mensilità\n",
+    "type": "SetVariable",
+    "dependsOn": [],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "endDate",
+        "value": {
+            "value": "@addDays(startOfMonth(convertFromUtc(pipeline().TriggerTime, 'W. Europe Standard Time')), -1)",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "StartDate",
+    "description": "mi calcolo la data di inzio della query mese precedente primo giorno",
+    "type": "SetVariable",
+    "dependsOn": [
+        {
+            "activity": "EndDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "startDate",
+        "value": {
+            "value": "@startOfMonth(variables('endDate'))",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "ForEachKPI",
+    "type": "ForEach",
+    "dependsOn": [
+        {
+            "activity": "QueryDASPO",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "items": {
+            "value": "@activity('QueryDASPO').output.value",
+            "type": "Expression"
+        },
+        "isSequential": true,
+        "activities": [
+            {
+                "name": "GetKPI",
+                "type": "SetVariable",
+                "dependsOn": [],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "item",
+                    "value": {
+                        "value": "@concat(item().KPI, ',')",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "ConcatKPI",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "GetKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonChunk",
+                    "value": {
+                        "value": "@concat(variables('JsonResult'), variables('Item'))",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "SetJsonResult",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "ConcatKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonResult",
+                    "value": {
+                        "value": "@variables('JsonChunk')",
+                        "type": "Expression"
+                    }
+                }
+            }
+        ]
+    }
+},
+{
+    "name": "CheckResult",
+    "type": "IfCondition",
+    "dependsOn": [
+        {
+            "activity": "ForEachKPI",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "expression": {
+            "value": "@greater(length(variables('JsonResult')), 0)",
+            "type": "Expression"
+        },
+        "ifTrueActivities": [
+            {
+                "name": "WriteEvhub",
+                "type": "WebActivity",
+                "dependsOn": [],
+                "policy": {
+                    "timeout": "0.12:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "method": "POST",
+                    "url": {
+                        "value": "@pipeline().globalParameters.evhBaseUrl",
+                        "type": "Expression"
+                    },
+                    "connectVia": {
+                        "referenceName": "AutoResolveIntegrationRuntime",
+                        "type": "IntegrationRuntimeReference"
+                    },
+                    "body": {
+                        "value": "@json(concat('[', variables('JsonResult'), ']'))",
+                        "type": "Expression"
+                    },
+                    "authentication": {
+                        "type": "MSI",
+                        "resource": {
+                            "value": "@concat(pipeline().globalParameters.evhBaseUrl, '/quality-improvement-psp-kpi/messages')",
+                            "type": "Expression"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/domains/observability/datafactory/pipelines/PDND_KPI_LFDR.json
+++ b/src/domains/observability/datafactory/pipelines/PDND_KPI_LFDR.json
@@ -1,0 +1,222 @@
+{
+    "name": "QueryLFDR",
+    "type": "Lookup",
+    "dependsOn": [
+        {
+            "activity": "StartDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "timeout": "0.12:00:00",
+        "retry": 0,
+        "retryIntervalInSeconds": 30,
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "source": {
+            "type": "AzureDataExplorerSource",
+            "query": {
+                "value": "let start=datetime('@{variables('startDate')}');\nlet end=datetime('@{variables('endDate')}');\n \n\nKPI_RENDICONTAZIONI\n| where GIORNATA_PAGAMENTO between (start .. end)\n| summarize TOTALE_FLUSSI=sum(TOTALE_FLUSSI), FDR_IN_RITARDO_F=sum(FDR_IN_RITARDO_FIRST_VERSION), FDR_IN_RITARDO_L=sum(FDR_IN_RITARDO_LAST_VERSION) by ID_PSP, ID_BROKER_PSP\n| join kind=inner PSP on $left.ID_PSP == $right.ID_PSP\n| join kind=inner INTERMEDIARI_PSP on $left.ID_BROKER_PSP == $right.ID_INTERMEDIARIO_PSP\n| extend kpi_id =\"LFDR\"\n| extend PERC_KPII=(FDR_IN_RITARDO_F * 100.00) / TOTALE_FLUSSI\n| extend PERC_KPI=round( case(isnan(PERC_KPII), 0.00, PERC_KPII),2)\n| extend kpi_threshold=1.0\n| extend kpi_outcome = iff(PERC_KPI > kpi_threshold,\"KO\",\"OK\")\n| project kpi_id, kpi_threshold,start , end , TOTALE_FLUSSI,FDR_IN_RITARDO_F,PERC_KPI,kpi_outcome,psp_id=ID_PSP,psp_company_name=iif(DESCRIZIONE <> '' , DESCRIZIONE,RAGIONE_SOCIALE) ,psp_broker_id=ID_BROKER_PSP, psp_broker_company_name=INTERMEDIARIO_DESCR\n| project pack_all()\n\n",
+                "type": "Expression"
+            },
+            "queryTimeout": "01:00:00",
+            "noTruncation": true
+        },
+        "dataset": {
+            "referenceName": "SMO_KPI_TPNP_DataSet",
+            "type": "DatasetReference"
+        },
+        "firstRowOnly": false
+    }
+},
+{
+    "name": "EndDate",
+    "description": "Ricavo la data fine per prendere la mensilità\n",
+    "type": "SetVariable",
+    "dependsOn": [],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "endDate",
+        "value": {
+            "value": "@addDays(startOfMonth(convertFromUtc(pipeline().TriggerTime, 'W. Europe Standard Time')), -1)",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "StartDate",
+    "description": "mi calcolo la data di inzio della query mese precedente primo giorno",
+    "type": "SetVariable",
+    "dependsOn": [
+        {
+            "activity": "EndDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "startDate",
+        "value": {
+            "value": "@startOfMonth(variables('endDate'))",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "ForEachKPI",
+    "type": "ForEach",
+    "dependsOn": [
+        {
+            "activity": "QueryLFDR",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "items": {
+            "value": "@activity('QueryLFDR').output.value",
+            "type": "Expression"
+        },
+        "isSequential": true,
+        "activities": [
+            {
+                "name": "GetKPI",
+                "type": "SetVariable",
+                "dependsOn": [],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "item",
+                    "value": {
+                        "value": "@concat(item().KPI, ',')",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "ConcatKPI",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "GetKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonChunk",
+                    "value": {
+                        "value": "@concat(variables('JsonResult'), variables('Item'))",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "SetJsonResult",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "ConcatKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonResult",
+                    "value": {
+                        "value": "@variables('JsonChunk')",
+                        "type": "Expression"
+                    }
+                }
+            }
+        ]
+    }
+},
+{
+    "name": "CheckResult",
+    "type": "IfCondition",
+    "dependsOn": [
+        {
+            "activity": "ForEachKPI",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "expression": {
+            "value": "@greater(length(variables('JsonResult')), 0)",
+            "type": "Expression"
+        },
+        "ifTrueActivities": [
+            {
+                "name": "WriteEvhub",
+                "type": "WebActivity",
+                "dependsOn": [],
+                "policy": {
+                    "timeout": "0.12:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "method": "POST",
+                    "url": {
+                        "value": "@pipeline().globalParameters.evhBaseUrl",
+                        "type": "Expression"
+                    },
+                    "connectVia": {
+                        "referenceName": "AutoResolveIntegrationRuntime",
+                        "type": "IntegrationRuntimeReference"
+                    },
+                    "body": {
+                        "value": "@json(concat('[', variables('JsonResult'), ']'))",
+                        "type": "Expression"
+                    },
+                    "authentication": {
+                        "type": "MSI",
+                        "resource": {
+                            "value": "@concat(pipeline().globalParameters.evhBaseUrl, '/quality-improvement-psp-kpi/messages')",
+                            "type": "Expression"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/domains/observability/datafactory/pipelines/PDND_KPI_LSPO.json
+++ b/src/domains/observability/datafactory/pipelines/PDND_KPI_LSPO.json
@@ -1,0 +1,222 @@
+{
+    "name": "QueryLSPO",
+    "type": "Lookup",
+    "dependsOn": [
+        {
+            "activity": "StartDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "timeout": "0.12:00:00",
+        "retry": 0,
+        "retryIntervalInSeconds": 30,
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "source": {
+            "type": "AzureDataExplorerSource",
+            "query": {
+                "value": "let start=datetime('@{variables('startDate')}');\nlet end=datetime('@{variables('endDate')}');\n\nKPI_TPSPO_DASPO\n| where ACTIVATE_REQ between (start .. end)\n| extend _d = parse_json(DETAILED_INFO)\n| extend FROM_FAULTCODE=toint(_d.FROM_FAULTCODE)\n| extend TOTALE_CHIAMATE=toint(_d.TOTALE_CHIAMATE)\n| summarize TOKEN_SCADUTO=sum(FROM_FAULTCODE), TOTALE_CHIAMATE=sum(TOTALE_CHIAMATE) by PSP,INTERMEDIARIO_PSP\n| extend PERC_KPI=(TOKEN_SCADUTO * 100.00) / TOTALE_CHIAMATE\n| extend PERC_KPI=round( case(isnan(PERC_KPI), 0.00, PERC_KPI),2)\n| join kind=inner PSP on $left.PSP == $right.ID_PSP\n| join kind=inner INTERMEDIARI_PSP on $left.INTERMEDIARIO_PSP == $right.ID_INTERMEDIARIO_PSP\n| extend KPI_THRESHOLD=2.0\n| extend  KPI_ID=\"LSPO#7\"\n| extend KPI_OUTCOME = iff(PERC_KPI > KPI_THRESHOLD,\"KO\",\"OK\")\n| project KPI_ID, KPI_THRESHOLD, start , end ,ID_PSP,PSP=iif( DESCRIZIONE <> '' , DESCRIZIONE,RAGIONE_SOCIALE) ,ID_INTERMEDIARIO_PSP, INTERMEDIARIO_DESCR, PERC_KPI, TOTALE_CHIAMATE, TOKEN_SCADUTO,KPI_OUTCOME\n| project  pack_all()",
+                "type": "Expression"
+            },
+            "queryTimeout": "01:00:00",
+            "noTruncation": true
+        },
+        "dataset": {
+            "referenceName": "SMO_ReEvent_DataSet",
+            "type": "DatasetReference"
+        },
+        "firstRowOnly": false
+    }
+},
+{
+    "name": "EndDate",
+    "description": "Ricavo la data fine per prendere la mensilità\n",
+    "type": "SetVariable",
+    "dependsOn": [],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "endDate",
+        "value": {
+            "value": "@addDays(startOfMonth(convertFromUtc(pipeline().TriggerTime, 'W. Europe Standard Time')), -1)",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "StartDate",
+    "description": "mi calcolo la data di inzio della query mese precedente primo giorno",
+    "type": "SetVariable",
+    "dependsOn": [
+        {
+            "activity": "EndDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "startDate",
+        "value": {
+            "value": "@startOfMonth(variables('endDate'))",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "ForEachKPI",
+    "type": "ForEach",
+    "dependsOn": [
+        {
+            "activity": "QueryLSPO",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "items": {
+            "value": "@activity('QueryLSPO').output.value",
+            "type": "Expression"
+        },
+        "isSequential": true,
+        "activities": [
+            {
+                "name": "GetKPI",
+                "type": "SetVariable",
+                "dependsOn": [],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "item",
+                    "value": {
+                        "value": "@concat(item().KPI, ',')",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "ConcatKPI",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "GetKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonChunk",
+                    "value": {
+                        "value": "@concat(variables('JsonResult'), variables('Item'))",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "SetJsonResult",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "ConcatKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonResult",
+                    "value": {
+                        "value": "@variables('JsonChunk')",
+                        "type": "Expression"
+                    }
+                }
+            }
+        ]
+    }
+},
+{
+    "name": "CheckResult",
+    "type": "IfCondition",
+    "dependsOn": [
+        {
+            "activity": "ForEachKPI",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "expression": {
+            "value": "@greater(length(variables('JsonResult')), 0)",
+            "type": "Expression"
+        },
+        "ifTrueActivities": [
+            {
+                "name": "WriteEvhub",
+                "type": "WebActivity",
+                "dependsOn": [],
+                "policy": {
+                    "timeout": "0.12:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "method": "POST",
+                    "url": {
+                        "value": "@pipeline().globalParameters.evhBaseUrl",
+                        "type": "Expression"
+                    },
+                    "connectVia": {
+                        "referenceName": "AutoResolveIntegrationRuntime",
+                        "type": "IntegrationRuntimeReference"
+                    },
+                    "body": {
+                        "value": "@json(concat('[', variables('JsonResult'), ']'))",
+                        "type": "Expression"
+                    },
+                    "authentication": {
+                        "type": "MSI",
+                        "resource": {
+                            "value": "@concat(pipeline().globalParameters.evhBaseUrl, '/quality-improvement-psp-kpi/messages')",
+                            "type": "Expression"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/domains/observability/datafactory/pipelines/PDND_KPI_NRFDR.json
+++ b/src/domains/observability/datafactory/pipelines/PDND_KPI_NRFDR.json
@@ -1,0 +1,222 @@
+{
+    "name": "QueryNRFDR",
+    "type": "Lookup",
+    "dependsOn": [
+        {
+            "activity": "StartDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "timeout": "0.12:00:00",
+        "retry": 0,
+        "retryIntervalInSeconds": 30,
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "source": {
+            "type": "AzureDataExplorerSource",
+            "query": {
+                "value": "let start=datetime('@{variables('startDate')}');\nlet end=datetime('@{variables('endDate')}');\n \nKPI_RENDICONTAZIONI\n| where GIORNATA_PAGAMENTO between (start .. end)\n| summarize TOTALE_FLUSSI=sum(TOTALE_FLUSSI), FDR_ASSENTI=sum(FLUSSI_ASSENTI), FDR_PRESENTI=sum(FLUSSI_PRESENTI) by ID_PSP, ID_BROKER_PSP\n| join kind=inner PSP on $left.ID_PSP == $right.ID_PSP\n| join kind=inner INTERMEDIARI_PSP on $left.ID_BROKER_PSP == $right.ID_INTERMEDIARIO_PSP\n| extend kpi_id =\"NRFDR\"\n| extend PERC_KPII=(FDR_ASSENTI * 100.00) / TOTALE_FLUSSI\n| extend PERC_KPI=round( case(isnan(PERC_KPII), 0.00, PERC_KPII),2)\n| extend kpi_threshold=1.0\n| extend kpi_outcome = iff(PERC_KPI > kpi_threshold,\"KO\",\"OK\")\n| project kpi_id, kpi_threshold,start , end , TOTALE_FLUSSI,FDR_ASSENTI,PERC_KPI,kpi_outcome,psp_id=ID_PSP,psp_company_name=iif(DESCRIZIONE <> '' , DESCRIZIONE,RAGIONE_SOCIALE) ,psp_broker_id=ID_BROKER_PSP, psp_broker_company_name=INTERMEDIARIO_DESCR\n| project pack_all()\n",
+                "type": "Expression"
+            },
+            "queryTimeout": "01:00:00",
+            "noTruncation": true
+        },
+        "dataset": {
+            "referenceName": "SMO_KPI_RENDICONTAZIONI_DataSet",
+            "type": "DatasetReference"
+        },
+        "firstRowOnly": false
+    }
+},
+{
+    "name": "EndDate",
+    "description": "Ricavo la data fine per prendere la mensilità\n",
+    "type": "SetVariable",
+    "dependsOn": [],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "endDate",
+        "value": {
+            "value": "@addDays(startOfMonth(convertFromUtc(pipeline().TriggerTime, 'W. Europe Standard Time')), -1)",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "StartDate",
+    "description": "mi calcolo la data di inzio della query mese precedente primo giorno",
+    "type": "SetVariable",
+    "dependsOn": [
+        {
+            "activity": "EndDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "startDate",
+        "value": {
+            "value": "@startOfMonth(variables('endDate'))",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "ForEachKPI",
+    "type": "ForEach",
+    "dependsOn": [
+        {
+            "activity": "QueryNRFDR",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "items": {
+            "value": "@activity('QueryNRFDR').output.value",
+            "type": "Expression"
+        },
+        "isSequential": true,
+        "activities": [
+            {
+                "name": "GetKPI",
+                "type": "SetVariable",
+                "dependsOn": [],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "item",
+                    "value": {
+                        "value": "@concat(item().KPI, ',')",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "ConcatKPI",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "GetKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonChunk",
+                    "value": {
+                        "value": "@concat(variables('JsonResult'), variables('Item'))",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "SetJsonResult",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "ConcatKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonResult",
+                    "value": {
+                        "value": "@variables('JsonChunk')",
+                        "type": "Expression"
+                    }
+                }
+            }
+        ]
+    }
+},
+{
+    "name": "CheckResult",
+    "type": "IfCondition",
+    "dependsOn": [
+        {
+            "activity": "ForEachKPI",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "expression": {
+            "value": "@greater(length(variables('JsonResult')), 0)",
+            "type": "Expression"
+        },
+        "ifTrueActivities": [
+            {
+                "name": "WriteEvhub",
+                "type": "WebActivity",
+                "dependsOn": [],
+                "policy": {
+                    "timeout": "0.12:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "method": "POST",
+                    "url": {
+                        "value": "@pipeline().globalParameters.evhBaseUrl",
+                        "type": "Expression"
+                    },
+                    "connectVia": {
+                        "referenceName": "AutoResolveIntegrationRuntime",
+                        "type": "IntegrationRuntimeReference"
+                    },
+                    "body": {
+                        "value": "@json(concat('[', variables('JsonResult'), ']'))",
+                        "type": "Expression"
+                    },
+                    "authentication": {
+                        "type": "MSI",
+                        "resource": {
+                            "value": "@concat(pipeline().globalParameters.evhBaseUrl, '/quality-improvement-psp-kpi/messages')",
+                            "type": "Expression"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/domains/observability/datafactory/pipelines/PDND_KPI_TNSPO.json
+++ b/src/domains/observability/datafactory/pipelines/PDND_KPI_TNSPO.json
@@ -1,0 +1,222 @@
+{
+    "name": "QueryTNSPO",
+    "type": "Lookup",
+    "dependsOn": [
+        {
+            "activity": "StartDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "timeout": "0.12:00:00",
+        "retry": 0,
+        "retryIntervalInSeconds": 30,
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "source": {
+            "type": "AzureDataExplorerSource",
+            "query": {
+                "value": "let start=datetime('@{variables('startDate')}');\nlet end=datetime('@{variables('startDate')}');\nKPI_TNSPO\n| where REQUEST_PSPNOTIFY between (start .. end)\n| extend KPI_THRESHOLD=2.0\n| extend DiffinSec=DIFF_TIME_IN_MS/1000\n| summarize TOT_CHIAMATE_OUTSLA= countif(DiffinSec>KPI_THRESHOLD), TOT_CHIAMATE = count(),MEDIA=round( avg(DIFF_TIME_IN_MS) ,2), take_any(KPI_THRESHOLD)  by  PSP, ID_BROKER_PSP\n| join kind=inner PSP on $left.PSP == $right.ID_PSP\n| join kind=inner INTERMEDIARI_PSP on $left.ID_BROKER_PSP == $right.ID_INTERMEDIARIO_PSP\n| extend KPI_ID =\"TNSPO\"\n| extend PercentualeKO =round( (TOT_CHIAMATE_OUTSLA*100.00)/TOT_CHIAMATE,2)\n| extend KPI_OUTCOME = iff(PercentualeKO > KPI_THRESHOLD,\"KO\",\"OK\")\n| project KPI_ID, KPI_THRESHOLD, start , end , MEDIA,TOT_CHIAMATE,TOT_CHIAMATE_OUTSLA,PercentualeKO,KPI_OUTCOME, ID_PSP,PSP=iif( DESCRIZIONE <> '' , DESCRIZIONE,RAGIONE_SOCIALE) ,ID_BROKER_PSP, INTERMEDIARIO_DESCR\n| project  pack_all()",
+                "type": "Expression"
+            },
+            "queryTimeout": "01:00:00",
+            "noTruncation": true
+        },
+        "dataset": {
+            "referenceName": "SMO_ReEvent_DataSet",
+            "type": "DatasetReference"
+        },
+        "firstRowOnly": false
+    }
+},
+{
+    "name": "EndDate",
+    "description": "Ricavo la data fine per prendere la mensilità\n",
+    "type": "SetVariable",
+    "dependsOn": [],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "endDate",
+        "value": {
+            "value": "@addDays(startOfMonth(convertFromUtc(pipeline().TriggerTime, 'W. Europe Standard Time')), -1)",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "StartDate",
+    "description": "mi calcolo la data di inzio della query mese precedente primo giorno",
+    "type": "SetVariable",
+    "dependsOn": [
+        {
+            "activity": "EndDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "startDate",
+        "value": {
+            "value": "@startOfMonth(variables('endDate'))",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "ForEachKPI",
+    "type": "ForEach",
+    "dependsOn": [
+        {
+            "activity": "QueryTNSPO",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "items": {
+            "value": "@activity('QueryTNSPO').output.value",
+            "type": "Expression"
+        },
+        "isSequential": true,
+        "activities": [
+            {
+                "name": "GetKPI",
+                "type": "SetVariable",
+                "dependsOn": [],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "item",
+                    "value": {
+                        "value": "@concat(item().KPI, ',')",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "ConcatKPI",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "GetKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonChunk",
+                    "value": {
+                        "value": "@concat(variables('JsonResult'), variables('Item'))",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "SetJsonResult",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "ConcatKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonResult",
+                    "value": {
+                        "value": "@variables('JsonChunk')",
+                        "type": "Expression"
+                    }
+                }
+            }
+        ]
+    }
+},
+{
+    "name": "CheckResult",
+    "type": "IfCondition",
+    "dependsOn": [
+        {
+            "activity": "ForEachKPI",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "expression": {
+            "value": "@greater(length(variables('JsonResult')), 0)",
+            "type": "Expression"
+        },
+        "ifTrueActivities": [
+            {
+                "name": "WriteEvhub",
+                "type": "WebActivity",
+                "dependsOn": [],
+                "policy": {
+                    "timeout": "0.12:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "method": "POST",
+                    "url": {
+                        "value": "@pipeline().globalParameters.evhBaseUrl",
+                        "type": "Expression"
+                    },
+                    "connectVia": {
+                        "referenceName": "AutoResolveIntegrationRuntime",
+                        "type": "IntegrationRuntimeReference"
+                    },
+                    "body": {
+                        "value": "@json(concat('[', variables('JsonResult'), ']'))",
+                        "type": "Expression"
+                    },
+                    "authentication": {
+                        "type": "MSI",
+                        "resource": {
+                            "value": "@concat(pipeline().globalParameters.evhBaseUrl, '/quality-improvement-psp-kpi/messages')",
+                            "type": "Expression"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/domains/observability/datafactory/pipelines/PDND_KPI_TPNP.json
+++ b/src/domains/observability/datafactory/pipelines/PDND_KPI_TPNP.json
@@ -1,0 +1,222 @@
+{
+    "name": "QueryTPNP",
+    "type": "Lookup",
+    "dependsOn": [
+        {
+            "activity": "StartDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "timeout": "0.12:00:00",
+        "retry": 0,
+        "retryIntervalInSeconds": 30,
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "source": {
+            "type": "AzureDataExplorerSource",
+            "query": {
+                "value": "let start=datetime('@{variables('startDate')}');\nlet end=datetime('@{variables('endDate')}');\nKPI_TNSPO\n| where REQUEST_PSPNOTIFY between (start .. end)\n| extend kpi_threshold=2.0\n| extend DiffinSec=DIFF_TIME_IN_MS/1000\n| summarize TOT_CHIAMATE_OUTSLA= countif(DiffinSec>kpi_threshold), TOT_CHIAMATE = count(),MEDIA=round( avg(DIFF_TIME_IN_MS) ,2), take_any(kpi_threshold)  by  PSP, ID_BROKER_PSP\n| join kind=inner PSP on $left.PSP == $right.ID_PSP\n| join kind=inner INTERMEDIARI_PSP on $left.ID_BROKER_PSP == $right.ID_INTERMEDIARIO_PSP\n| extend kpi_id =\"TNSPO\"\n| extend PERC_KPII =round( (TOT_CHIAMATE_OUTSLA*100.00)/TOT_CHIAMATE,2)\n| extend PERC_KPI=round( case(isnan(PERC_KPII), 0.00, PERC_KPII),2)\n| extend kpi_outcome = iff(PERC_KPI > kpi_threshold,\"KO\",\"OK\")\n| project kpi_id, kpi_threshold, start, end, psp_id= ID_PSP, psp_company_name=iif( DESCRIZIONE <> '' , DESCRIZIONE,RAGIONE_SOCIALE), psp_broker_id=ID_BROKER_PSP, psp_broker_company_name=INTERMEDIARIO_DESCR, PERC_KPI, kpi_outcome\n| project  KPI=pack_all()",
+                "type": "Expression"
+            },
+            "queryTimeout": "01:00:00",
+            "noTruncation": true
+        },
+        "dataset": {
+            "referenceName": "SMO_ReEvent_DataSet",
+            "type": "DatasetReference"
+        },
+        "firstRowOnly": false
+    }
+},
+{
+    "name": "EndDate",
+    "description": "Ricavo la data fine per prendere la mensilità\n",
+    "type": "SetVariable",
+    "dependsOn": [],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "endDate",
+        "value": {
+            "value": "@addDays(startOfMonth(convertFromUtc(pipeline().TriggerTime, 'W. Europe Standard Time')), -1)",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "StartDate",
+    "description": "mi calcolo la data di inzio della query mese precedente primo giorno",
+    "type": "SetVariable",
+    "dependsOn": [
+        {
+            "activity": "EndDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "startDate",
+        "value": {
+            "value": "@startOfMonth(variables('endDate'))",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "ForEachKPI",
+    "type": "ForEach",
+    "dependsOn": [
+        {
+            "activity": "QueryTPNP",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "items": {
+            "value": "@activity('QueryTPNP').output.value",
+            "type": "Expression"
+        },
+        "isSequential": true,
+        "activities": [
+            {
+                "name": "GetKPI",
+                "type": "SetVariable",
+                "dependsOn": [],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "item",
+                    "value": {
+                        "value": "@concat(item().KPI, ',')",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "ConcatKPI",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "GetKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonChunk",
+                    "value": {
+                        "value": "@concat(variables('JsonResult'), variables('Item'))",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "SetJsonResult",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "ConcatKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonResult",
+                    "value": {
+                        "value": "@variables('JsonChunk')",
+                        "type": "Expression"
+                    }
+                }
+            }
+        ]
+    }
+},
+{
+    "name": "CheckResult",
+    "type": "IfCondition",
+    "dependsOn": [
+        {
+            "activity": "ForEachKPI",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "expression": {
+            "value": "@greater(length(variables('JsonResult')), 0)",
+            "type": "Expression"
+        },
+        "ifTrueActivities": [
+            {
+                "name": "WriteEvhub",
+                "type": "WebActivity",
+                "dependsOn": [],
+                "policy": {
+                    "timeout": "0.12:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "method": "POST",
+                    "url": {
+                        "value": "@pipeline().globalParameters.evhBaseUrl",
+                        "type": "Expression"
+                    },
+                    "connectVia": {
+                        "referenceName": "AutoResolveIntegrationRuntime",
+                        "type": "IntegrationRuntimeReference"
+                    },
+                    "body": {
+                        "value": "@json(concat('[', variables('JsonResult'), ']'))",
+                        "type": "Expression"
+                    },
+                    "authentication": {
+                        "type": "MSI",
+                        "resource": {
+                            "value": "@concat(pipeline().globalParameters.evhBaseUrl, '/quality-improvement-psp-kpi/messages')",
+                            "type": "Expression"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/domains/observability/datafactory/pipelines/PDND_KPI_WAFDR.json
+++ b/src/domains/observability/datafactory/pipelines/PDND_KPI_WAFDR.json
@@ -1,0 +1,222 @@
+{
+    "name": "QueryWAFDR",
+    "type": "Lookup",
+    "dependsOn": [
+        {
+            "activity": "StartDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "timeout": "0.12:00:00",
+        "retry": 0,
+        "retryIntervalInSeconds": 30,
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "source": {
+            "type": "AzureDataExplorerSource",
+            "query": {
+                "value": "let start=datetime('@{variables('startDate')}');\nlet end=datetime('@{variables('endDate')}');\n\nKPI_RENDICONTAZIONI\n| where GIORNATA_PAGAMENTO between (start .. end)\n| summarize TOTALE_FLUSSI=sum(TOTALE_FLUSSI), TOTALE_DIFF_AMOUNT=sum(TOTALE_DIFF_AMOUNT) by ID_PSP, ID_BROKER_PSP\n| join kind=inner PSP on $left.ID_PSP == $right.ID_PSP\n| join kind=inner INTERMEDIARI_PSP on $left.ID_BROKER_PSP == $right.ID_INTERMEDIARIO_PSP\n| extend kpi_id =\"WAFDR\"\n| extend PERC_KPII=(TOTALE_DIFF_AMOUNT * 100.00) / TOTALE_FLUSSI\n| extend PERC_KPI=round( case(isnan(PERC_KPII), 0.00, PERC_KPII),2)\n| extend kpi_threshold=1.0\n| extend kpi_outcome = iff(PERC_KPI > kpi_threshold,\"KO\",\"OK\")\n| project kpi_id, kpi_threshold,start , end , TOTALE_FLUSSI,TOTALE_DIFF_AMOUNT,PERC_KPI,kpi_outcome,psp_id=ID_PSP,psp_company_name=iif(DESCRIZIONE <> '' , DESCRIZIONE,RAGIONE_SOCIALE) ,psp_broker_id=ID_BROKER_PSP, psp_broker_company_name=INTERMEDIARIO_DESCR\n| project KPI=pack_all()",
+                "type": "Expression"
+            },
+            "queryTimeout": "01:00:00",
+            "noTruncation": true
+        },
+        "dataset": {
+            "referenceName": "SMO_KPI_RENDICONTAZIONI_DataSet",
+            "type": "DatasetReference"
+        },
+        "firstRowOnly": false
+    }
+},
+{
+    "name": "EndDate",
+    "description": "Ricavo la data fine per prendere la mensilità\n",
+    "type": "SetVariable",
+    "dependsOn": [],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "endDate",
+        "value": {
+            "value": "@addDays(startOfMonth(convertFromUtc(pipeline().TriggerTime, 'W. Europe Standard Time')), -1)",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "StartDate",
+    "description": "mi calcolo la data di inzio della query mese precedente primo giorno",
+    "type": "SetVariable",
+    "dependsOn": [
+        {
+            "activity": "EndDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "startDate",
+        "value": {
+            "value": "@startOfMonth(variables('endDate'))",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "ForEachKPI",
+    "type": "ForEach",
+    "dependsOn": [
+        {
+            "activity": "QueryWAFDR",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "items": {
+            "value": "@activity('QueryWAFDR').output.value",
+            "type": "Expression"
+        },
+        "isSequential": true,
+        "activities": [
+            {
+                "name": "GetKPI",
+                "type": "SetVariable",
+                "dependsOn": [],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "item",
+                    "value": {
+                        "value": "@concat(item().KPI, ',')",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "ConcatKPI",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "GetKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonChunk",
+                    "value": {
+                        "value": "@concat(variables('JsonResult'), variables('Item'))",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "SetJsonResult",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "ConcatKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonResult",
+                    "value": {
+                        "value": "@variables('JsonChunk')",
+                        "type": "Expression"
+                    }
+                }
+            }
+        ]
+    }
+},
+{
+    "name": "CheckResult",
+    "type": "IfCondition",
+    "dependsOn": [
+        {
+            "activity": "ForEachKPI",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "expression": {
+            "value": "@greater(length(variables('JsonResult')), 0)",
+            "type": "Expression"
+        },
+        "ifTrueActivities": [
+            {
+                "name": "WriteEvhub",
+                "type": "WebActivity",
+                "dependsOn": [],
+                "policy": {
+                    "timeout": "0.12:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "method": "POST",
+                    "url": {
+                        "value": "@pipeline().globalParameters.evhBaseUrl",
+                        "type": "Expression"
+                    },
+                    "connectVia": {
+                        "referenceName": "AutoResolveIntegrationRuntime",
+                        "type": "IntegrationRuntimeReference"
+                    },
+                    "body": {
+                        "value": "@json(concat('[', variables('JsonResult'), ']'))",
+                        "type": "Expression"
+                    },
+                    "authentication": {
+                        "type": "MSI",
+                        "resource": {
+                            "value": "@concat(pipeline().globalParameters.evhBaseUrl, '/quality-improvement-psp-kpi/messages')",
+                            "type": "Expression"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/domains/observability/datafactory/pipelines/PDND_KPI_WPNFDR.json
+++ b/src/domains/observability/datafactory/pipelines/PDND_KPI_WPNFDR.json
@@ -1,0 +1,222 @@
+{
+    "name": "QueryWPNFDR",
+    "type": "Lookup",
+    "dependsOn": [
+        {
+            "activity": "StartDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "timeout": "0.12:00:00",
+        "retry": 0,
+        "retryIntervalInSeconds": 30,
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "source": {
+            "type": "AzureDataExplorerSource",
+            "query": {
+                "value": "let start=datetime('@{variables('startDate')}');\nlet end=datetime('@{variables('endDate')}');\n\nKPI_RENDICONTAZIONI\n| where GIORNATA_PAGAMENTO between (start .. end)\n| summarize TOTALE_FLUSSI=sum(TOTALE_FLUSSI), TOTALE_DIFF_NUM=sum(TOTALE_DIFF_NUM) by ID_PSP, ID_BROKER_PSP\n| join kind=inner PSP on $left.ID_PSP == $right.ID_PSP\n| join kind=inner INTERMEDIARI_PSP on $left.ID_BROKER_PSP == $right.ID_INTERMEDIARIO_PSP\n| extend kpi_id =\"WPNFDR\"\n| extend PERC_KPII=(TOTALE_DIFF_NUM * 100.00) / TOTALE_FLUSSI\n| extend PERC_KPI=round( case(isnan(PERC_KPII), 0.00, PERC_KPII),2)\n| extend kpi_threshold=1.0\n| extend kpi_outcome = iff(PERC_KPI > kpi_threshold,\"KO\",\"OK\")\n| project kpi_id, kpi_threshold,start , end , TOTALE_FLUSSI,TOTALE_DIFF_NUM,PERC_KPI,kpi_outcome,psp_id=ID_PSP,psp_company_name=iif(DESCRIZIONE <> '' , DESCRIZIONE,RAGIONE_SOCIALE) ,psp_broker_id=ID_BROKER_PSP, psp_broker_company_name=INTERMEDIARIO_DESCR\n| project KPI=pack_all()\n",
+                "type": "Expression"
+            },
+            "queryTimeout": "01:00:00",
+            "noTruncation": true
+        },
+        "dataset": {
+            "referenceName": "SMO_KPI_RENDICONTAZIONI_DataSet",
+            "type": "DatasetReference"
+        },
+        "firstRowOnly": false
+    }
+},
+{
+    "name": "EndDate",
+    "description": "Ricavo la data fine per prendere la mensilità\n",
+    "type": "SetVariable",
+    "dependsOn": [],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "endDate",
+        "value": {
+            "value": "@addDays(startOfMonth(convertFromUtc(pipeline().TriggerTime, 'W. Europe Standard Time')), -1)",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "StartDate",
+    "description": "mi calcolo la data di inzio della query mese precedente primo giorno",
+    "type": "SetVariable",
+    "dependsOn": [
+        {
+            "activity": "EndDate",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "policy": {
+        "secureOutput": false,
+        "secureInput": false
+    },
+    "userProperties": [],
+    "typeProperties": {
+        "variableName": "startDate",
+        "value": {
+            "value": "@startOfMonth(variables('endDate'))",
+            "type": "Expression"
+        }
+    }
+},
+{
+    "name": "ForEachKPI",
+    "type": "ForEach",
+    "dependsOn": [
+        {
+            "activity": "QueryWPNFDR",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "items": {
+            "value": "@activity('QueryWPNFDR').output.value",
+            "type": "Expression"
+        },
+        "isSequential": true,
+        "activities": [
+            {
+                "name": "GetKPI",
+                "type": "SetVariable",
+                "dependsOn": [],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "item",
+                    "value": {
+                        "value": "@concat(item().KPI, ',')",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "ConcatKPI",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "GetKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonChunk",
+                    "value": {
+                        "value": "@concat(variables('JsonResult'), variables('Item'))",
+                        "type": "Expression"
+                    }
+                }
+            },
+            {
+                "name": "SetJsonResult",
+                "type": "SetVariable",
+                "dependsOn": [
+                    {
+                        "activity": "ConcatKPI",
+                        "dependencyConditions": [
+                            "Succeeded"
+                        ]
+                    }
+                ],
+                "policy": {
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "variableName": "jsonResult",
+                    "value": {
+                        "value": "@variables('JsonChunk')",
+                        "type": "Expression"
+                    }
+                }
+            }
+        ]
+    }
+},
+{
+    "name": "CheckResult",
+    "type": "IfCondition",
+    "dependsOn": [
+        {
+            "activity": "ForEachKPI",
+            "dependencyConditions": [
+                "Succeeded"
+            ]
+        }
+    ],
+    "userProperties": [],
+    "typeProperties": {
+        "expression": {
+            "value": "@greater(length(variables('JsonResult')), 0)",
+            "type": "Expression"
+        },
+        "ifTrueActivities": [
+            {
+                "name": "WriteEvhub",
+                "type": "WebActivity",
+                "dependsOn": [],
+                "policy": {
+                    "timeout": "0.12:00:00",
+                    "retry": 0,
+                    "retryIntervalInSeconds": 30,
+                    "secureOutput": false,
+                    "secureInput": false
+                },
+                "userProperties": [],
+                "typeProperties": {
+                    "method": "POST",
+                    "url": {
+                        "value": "@pipeline().globalParameters.evhBaseUrl",
+                        "type": "Expression"
+                    },
+                    "connectVia": {
+                        "referenceName": "AutoResolveIntegrationRuntime",
+                        "type": "IntegrationRuntimeReference"
+                    },
+                    "body": {
+                        "value": "@json(concat('[', variables('JsonResult'), ']'))",
+                        "type": "Expression"
+                    },
+                    "authentication": {
+                        "type": "MSI",
+                        "resource": {
+                            "value": "@concat(pipeline().globalParameters.evhBaseUrl, '/quality-improvement-psp-kpi/messages')",
+                            "type": "Expression"
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Added resource definitions for quality improvement DataFactory pipelines to transfer PSP KPI to Data Lake, below the pipeline resource list:

- PDND_KPI_DASPO
- PDND_KPI_LFDR
- PDND_KPI_LSPO
- PDND_KPI_NRFDR
- PDND_KPI_TNSPO
- PDND_KPI_TPNP
- PDND_KPI_WAFDR
- PDND_KPI_WPNFDR

<!--- Describe your changes in detail -->

### Motivation and context

In the context of Quality Improvement initiative, it's necessary to transfer all computed PSP KPI (performance & FdR) to Data Lake

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
