### PR TITLE
feat: NOD-724: add secret db nodo offline Nexi

### DIFF
--- a/src/domains/nodo-secret/secret/weu-dev/noedit_secret_enc.json
+++ b/src/domains/nodo-secret/secret/weu-dev/noedit_secret_enc.json
@@ -35,6 +35,7 @@
 	"slack-webhook-url": "ENC[AES256_GCM,data:Qbd8QIYRnJrZSXbvjBADUgIgykFnZ6F8BixM9g08qSXlNAUFSgyK0zGtQevXS/f6y81MDX5eLduVC+UutFh+p/04z8AJOv3PEwd12wFgHg==,iv:TUYflLPfX6eWNw4wHxwOP6TGbKJy7DfPi7ogGcapORg=,tag:t+NOodkmjeRjV2WTHEhYFw==,type:str]",
 	"db-sync-password": "ENC[AES256_GCM,data:lXdtS+n4X1UB2BoJM2PT,iv:MWIA3RCYyoimu8rJqR5uPAO8YL25FUKo1N/nLvRXvFc=,tag:O3VvMpQjwKmQZyUxZYAZiA==,type:str]",
 	"db-nexi-cfg-password": "ENC[AES256_GCM,data:WjkmxMzvilfTZHFi,iv:wttmezAMFnIbA5MyGxnGjYIwzW7zh+U27pdIdZa/gsI=,tag:cjX42xdWD/I3xs/KYdDMYw==,type:str]",
+	"db-nexi-offline-password": "ENC[AES256_GCM,data:UqC7ty9/sbRPLiFy,iv:Lp/2bw/qhshlxEcI3u9UJvLNAywNugwM41D38gdVIBg=,tag:chKrV0vMwVq6dmP6LT3qlg==,type:str]",
 	"cosmos-verifyko-account-key": "ENC[AES256_GCM,data:X8liiYviw0s2BOsYqVtErPRUZbsoOv9poJh6BXg/4HIAWelFM13B2O1onzMCqSLTi3oBSMuOnZM2pTWrm+dRA0rF4TQbFVipjX6Poaag+c9IaHkjrhNJ6w==,iv:JivBPHoLLQD1SgOrSmw/DhA0vV+87oYx8i5YJ6T5CLU=,tag:h1Z0/jRA0DM2r8cGNmKPiQ==,type:str]",
 	"cosmos-standin-account-key": "ENC[AES256_GCM,data:e5Q8GyhaFaLKVV5RJXFaNeeVQYFbcSrczdyepS/R9vhkjsaNFecJNKodiwZi5j0XlCwXEekLoYZsMaGP9tw/9ot0r+6ntP+z4/PNLfJ/IgxvhKPhJ2DpIw==,iv:vHfP5bDRBpJ356OAqRuOiRmBAGMRpLkOl5mQqlE/wY4=,tag:vMEYVJqsVvJn7Bz+/WzihQ==,type:str]",
 	"standin-aws-ses-user": "ENC[AES256_GCM,data:u4dAOC9QIJup/d/3AtJarRLDcdHFvqdxyXQuT0suUVIISqvso+41,iv:nHyhM1WFVwq3MCHog711zdjGiDwpwLAkJwYDtDOBFWE=,tag:kEBwJ8vbHpZNlFpvcq0hKQ==,type:str]",
@@ -60,8 +61,8 @@
 		],
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2024-02-26T09:58:32Z",
-		"mac": "ENC[AES256_GCM,data:sqnzoyCnfH38h9hzBuZrC3wt/znD56kiAfngr4+SeiK+jV0xBBEebJcdenji7ZBkurRjgiuItGTEUCZhd0miuxWCixTaao/PX7l5TyGzMx55wgVXssWMBzgPkbUd29grZOXu8GHyJCHcg4skfhe8I/GXQ/GlmrWrHElT1Ji4C9s=,iv:/rqPwUgdEs2fcxS9FNpsRR7IKGJB3mkxAsBENAv0jA0=,tag:OtatxlKx6qKHe8dotzLP0A==,type:str]",
+		"lastmodified": "2024-03-13T16:40:30Z",
+		"mac": "ENC[AES256_GCM,data:dScyeFW63hbhz66bKGF497iD0lgZiTn8wgUdlv5InQnI5mMCd/kZ1ECK5o8QssFR/G0DaQqIAvHpILcv6TeaIhIXX/gnO6PNrV/cot2nfuI7ri9iERT6rGC+Rj4bpbtZ+s2qHV2DPaUKs+x1fhDiW3uYxUpPmAPV/zSb/8EcfWc=,iv:NmW11yD+2Y1/j/Yt9yEE9yg3r0kjvdaYFpfTA2dkeE4=,tag:0sZvBGrbArgxpmfpSaxfYQ==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.8.1"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

New secret _db-nexi-offline-password_ added. This secret is used by **pagopa-node-technical-support-worker** for connecting to Nexi database

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
