### PR TITLE
fix: set missing asset field

### DIFF
--- a/src/domains/ecommerce-app/api/ecommerce-io/v1/_calculate_fees_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-io/v1/_calculate_fees_policy.xml.tpl
@@ -131,6 +131,7 @@
                                     response["paymentMethodStatus"] = ((string)((JObject)context.Variables["paymentMethod"])["status"]);
                                     response["belowThreshold"] = false;
                                     response["bundles"] = (JArray)pspResponse;
+                                    response["asset"] = "https://assets.cdn.platform.pagopa.it/creditcard/generic.png";
                                     return response.ToString();
                                 }</set-body>
                         </return-response>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add missing `asset` field in calculate fees response for app IO with PM
<!--- Describe your changes in detail -->

### Motivation and context
Add missing `asset` field in calculate fees response for app IO with PM
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
