### PR TITLE
refactor: CHK-2645 Update ecommerce for checkout auth request policy to zero downtime pgs->npg

### DIFF
--- a/src/domains/ecommerce-app/04_apim_ecommerce_checkout.tf
+++ b/src/domains/ecommerce-app/04_apim_ecommerce_checkout.tf
@@ -135,7 +135,6 @@ resource "azurerm_api_management_api_operation_policy" "transaction_authorizatio
   xml_content = templatefile("./api/ecommerce-checkout/v1/_auth_request.xml.tpl", {
     ecommerce_xpay_psps_list = var.ecommerce_xpay_psps_list
     ecommerce_vpos_psps_list = var.ecommerce_vpos_psps_list
-    ecommerce_npg_psps_list  = var.ecommerce_npg_psps_list
   })
 }
 

--- a/src/domains/ecommerce-app/99_variables.tf
+++ b/src/domains/ecommerce-app/99_variables.tf
@@ -130,12 +130,6 @@ variable "ecommerce_vpos_psps_list" {
   default     = ""
 }
 
-variable "ecommerce_npg_psps_list" {
-  type        = string
-  description = "psps list using npg as comma separated value"
-  default     = ""
-}
-
 variable "dns_zone_checkout" {
   type        = string
   default     = null

--- a/src/domains/ecommerce-app/README.md
+++ b/src/domains/ecommerce-app/README.md
@@ -150,7 +150,6 @@
 | <a name="input_dns_zone_internal_prefix"></a> [dns\_zone\_internal\_prefix](#input\_dns\_zone\_internal\_prefix) | The dns subdomain. | `string` | `null` | no |
 | <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | n/a | yes |
 | <a name="input_ecommerce_io_with_pm_enabled"></a> [ecommerce\_io\_with\_pm\_enabled](#input\_ecommerce\_io\_with\_pm\_enabled) | ecommerce for IO using Payment Manager enabled | `bool` | `false` | no |
-| <a name="input_ecommerce_npg_psps_list"></a> [ecommerce\_npg\_psps\_list](#input\_ecommerce\_npg\_psps\_list) | psps list using npg as comma separated value | `string` | `""` | no |
 | <a name="input_ecommerce_vpos_psps_list"></a> [ecommerce\_vpos\_psps\_list](#input\_ecommerce\_vpos\_psps\_list) | psps list using vpos as comma separated value | `string` | `""` | no |
 | <a name="input_ecommerce_xpay_psps_list"></a> [ecommerce\_xpay\_psps\_list](#input\_ecommerce\_xpay\_psps\_list) | psps list using xpay as comma separated value | `string` | `""` | no |
 | <a name="input_env"></a> [env](#input\_env) | n/a | `string` | n/a | yes |

--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_auth_request.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_auth_request.xml.tpl
@@ -21,7 +21,6 @@
         <!-- START set pgsId -->
         <set-variable name="XPAYPspsList" value="${ecommerce_xpay_psps_list}"/>
         <set-variable name="VPOSPspsList" value="${ecommerce_vpos_psps_list}"/>
-        <set-variable name="NPGPspsList" value="${ecommerce_npg_psps_list}"/>
         <set-variable name="requestBody" value="@((JObject)context.Request.Body.As<JObject>(true))" />
 
         <set-variable name="pspId" value="@(((string)((JObject)context.Variables["requestBody"])["pspId"]))"/>
@@ -39,7 +38,6 @@
             string pgsId = "";
 
             // card -> ecommerce with PGS request
-            
             if ( detailType == "card" ){                                    
 
                 if (xpayList.Contains(pspId)) {
@@ -50,17 +48,16 @@
                     pgsId = "VPOS";
                 }
 
-            // cards -> ecommerce with NPG request
-
-            } else if ( detailType == "cards" && npgList.Contains(pspId)){      
+            // cards or apm -> ecommerce with NPG request
+            } else if ( detailType == "cards" || detailType == "apm"){      
              
                 pgsId = "NPG";
 
             // redirect -> ecommerce with redirect
             } else if ( detailType == "redirect"){      
 
-                pgsId = "REDIRECT";
-            }
+                pgsId = "REDIRECT";            
+            } 
 
             return pgsId;
         }"/>

--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_auth_request.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_auth_request.xml.tpl
@@ -59,7 +59,7 @@
             // redirect -> ecommerce with redirect
             } else if ( detailType == "redirect"){      
 
-                pgsId = "redirect";
+                pgsId = "REDIRECT";
             }
 
             return pgsId;

--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_auth_request.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_auth_request.xml.tpl
@@ -53,7 +53,13 @@
             // cards -> ecommerce with NPG request
 
             } else if ( detailType == "cards" && npgList.Contains(pspId)){      
+             
                 pgsId = "NPG";
+
+            // redirect -> ecommerce with redirect
+            } else if ( detailType == "redirect"){      
+
+                pgsId = "redirect";
             }
 
             return pgsId;

--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_auth_request.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_auth_request.xml.tpl
@@ -30,7 +30,6 @@
             
             string[] xpayList = ((string)context.Variables["XPAYPspsList"]).Split(',');
             string[] vposList = ((string)context.Variables["VPOSPspsList"]).Split(',');
-            string[] npgList = ((string)context.Variables["NPGPspsList"]).Split(',');
             
             string pspId = (string)(context.Variables.GetValueOrDefault("pspId",""));
             string detailType = (string)(context.Variables.GetValueOrDefault("detailType",""));

--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_auth_request.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_auth_request.xml.tpl
@@ -18,26 +18,47 @@
         }
         return "";
         }"/>
+        <!-- START set pgsId -->
         <set-variable name="XPAYPspsList" value="${ecommerce_xpay_psps_list}"/>
         <set-variable name="VPOSPspsList" value="${ecommerce_vpos_psps_list}"/>
         <set-variable name="NPGPspsList" value="${ecommerce_npg_psps_list}"/>
-        <set-variable name="pspId" value="@(((string)((JObject)context.Request.Body.As<JObject>(preserveContent: true))["pspId"]))"/>
+        <set-variable name="requestBody" value="@((JObject)context.Request.Body.As<JObject>(true))" />
+
+        <set-variable name="pspId" value="@(((string)((JObject)context.Variables["requestBody"])["pspId"]))"/>
+        <set-variable name="detailType" value="@((string)((JObject)((JObject)context.Variables["requestBody"])["details"])["detailType"])"/>
+
         <set-variable name="pgsId" value="@{
-        string[] xpayList = ((string)context.Variables["XPAYPspsList"]).Split(',');
-        string[] vposList = ((string)context.Variables["VPOSPspsList"]).Split(',');
-        string[] npgList = ((string)context.Variables["NPGPspsList"]).Split(',');
-        string pspId = (string)(context.Variables.GetValueOrDefault("pspId",""));
-        if (xpayList.Contains(pspId)) {
-            return "XPAY";
-        }
-        if (vposList.Contains(pspId)) {
-            return "VPOS";
-        }
-        if (npgList.Contains(pspId)) {
-            return "NPG";
-        }
-        return "";
-    }"/>
+            
+            string[] xpayList = ((string)context.Variables["XPAYPspsList"]).Split(',');
+            string[] vposList = ((string)context.Variables["VPOSPspsList"]).Split(',');
+            string[] npgList = ((string)context.Variables["NPGPspsList"]).Split(',');
+            
+            string pspId = (string)(context.Variables.GetValueOrDefault("pspId",""));
+            string detailType = (string)(context.Variables.GetValueOrDefault("detailType",""));
+            
+            string pgsId = "";
+
+            // card -> ecommerce with PGS request
+            
+            if ( detailType == "card" ){                                    
+
+                if (xpayList.Contains(pspId)) {
+
+                    pgsId = "XPAY";
+                } else if (vposList.Contains(pspId)) {
+
+                    pgsId = "VPOS";
+                }
+
+            // cards -> ecommerce with NPG request
+
+            } else if ( detailType == "cards" && npgList.Contains(pspId)){      
+                pgsId = "NPG";
+            }
+
+            return pgsId;
+        }"/>
+        <!-- END set pgsId -->
         <choose>
             <when condition="@((string)context.Variables.GetValueOrDefault("tokenTransactionId","") != (string)context.Variables.GetValueOrDefault("requestTransactionId",""))">
                 <return-response>

--- a/src/domains/ecommerce-app/env/weu-dev/terraform.tfvars
+++ b/src/domains/ecommerce-app/env/weu-dev/terraform.tfvars
@@ -35,7 +35,6 @@ tls_cert_check_helm = {
 
 ecommerce_xpay_psps_list = "XPAY,IDPSPFNZ,60000000001"
 ecommerce_vpos_psps_list = "PSPtest1,CHARITY_AMEX,CHARITY_IDPSPFNZ,CHARITY_ISP,40000000001,DINERS,MARIOGAM,73473473473,PAYTITM1,POSTE1,ProvaCDI,50000000001,70000000001,10000000001,idPsp2,irraggiungibile_wisp,prova_ila_1,pspStress50,pspStress79,pspStress80,pspStress81"
-ecommerce_npg_psps_list  = "BCITITMM,CIPBITMM,BIC36019,UNCRITMM,BPPIITRRXXX,PPAYITR1XXX,BNLIITRR,POSOIT22XXX"
 
 dns_zone_checkout = "dev.checkout"
 

--- a/src/domains/ecommerce-app/env/weu-prod/terraform.tfvars
+++ b/src/domains/ecommerce-app/env/weu-prod/terraform.tfvars
@@ -44,7 +44,6 @@ ecommerce_xpay_psps_list = "CIPBITMM"
 # - PPAYITR1XXX (POSTEPAY)
 # - BIC36019 (AMEX)
 ecommerce_vpos_psps_list = "BNLIITRR,BCITITMM,UNCRITMM,BPPIITRRXXX,PPAYITR1XXX,BIC36019"
-ecommerce_npg_psps_list  = ""
 
 dns_zone_checkout = "checkout"
 

--- a/src/domains/ecommerce-app/env/weu-uat/terraform.tfvars
+++ b/src/domains/ecommerce-app/env/weu-uat/terraform.tfvars
@@ -35,7 +35,6 @@ tls_cert_check_helm = {
 
 ecommerce_xpay_psps_list = ""
 ecommerce_vpos_psps_list = ""
-ecommerce_npg_psps_list  = "CIPBITMM,BNLIITRR,BCITITMM,UNCRITMM,BPPIITRRXXX,PPAYITR1XXX,BIC36019,POSOIT22XXX"
 
 dns_zone_checkout = "uat.checkout"
 

--- a/src/domains/ecommerce-app/env/weu-uat/terraform.tfvars
+++ b/src/domains/ecommerce-app/env/weu-uat/terraform.tfvars
@@ -33,8 +33,8 @@ tls_cert_check_helm = {
   image_tag     = "v1.2.2@sha256:22f4b53177cc8891bf10cbd0deb39f60e1cd12877021c3048a01e7738f63e0f9"
 }
 
-ecommerce_xpay_psps_list = ""
-ecommerce_vpos_psps_list = ""
+ecommerce_xpay_psps_list = "CIPBITMM"
+ecommerce_vpos_psps_list = "BNLIITRR,BCITITMM,UNCRITMM,BPPIITRRXXX,PPAYITR1XXX,BIC36019"
 
 dns_zone_checkout = "uat.checkout"
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- Update ecommerce for checkout auth request policy to zero downtime pgs->npg

### Motivation and context

The goal of this PR is to refactor the policy for selecting the `pgsId` for the `checkout` flow with `eCommerce` to ensure zero downtime during the migration from `eCommerce` with `PGS` to `eCommerce` with `NPG`. So, the selection of the `pgsId` is based on the value of the `detailsType`, where `"card"` indicates a `PGS` flow, while `"cards"` indicates a `NPG` flow.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
