### PR TITLE
[CHK-2717] fix(notification): Check additionalData field not null

### DIFF
--- a/src/domains/wallet-app/api/npg-notifications/v1/_base_policy.xml.tpl
+++ b/src/domains/wallet-app/api/npg-notifications/v1/_base_policy.xml.tpl
@@ -46,7 +46,7 @@
                 DateTimeOffset dateTimeOffset = new DateTimeOffset(utcDateTime);
                 timestampOperation = dateTimeOffset.ToString("o");
             }
-            if(additionalData.Type != JTokenType.Null){
+            if(additionalData != null && additionalData.Type != JTokenType.Null){
                 JObject receivedAdditionalData = (JObject)additionalData;
                 errorCode = (string)receivedAdditionalData["authorizationStatus"];
                 cardId4 = (string)((JObject)additionalData)["cardId4"];


### PR DESCRIPTION
Check if `additionalData` field is null before reading it.
This checking is needed to make paypal onboarding work

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
