### PR TITLE
[CHK-2732] fix(openapi): missing field in payment method response

### DIFF
--- a/src/domains/wallet-app/api/payment-wallet/v1/_openapi.json.tpl
+++ b/src/domains/wallet-app/api/payment-wallet/v1/_openapi.json.tpl
@@ -843,6 +843,9 @@
             "type": "string",
             "description": "Payment method type code"
           },
+          "methodManagement": {
+            "$ref": "#/components/schemas/PaymentMethodManagementType"
+          },
           "ranges": {
             "description": "Payment amount range in eurocents",
             "type": "array",
@@ -865,7 +868,8 @@
           "description",
           "status",
           "paymentTypeCode",
-          "ranges"
+          "ranges",
+          "methodManagement"
         ]
       },
       "PaymentMethodStatus": {
@@ -875,6 +879,15 @@
           "ENABLED",
           "DISABLED",
           "INCOMING"
+        ]
+      },
+      "PaymentMethodManagementType": {
+        "type": "string",
+        "description": "Payment method management type",
+        "enum": [
+          "ONBOARDABLE",
+          "NOT_ONBOARDABLE",
+          "REDIRECT"
         ]
       },
       "Range": {


### PR DESCRIPTION
add missing field `methodManagement` and type to GET payment-method exposed for wallet

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
