### PR TITLE
feat(closepayment-spec): add missing fields for close payment

### DIFF
--- a/src/core/api/nodopagamenti_api/nodoPerPM/v2/_openapi.json.tpl
+++ b/src/core/api/nodopagamenti_api/nodoPerPM/v2/_openapi.json.tpl
@@ -131,12 +131,6 @@
       },
       "CardAdditionalPaymentInformations": {
         "type": "object",
-        "required": [
-          "outcomePaymentGateway",
-          "fee",
-          "totalAmount",
-          "timestampOperation"
-        ],
         "properties": {
           "outcomePaymentGateway": {
             "type": "string",
@@ -174,8 +168,18 @@
           "eMail": {
             "type": "string",
             "description": "User email used for the transaction outcome notification"
+          },
+          "paymentGateway": {
+            "type": "string",
+            "description": "Transaction payment gateway"
           }
-        }
+        },
+        "required": [
+          "outcomePaymentGateway",
+          "fee",
+          "totalAmount",
+          "timestampOperation"
+        ]
       },
       "RedirectAdditionalPaymentInformations": {
         "type": "object",
@@ -862,7 +866,9 @@
           "transactionId",
           "transactionStatus",
           "amount",
-          "grandTotal"
+          "grandTotal",
+          "paymentGateway",
+          "timestampOperation"
         ],
         "type": "object",
         "properties": {
@@ -923,7 +929,8 @@
           "brokerName",
           "businessName",
           "idChannel",
-          "idPsp"
+          "idPsp",
+          "pspOnUs"
         ],
         "type": "object",
         "properties": {
@@ -969,6 +976,15 @@
           },
           "clientId": {
             "type": "string"
+          },
+          "bin": {
+            "type": "string"
+          },
+          "lastFourDigits": {
+            "type": "string"
+          },
+          "maskedEmail": {
+            "type": "string"
           }
         }
       },
@@ -978,10 +994,17 @@
           "type": {
             "type": "string",
             "enum": [
-              "GUEST"
+              "GUEST",
+              "REGISTERED"
             ]
+          },
+          "fiscalCode": {
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "type"
+        ]
       }
     }
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add missing fields for ClosePayment requests:

`transactionDetails.info`:

- bin (valued only for onboarded card payment)
- lastFourDigits (valued only for onboarded card payment)
- maskedEmail (valued only for onboarded paypal payment)

transactionDetails.user:

- add fiscalCode (valued only for user registered transaction)
- add REGISTERED type

<!--- Describe your changes in detail -->

### Motivation and context
Add missing close payment request fields to reflect the last specifications
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
