### PR TITLE
chore(GPD): federated identity and alert tuning [PAGOPA-1668]

### DIFF
--- a/src/domains/gps-app/00_alert_gpd_payments.tf
+++ b/src/domains/gps-app/00_alert_gpd_payments.tf
@@ -65,7 +65,7 @@ AzureDiagnostics
   time_window = 5
   trigger {
     operator  = "GreaterThanOrEqual"
-    threshold = 1
+    threshold = 2
   }
 }
 

--- a/src/domains/gps-common/10_github_identity.tf
+++ b/src/domains/gps-common/10_github_identity.tf
@@ -12,7 +12,8 @@ locals {
   repos_01 = [
     "pagopa-gpd-upload",
     "pagopa-gpd-upload-function",
-    "pagopa-gpd-payments-pull"
+    "pagopa-gpd-payments-pull",
+    "pagopa-gps-donation-service"
   ]
 
   federations_01 = [


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- `pagopa-gps-donation-service` federated identity has been added
- `pagopa-gpd-payments` alert on SOAP-API availability has been adjusted

apply with 
`sh terraform.sh apply weu-${env} --target=module.identity_cd_01 --target=azurerm_key_vault_access_policy.gha_iac_managed_identities`

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

- `pagopa-gps-donation-service` needs to be updated for the deployment pipeline that uses federated-identity
- when the traffic load is low there are false positives for the `pagopa-gpd-payments` alert

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
