### PR TITLE
[CHK-2665] fix(auth-request): set user id in get wallet request in post auth request

### DIFF
--- a/src/domains/ecommerce-app/api/ecommerce-io/v1/_auth_request.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-io/v1/_auth_request.xml.tpl
@@ -143,6 +143,9 @@
                         <send-request response-variable-name="walletResponse" timeout="10">
                             <set-url>@($"https://${wallet-basepath}/pagopa-wallet-service/wallets/{(string)context.Variables["walletId"]}")</set-url>
                             <set-method>GET</set-method>
+                            <set-header name="x-user-id" exists-action="override">
+                                <value>@((string)context.Variables.GetValueOrDefault("xUserId",""))</value>
+                            </set-header>
                         </send-request>
                         <choose>
                             <when condition="@(((int)((IResponse)context.Variables["walletResponse"]).StatusCode) == 200)">

--- a/src/domains/ecommerce-app/api/ecommerce-io/v1/_auth_request.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-io/v1/_auth_request.xml.tpl
@@ -2,6 +2,7 @@
     <inbound>
         <base />
         <set-header name="x-pgs-id" exists-action="delete" />
+        <set-header name="x-user-id" exists-action="delete" />
         <set-variable name="sessionToken" value="@(context.Request.Headers.GetValueOrDefault("Authorization", "").Replace("Bearer ",""))" />
         <set-variable name="body" value="@(context.Request.Body.As<JObject>(preserveContent: true))" />
         <set-variable name="walletId" value="@((string)((JObject) context.Variables["body"])["details"]["walletId"])" />

--- a/src/domains/wallet-app/api/payment-wallet/v1/_base_policy.xml.tpl
+++ b/src/domains/wallet-app/api/payment-wallet/v1/_base_policy.xml.tpl
@@ -1,6 +1,7 @@
 <policies>
     <inbound>
       <base />
+      <set-header name="x-user-id" exists-action="delete" />
       <set-backend-service base-url="https://${hostname}/pagopa-wallet-service" />
       <set-header name="x-client-id" exists-action="override">
           <value>IO</value>


### PR DESCRIPTION
Since get wallet by id is protected by userId check, this parameter has to be put in the auth request policy GET wallet by id api invocation

### List of changes

- auth-request policy

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
