### PR TITLE
[CHK-2757] Add contract hmac optional header for cstar migration

### DIFF
--- a/src/domains/wallet-app/api/payment-wallet-migrations-for-cstar/v1/_openapi.json.tpl
+++ b/src/domains/wallet-app/api/payment-wallet-migrations-for-cstar/v1/_openapi.json.tpl
@@ -31,6 +31,16 @@
         "summary": "Update wallet details by Payment Manager.",
         "description": "Update Wallet with its details by Payment Manager during the migration process. Also the Wallet goes to VALIDATED status.\n",
         "operationId": "updateWalletDetailsByPM",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-contract-hmac",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "description": "Wallet details by Payment Manager",
           "content": {
@@ -105,6 +115,16 @@
         "summary": "Remove existing Wallet from given ContractId",
         "description": "Remove an existing Wallet associated from given ContractId. The status of Wallet\nwill be move to DELETED.\n",
         "operationId": "removeWalletByPM",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-contract-hmac",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "description": "Contract Id associated to Wallet",
           "content": {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR updates openapi spec for migration by adding a new optional header x-contract-hmac provided by CSTAR during migration phase. The header allows to achieve better cross domain observability.

### List of changes
- add x-contract-hmac as optional header for CSTAR apis

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
