### PR TITLE
[CHK-2855] feat(ecommerce-helpdesk): add authorization and refund operation id in API when available

### DIFF
--- a/src/domains/ecommerce-app/api/ecommerce-helpdesk-api/v1/_openapi.json.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-helpdesk-api/v1/_openapi.json.tpl
@@ -840,6 +840,14 @@
           "authorizationCode": {
             "type": "string"
           },
+          "authorizationOperationId": {
+            "type": "string",
+            "description": "Operation id for authorization. Present only if the payment gateway is NPG"
+          },
+          "refundOperationId": {
+            "type": "string",
+            "description": "Operation id for refund. Present only if the payment gateway is NPG"
+          },
           "paymentMethodName": {
             "type": "string"
           },
@@ -878,6 +886,8 @@
           "grandTotal": 110,
           "rrn": "rrn",
           "authorizationCode": "auth code",
+          "authorizationOperationId": "009911013",
+          "refundOperationId": "645561643244",
           "paymentMethodName": "payment method name",
           "brand": "brand",
           "authorizationRequestId": "authorizationRequestId",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
<!--- Describe your changes in detail -->
 * add authorization and refund operation id in API when available

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
See pagopa/pagopa-ecommerce-helpdesk-service#107

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
