### PR TITLE
chore(shared-app): Authorizer migration to AKS [PAGOPA-1678] 

### DIFF
--- a/src/domains/shared-app/04_apim_statuspage.tf
+++ b/src/domains/shared-app/04_apim_statuspage.tf
@@ -124,7 +124,7 @@ module "apim_api_statuspage_api_v1" {
       "apiconfigcacheo"          = format("%s/api-config-cache/o", format(local.aks_path, "apiconfig"))
       "apiconfigcachep"          = format("%s/api-config-cache/p", format(local.aks_path, "apiconfig"))
       "apiconfigselfcare"        = format("%s/pagopa-api-config-selfcare-integration", format(local.aks_path, "apiconfig"))
-      "authorizer"               = format("%s/", data.azurerm_function_app.authorizer.default_hostname)
+      "authorizer"               = format("%s//authorizer-functions", format(local.aks_path, "shared"))
       "authorizerconfig"         = format("%s//authorizer-config", format(local.aks_path, "shared"))
       "bizevents"                = format("%s/pagopa-biz-events-service", format(local.aks_path, "bizevents"))
       "bizeventsdatastoreneg"    = format("%s/pagopa-negative-biz-events-datastore-service", format(local.aks_path, "bizevents"))

--- a/src/domains/shared-app/05_authorizer_functions.tf
+++ b/src/domains/shared-app/05_authorizer_functions.tf
@@ -1,6 +1,5 @@
-
+// todo: remove and destroy
 locals {
-
   authorizer_functions_app_settings = {
     linux_fx_version                    = "JAVA|11"
     FUNCTIONS_WORKER_RUNTIME            = "java"
@@ -22,7 +21,7 @@ locals {
     IS_EC_ENROLLED_SQL_QUERY = "SELECT VALUE COUNT(i) FROM c JOIN i IN c.authorization WHERE c.domain = {domain} AND ARRAY_CONTAINS(c.authorization, {organizationFiscalCode})"
   }
 }
-
+// todo: remove and destroy
 # Subnet to host authorizer function
 module "authorizer_functions_snet" {
   source                                    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet?ref=v6.6.0"
@@ -44,11 +43,11 @@ module "authorizer_functions_snet" {
     }
   }
 }
-
+// todo: remove and destroy
 data "azurerm_resource_group" "shared_rg" {
   name = "${local.project}-rg"
 }
-
+// todo: remove and destroy
 module "authorizer_function_app" {
   source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//function_app?ref=v7.29.0"
 
@@ -105,7 +104,7 @@ module "authorizer_function_app" {
 
   tags = var.tags
 }
-
+// todo: remove and destroy
 module "authorizer_function_app_slot_staging" {
   count = var.env_short == "p" ? 1 : 0
 
@@ -140,7 +139,7 @@ module "authorizer_function_app_slot_staging" {
 
   tags = var.tags
 }
-
+// todo: remove and destroy
 resource "azurerm_monitor_autoscale_setting" "authorizer_function" {
   count = var.env_short != "d" ? 1 : 0
 
@@ -203,7 +202,7 @@ resource "azurerm_monitor_autoscale_setting" "authorizer_function" {
     }
   }
 }
-
+// todo: remove and destroy
 data "azurerm_container_registry" "acr" {
   name                = local.acr_name
   resource_group_name = local.acr_resource_group_name

--- a/src/domains/shared-app/99_locals.tf
+++ b/src/domains/shared-app/99_locals.tf
@@ -38,8 +38,8 @@ locals {
   apim_hostname   = "api.${var.apim_dns_zone_prefix}.${var.external_domain}"
   shared_hostname = var.env == "prod" ? "weuprod.shared.internal.platform.pagopa.it" : "weu${var.env}.shared.internal.${var.env}.platform.pagopa.it"
 
-  cache_generator_hostname   = "${var.prefix}-${var.env_short}-${var.location_short}-shared-authorizer-fn.azurewebsites.net/api"
-  cache_generator_hostname_2 = "${var.prefix}-${var.env_short}-${var.location_short}-shared-authorizer-fn.azurewebsites.net"
+  cache_generator_hostname   = "${local.shared_hostname}/authorizer-functions/api"
+  cache_generator_hostname_2 = "${local.shared_hostname}/authorizer-functions"
 
   authorizer_config_hostname = "${local.shared_hostname}/authorizer-config"
 

--- a/src/domains/shared-common/.terraform.lock.hcl
+++ b/src/domains/shared-common/.terraform.lock.hcl
@@ -5,10 +5,6 @@ provider "registry.terraform.io/hashicorp/azuread" {
   version     = "2.21.0"
   constraints = "2.21.0"
   hashes = [
-    "h1:9gG6SWoUZZmmXbYBv6ra2RF5NYpamB9tGjsuBxrasFQ=",
-    "h1:KbY8dRdbfTwTzEBcdOFdD50JX8CUG5Mni25D2+k1rGc=",
-    "h1:akcofWscEl0ecIbf7lyEqRvPfOdA5q75EZvK8uSum1c=",
-    "h1:p9epRqujcxIMeT9THP0oNLGe4jjMBLjT5a7RntnFDaA=",
     "h1:qHYbB6LJsYPVUcd7QkZ5tU+IX+10VcUG4NzsmIuWdlE=",
     "zh:18c56e0478e8b3849f6d52f7e0ee495538e7fce66f22fc84a79599615e50ad1c",
     "zh:1b95ba8dddc46c744b2d2be7da6fafaa8ebd8368d46ff77416a95cb7d622251e",
@@ -29,10 +25,6 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.84.0"
   constraints = ">= 3.30.0, <= 3.84.0, <= 3.85.0"
   hashes = [
-    "h1:1Ucponuagrx5kNeIlcZwG2urqoRXBCTddDKqL265+xM=",
-    "h1:3KYwbI62e6u2f7ob9Ps8yahnIaNHkE56UsF0130zRzE=",
-    "h1:UJ3cVk6rVnpRjicml3wP66rYnsrdR5gkkmLpQw8wb/4=",
-    "h1:aoqNC2sfLKyblgQh0SfQW0BHl3UP1mMAUJLYLGG3PxE=",
     "h1:y/NWRLvnJmyJ5lf/AnLFy25jfyJqp6xwwxLxZnvovAs=",
     "zh:14a96daf672541dbc27137d9cc0a96a737710597262ecaaa64a328eb1174e5df",
     "zh:16d8e794fdd87ed8e64291fe8a617f420d8263f21672033333a020d06f4c9618",
@@ -53,11 +45,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version     = "3.1.1"
   constraints = "3.1.1"
   hashes = [
-    "h1:1J3nqAREzuaLE7x98LEELCCaMV6BRiawHSg9MmFvfQo=",
-    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
     "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
-    "h1:YvH6gTaQzGdNv+SKTZujU1O0bO+Pw6vJHOPhqgN8XNs=",
-    "h1:ZD4wyZ0KJzt5s2mD0xD7paJlVONNicLvZKdgtezz02I=",
     "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
     "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
     "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
@@ -77,10 +65,6 @@ provider "registry.terraform.io/integrations/github" {
   version     = "5.18.3"
   constraints = "5.18.3"
   hashes = [
-    "h1:+WUsuR5XPYdbKwQi13GxEVKRV+JgkRa3Bw/HaCG/oeM=",
-    "h1:EKpGchrcouicFulbwG00s3NmXWsDDnlhffWqnGANSQQ=",
-    "h1:WbZvLB2qXKVoh4BvOOwFfEds+SZQrkINfSAWPnWFxGo=",
-    "h1:Z/0vjFX80YzM3Oeq0mBbn4XYwb1POggjsu3RVQcbjNc=",
     "h1:rv3mwpUeJ0n13sY+KZMI25WAVCSeipX4n8JMWKD1XcE=",
     "zh:050b37d96628cb7451137755929ca8d21ea546bc46d11a715652584070e83ff2",
     "zh:053051061f1b7f7673b0ceffac1f239ba28b0e5b375999206fd39976e85d9f2b",

--- a/src/domains/shared-common/10_github_identity.tf
+++ b/src/domains/shared-common/10_github_identity.tf
@@ -12,7 +12,8 @@ locals {
   repos_01 = [
     "pagopa-shared-toolbox",
     "pagopa-platform-authorizer",
-    "pagopa-platform-authorizer-config"
+    "pagopa-platform-authorizer-config",
+    "pagopa-infra"
   ]
 
   federations_01 = [

--- a/src/domains/shared-common/10_github_identity.tf
+++ b/src/domains/shared-common/10_github_identity.tf
@@ -11,6 +11,8 @@ data "azurerm_kubernetes_cluster" "aks" {
 locals {
   repos_01 = [
     "pagopa-shared-toolbox",
+    "pagopa-platform-authorizer",
+    "pagopa-platform-authorizer-config"
   ]
 
   federations_01 = [


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Update cache_generator_hostname
- Remove and destroy function-app related modules

```
sh terraform.sh apply weu-{env} --target=azapi_resource.authorizer_fragment
```

```
sh terraform.sh apply weu-{env} --target=azurerm_key_vault_access_policy.gha_iac_managed_identities --target=module.identity_cd_01
```

```
sh terraform.sh apply weu-{env} --target=module.apim_api_statuspage_api_v1
```

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

The two functions `CacheNotifier` and `CacheGenerator` have been migrated to AKS

related to https://github.com/pagopa/pagopa-platform-authorizer/pull/33

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [x] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
