### PR TITLE
feat(mongo-wallet): CHK-2945 upgrade mongo 6 for wallet

### DIFF
--- a/src/domains/pay-wallet-common/03_cosmosdb.tf
+++ b/src/domains/pay-wallet-common/03_cosmosdb.tf
@@ -15,11 +15,11 @@ module "cosmosdb_account_mongodb" {
   resource_group_name = azurerm_resource_group.cosmosdb_pay_wallet_rg.name
   domain              = var.domain
 
-  offer_type           = var.cosmos_mongo_db_params.offer_type
-  kind                 = var.cosmos_mongo_db_params.kind
-  capabilities         = var.cosmos_mongo_db_params.capabilities
+  offer_type   = var.cosmos_mongo_db_params.offer_type
+  kind         = var.cosmos_mongo_db_params.kind
+  capabilities = var.cosmos_mongo_db_params.capabilities
   #mongo_server_version = var.cosmos_mongo_db_params.server_version
-  enable_free_tier     = var.cosmos_mongo_db_params.enable_free_tier
+  enable_free_tier = var.cosmos_mongo_db_params.enable_free_tier
 
   public_network_access_enabled     = var.cosmos_mongo_db_params.public_network_access_enabled
   private_endpoint_enabled          = var.cosmos_mongo_db_params.private_endpoint_enabled

--- a/src/domains/pay-wallet-common/03_cosmosdb.tf
+++ b/src/domains/pay-wallet-common/03_cosmosdb.tf
@@ -18,7 +18,7 @@ module "cosmosdb_account_mongodb" {
   offer_type           = var.cosmos_mongo_db_params.offer_type
   kind                 = var.cosmos_mongo_db_params.kind
   capabilities         = var.cosmos_mongo_db_params.capabilities
-  mongo_server_version = var.cosmos_mongo_db_params.server_version
+  #mongo_server_version = var.cosmos_mongo_db_params.server_version
   enable_free_tier     = var.cosmos_mongo_db_params.enable_free_tier
 
   public_network_access_enabled     = var.cosmos_mongo_db_params.public_network_access_enabled

--- a/src/domains/pay-wallet-common/env/itn-dev/terraform.tfvars
+++ b/src/domains/pay-wallet-common/env/itn-dev/terraform.tfvars
@@ -55,7 +55,7 @@ cosmos_mongo_db_params = {
     max_interval_in_seconds = 5
     max_staleness_prefix    = 100000
   }
-  server_version                   = "4.2"
+  server_version                   = "6.0"
   main_geo_location_zone_redundant = false
   enable_free_tier                 = false
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- upgrade pay-walet cosmos to mongo 6 

### Motivation and context

The goal of this PR is to exlude the mongo cosmos version for the `payment-wallet` as the terraform resource does not support version 6.

```
╷
│ Error: expected mongo_server_version to be one of ["3.2" "3.6" "4.0" "4.2"], got 6.0
│ 
│   with module.cosmosdb_account_mongodb[0].azurerm_cosmosdb_account.this,
│   on .terraform/modules/cosmosdb_account_mongodb/cosmosdb_account/main.tf line 11, in resource "azurerm_cosmosdb_account" "this":
│   11:   mongo_server_version = var.mongo_server_version
```

The version has been updated from the portal.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
