### PR TITLE
feat(wallet-common & pay-wallet-common): add expiration storage queue

### DIFF
--- a/src/domains/pay-wallet-common/03_storage.tf
+++ b/src/domains/pay-wallet-common/03_storage.tf
@@ -68,6 +68,18 @@ resource "azurerm_storage_queue" "pay_wallet_usage_update_queue_blue" {
   storage_account_name = module.pay_wallet_storage[0].name
 }
 
+resource "azurerm_storage_queue" "pay_wallet_wallet_expiration_queue" {
+  name                 = "${local.project}-expiration-queue"
+  storage_account_name = module.pay_wallet_storage[0].name
+}
+
+//storage queue for blue deployment
+resource "azurerm_storage_queue" "pay_wallet_wallet_expiration_queue_blue" {
+  count                = var.env_short == "u" ? 1 : 0
+  name                 = "${local.project}-expiration-queue-b"
+  storage_account_name = module.pay_wallet_storage[0].name
+}
+
 # wallet queue alert diagnostic settings
 resource "azurerm_monitor_diagnostic_setting" "pay_wallet_queue_diagnostics" {
   count                      = var.is_feature_enabled.storage && var.env_short == "p" ? 1 : 0
@@ -117,6 +129,13 @@ locals {
   queue_alert_props = var.env_short == "p" ? [
     {
       queue_key   = "usage-update-queue"
+      severity    = 1
+      time_window = 30
+      frequency   = 15
+      threshold   = 10
+    },
+    {
+      queue_key   = "expiration-queue"
       severity    = 1
       time_window = 30
       frequency   = 15

--- a/src/domains/pay-wallet-common/README.md
+++ b/src/domains/pay-wallet-common/README.md
@@ -63,6 +63,8 @@
 | [azurerm_resource_group.storage_pay_wallet_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_queue.pay_wallet_usage_update_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_storage_queue.pay_wallet_usage_update_queue_blue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
+| [azurerm_storage_queue.pay_wallet_wallet_expiration_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
+| [azurerm_storage_queue.pay_wallet_wallet_expiration_queue_blue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |

--- a/src/domains/wallet-common/03_storage.tf
+++ b/src/domains/wallet-common/03_storage.tf
@@ -82,6 +82,18 @@ resource "azurerm_storage_queue" "wallet_usage_update_queue_blue" {
   storage_account_name = module.wallet_storage.name
 }
 
+resource "azurerm_storage_queue" "wallet_expiration_queue" {
+  name                 = "${local.project}-expiration-queue"
+  storage_account_name = module.wallet_storage.name
+}
+
+//storage queue for blue deployment
+resource "azurerm_storage_queue" "wallet_expiration_queue_blue" {
+  count                = var.env_short == "u" ? 1 : 0
+  name                 = "${local.project}-expiration-queue-b"
+  storage_account_name = module.wallet_storage.name
+}
+
 # wallet queue alert diagnostic settings
 resource "azurerm_monitor_diagnostic_setting" "wallet_queue_diagnostics" {
   count                      = var.env_short == "p" ? 1 : 0
@@ -131,6 +143,13 @@ locals {
   queue_alert_props = var.env_short == "p" ? [
     {
       "queue_key"   = "usage-update-queue"
+      "severity"    = 1
+      "time_window" = 30
+      "frequency"   = 15
+      "threshold"   = 10
+    },
+    {
+      "queue_key"   = "expiration-queue"
       "severity"    = 1
       "time_window" = 30
       "frequency"   = 15

--- a/src/domains/wallet-common/README.md
+++ b/src/domains/wallet-common/README.md
@@ -68,6 +68,8 @@
 | [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.storage_wallet_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.wallet_fe_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_storage_queue.wallet_expiration_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
+| [azurerm_storage_queue.wallet_expiration_queue_blue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_storage_queue.wallet_usage_update_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_storage_queue.wallet_usage_update_queue_blue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add `pagopa-ENV-wallet-expiration-queue` for both `wallet` and `pay-wallet` domains
<!--- Describe your changes in detail -->

### Motivation and context
This queue will be used by wallet b.e. to trace wallet creation process expiration
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
