### PR TITLE
feat(pay-wall): Subnets are now subnets under 10.3.5.0/24 cird

### DIFF
--- a/src/core-itn/env/dev/terraform.tfvars
+++ b/src/core-itn/env/dev/terraform.tfvars
@@ -31,10 +31,8 @@ cidr_vnet_italy = ["10.3.0.0/16"]
 cidr_aks_system      = ["10.3.1.0/24"] #see aks-leonardo
 cidr_aks_user        = ["10.3.2.0/24"] #see aks-leonardo
 cidr_eventhubs_italy = ["10.3.4.0/24"]
-
-cidr_cosmosdb_wallet_italy = ["10.3.8.0/24"]  #placeholder
-cird_redis_wallet_italy    = ["10.3.9.0/24"]  #placeholder
-cidr_storage_wallet_italy  = ["10.3.10.0/24"] #placeholder
+cird_pay_wallet_domain = ["10.3.5.0/24"] #placeholder for domain pay wallet
+cird_pay_wallet_domain_aks = ["10.3.6.0/24"] #placeholder for domain pay wallet
 
 cird_printit_domain = ["10.3.12.0/24"] #placeholder for domain printit
 

--- a/src/core-itn/env/dev/terraform.tfvars
+++ b/src/core-itn/env/dev/terraform.tfvars
@@ -28,10 +28,10 @@ is_feature_enabled = {
 ### Network Italy
 cidr_vnet_italy = ["10.3.0.0/16"]
 
-cidr_aks_system      = ["10.3.1.0/24"] #see aks-leonardo
-cidr_aks_user        = ["10.3.2.0/24"] #see aks-leonardo
-cidr_eventhubs_italy = ["10.3.4.0/24"]
-cird_pay_wallet_domain = ["10.3.5.0/24"] #placeholder for domain pay wallet
+cidr_aks_system            = ["10.3.1.0/24"] #see aks-leonardo
+cidr_aks_user              = ["10.3.2.0/24"] #see aks-leonardo
+cidr_eventhubs_italy       = ["10.3.4.0/24"]
+cird_pay_wallet_domain     = ["10.3.5.0/24"] #placeholder for domain pay wallet
 cird_pay_wallet_domain_aks = ["10.3.6.0/24"] #placeholder for domain pay wallet
 
 cird_printit_domain = ["10.3.12.0/24"] #placeholder for domain printit

--- a/src/core/env/uat/terraform.tfvars
+++ b/src/core/env/uat/terraform.tfvars
@@ -18,8 +18,8 @@ tags = {
 # Feature flag
 #
 enabled_features = {
-  apim_v2  = false
-  vnet_ita = false
+  apim_v2       = false
+  vnet_ita      = false
   apim_migrated = true
 }
 

--- a/src/domains/pay-wallet-common/env/itn-dev/terraform.tfvars
+++ b/src/domains/pay-wallet-common/env/itn-dev/terraform.tfvars
@@ -30,15 +30,14 @@ log_analytics_italy_workspace_resource_group_name = "pagopa-d-itn-core-monitor-r
 
 ### NETWORK
 
-cidr_subnet_cosmosdb_pay_wallet = ["10.3.8.0/24"]
-cidr_subnet_redis_pay_wallet    = ["10.3.9.0/24"]
-cidr_subnet_storage_pay_wallet  = ["10.3.10.0/24"]
+cidr_subnet_cosmosdb_pay_wallet = ["10.3.5.0/27"]
+cidr_subnet_redis_pay_wallet    = ["10.3.5.64/27"]
+cidr_subnet_storage_pay_wallet  = ["10.3.5.96/27"]
 
-
-
+### AKS
 ingress_load_balancer_ip = "10.3.2.250"
 
-### dns
+### DNS
 
 external_domain          = "pagopa.it"
 dns_zone_prefix          = "dev.payment-wallet"

--- a/src/domains/pay-wallet-common/env/itn-prod/terraform.tfvars
+++ b/src/domains/pay-wallet-common/env/itn-prod/terraform.tfvars
@@ -29,9 +29,9 @@ log_analytics_italy_workspace_resource_group_name = "pagopa-p-itn-core-monitor-r
 
 ### NETWORK
 
-cidr_subnet_cosmosdb_pay_wallet = ["10.3.8.0/24"]
-cidr_subnet_redis_pay_wallet    = ["10.3.9.0/24"]
-cidr_subnet_storage_pay_wallet  = ["10.3.10.0/24"]
+cidr_subnet_cosmosdb_pay_wallet = ["10.3.5.0/27"]
+cidr_subnet_redis_pay_wallet    = ["10.3.5.64/27"]
+cidr_subnet_storage_pay_wallet  = ["10.3.5.96/27"]
 
 
 ingress_load_balancer_ip = "10.3.2.250"

--- a/src/domains/pay-wallet-common/env/itn-uat/terraform.tfvars
+++ b/src/domains/pay-wallet-common/env/itn-uat/terraform.tfvars
@@ -29,14 +29,14 @@ log_analytics_italy_workspace_resource_group_name = "pagopa-u-itn-core-monitor-r
 
 ### NETWORK
 
-cidr_subnet_cosmosdb_pay_wallet = ["10.3.8.0/24"]
-cidr_subnet_redis_pay_wallet    = ["10.3.9.0/24"]
-cidr_subnet_storage_pay_wallet  = ["10.3.10.0/24"]
+cidr_subnet_cosmosdb_pay_wallet = ["10.3.5.0/27"]
+cidr_subnet_redis_pay_wallet    = ["10.3.5.64/27"]
+cidr_subnet_storage_pay_wallet  = ["10.3.5.96/27"]
 
-
+### AKS
 ingress_load_balancer_ip = "10.3.2.250"
 
-### dns
+### DNS
 
 external_domain          = "pagopa.it"
 dns_zone_prefix          = "uat.payment-wallet"

--- a/src/next-core/env/dev/terraform.tfvars
+++ b/src/next-core/env/dev/terraform.tfvars
@@ -62,8 +62,8 @@ geo_replica_enabled = false
 # apim v2
 #
 redis_cache_enabled = true
-cidr_subnet_apim = ["10.230.8.160/27"]
-apim_v2_zones    = ["1"]
+cidr_subnet_apim    = ["10.230.8.160/27"]
+apim_v2_zones       = ["1"]
 apim_v2_subnet_nsg_security_rules = [
   {
     name                       = "inbound-management-3443"

--- a/src/next-core/env/uat/terraform.tfvars
+++ b/src/next-core/env/uat/terraform.tfvars
@@ -64,8 +64,8 @@ geo_replica_enabled = false
 # apim v2
 #
 redis_cache_enabled = true
-cidr_subnet_apim = ["10.230.9.160/27"]
-apim_v2_zones    = ["1"]
+cidr_subnet_apim    = ["10.230.9.160/27"]
+apim_v2_zones       = ["1"]
 apim_v2_subnet_nsg_security_rules = [
   {
     name                       = "inbound-management-3443"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- changed subnets cird

### Motivation and context

Now pay-wallet domain use a range cird 10.3.5.0/24, so all the subnets are inside this range, and are /27

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
