### PR TITLE
fix: introducing api-config subkey to printit

### DIFF
--- a/src/domains/printit-app/00_data.tf
+++ b/src/domains/printit-app/00_data.tf
@@ -46,3 +46,9 @@ data "azurerm_storage_account" "institutions_storage_sa" {
   resource_group_name = "pagopa-${var.env_short}-${var.location_short}-${var.domain}-pdf-rg"
 }
 
+
+data "azurerm_api_management_product" "apim_api_config_product" {
+  product_id          = "product-api-config"
+  api_management_name = local.pagopa_apim_name
+  resource_group_name = local.pagopa_apim_rg
+}

--- a/src/domains/printit-app/05_subkey.tf
+++ b/src/domains/printit-app/05_subkey.tf
@@ -31,3 +31,13 @@ resource "azurerm_api_management_subscription" "pdf_engine_subkey" {
   allow_tracing       = false
   state               = "active"
 }
+
+
+resource "azurerm_api_management_subscription" "api_config_subkey" {
+  api_management_name = data.azurerm_api_management.apim.name
+  resource_group_name = data.azurerm_api_management.apim.resource_group_name
+  product_id          = data.azurerm_api_management_product.apim_api_config_product.id
+  display_name        = "Subscription for Api Config APIM"
+  allow_tracing       = false
+  state               = "active"
+}

--- a/src/domains/printit-app/06_keyvault.tf
+++ b/src/domains/printit-app/06_keyvault.tf
@@ -170,11 +170,7 @@ resource "azurerm_key_vault_secret" "pdf_engine_subkey_secret" {
   key_vault_id = data.azurerm_key_vault.kv.id
 }
 
-data "azurerm_api_management_product" "apim_api_config_product" {
-  product_id          = "product-api-config"
-  api_management_name = local.pagopa_apim_name
-  resource_group_name = local.pagopa_apim_rg
-}
+
 
 resource "azurerm_api_management_subscription" "api_config_subkey" {
   api_management_name = data.azurerm_api_management.apim.name

--- a/src/domains/printit-app/06_keyvault.tf
+++ b/src/domains/printit-app/06_keyvault.tf
@@ -169,3 +169,27 @@ resource "azurerm_key_vault_secret" "pdf_engine_subkey_secret" {
   content_type = "text/plain"
   key_vault_id = data.azurerm_key_vault.kv.id
 }
+
+data "azurerm_api_management_product" "apim_api_config_product" {
+  product_id          = "product-api-config"
+  api_management_name = local.pagopa_apim_name
+  resource_group_name = local.pagopa_apim_rg
+}
+
+resource "azurerm_api_management_subscription" "api_config_subkey" {
+  api_management_name = data.azurerm_api_management.apim.name
+  resource_group_name = data.azurerm_api_management.apim.resource_group_name
+  product_id          = data.azurerm_api_management_product.apim_api_config_product.id
+  display_name        = "Subscription for Api Config APIM"
+  allow_tracing       = false
+  state               = "active"
+}
+
+resource "azurerm_key_vault_secret" "api_config_subscription_key" {
+  name         = "api-config-sub-key"
+  value        = azurerm_api_management_subscription.api_config_subkey.primary_key
+  content_type = "text/plain"
+
+  key_vault_id = data.azurerm_key_vault.kv.id
+}
+

--- a/src/domains/printit-app/06_keyvault.tf
+++ b/src/domains/printit-app/06_keyvault.tf
@@ -172,15 +172,6 @@ resource "azurerm_key_vault_secret" "pdf_engine_subkey_secret" {
 
 
 
-resource "azurerm_api_management_subscription" "api_config_subkey" {
-  api_management_name = data.azurerm_api_management.apim.name
-  resource_group_name = data.azurerm_api_management.apim.resource_group_name
-  product_id          = data.azurerm_api_management_product.apim_api_config_product.id
-  display_name        = "Subscription for Api Config APIM"
-  allow_tracing       = false
-  state               = "active"
-}
-
 resource "azurerm_key_vault_secret" "api_config_subscription_key" {
   name         = "api-config-sub-key"
   value        = azurerm_api_management_subscription.api_config_subkey.primary_key

--- a/src/domains/printit-app/README.md
+++ b/src/domains/printit-app/README.md
@@ -152,10 +152,12 @@ No outputs.
 |------|------|
 | [azurerm_api_management_api_version_set.api_pdf_engine_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_version_set) | resource |
 | [azurerm_api_management_api_version_set.api_pdf_engine_node_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_version_set) | resource |
+| [azurerm_api_management_subscription.api_config_subkey](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_subscription) | resource |
 | [azurerm_api_management_subscription.generator_for_service_subkey](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_subscription) | resource |
 | [azurerm_api_management_subscription.pdf_engine_node_subkey](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_subscription) | resource |
 | [azurerm_api_management_subscription.pdf_engine_subkey](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_subscription) | resource |
 | [azurerm_key_vault_secret.aks_apiserver_url](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
+| [azurerm_key_vault_secret.api_config_subscription_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.application_insights_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.azure_devops_sa_cacrt](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.azure_devops_sa_token](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
@@ -189,6 +191,7 @@ No outputs.
 | [kubernetes_role_binding.deployer_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
 | [kubernetes_role_binding.system_deployer_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
 | [azurerm_api_management.apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/api_management) | data source |
+| [azurerm_api_management_product.apim_api_config_product](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/api_management_product) | data source |
 | [azurerm_application_insights.application_insights_italy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/application_insights) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_container_registry.container_registry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_registry) | data source |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
➕ added new secret: subkey to invoke apiconfig

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
