### PR TITLE
fix: Set `additionalPaymentInformations` timestamps to naive date time format

### DIFF
--- a/src/core/api/nodopagamenti_api/nodoPerPM/v2/_openapi.json.tpl
+++ b/src/core/api/nodopagamenti_api/nodoPerPM/v2/_openapi.json.tpl
@@ -207,7 +207,7 @@
           },
           "timestampOperation": {
             "type": "string",
-            "format": "date-time",
+            "format": "yyyy-MM-ddThh:mm:ss",
             "description": "Transaction timestamp"
           },
           "authorizationCode": {
@@ -249,7 +249,7 @@
           },
           "timestampOperation": {
             "type": "string",
-            "format": "date-time",
+            "format": "yyyy-MM-ddThh:mm:ss",
             "description": "Transaction timestamp"
           },
           "email": {
@@ -295,7 +295,7 @@
           },
           "timestampOperation": {
             "type": "string",
-            "format": "date-time",
+            "format": "yyyy-MM-ddThh:mm:ss",
             "description": "Transaction timestamp"
           },
           "authorizationCode": {
@@ -346,7 +346,7 @@
           },
           "timestampOperation": {
             "type": "string",
-            "format": "date-time",
+            "format": "yyyy-MM-ddThh:mm:ss",
             "description": "Transaction timestamp"
           },
           "email": {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
<!--- Describe your changes in detail -->

Changed `closePayment` OpenAPI to use local datetime format in `additionalPaymentInformation` timestamps (`timestampOperation` field)

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->

This PR fixes a regression on the `closePayment` call, previously the format specified did break the following calls.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->

