### PR TITLE
fix: Always return 401 when checking wallet token with PM is unsuccessful

### DIFF
--- a/src/domains/shared-app/api/session-wallet/v1/_fragment_policiy_chk_token.tpl.xml
+++ b/src/domains/shared-app/api/session-wallet/v1/_fragment_policiy_chk_token.tpl.xml
@@ -8,7 +8,7 @@
         </set-header>
     </send-request>
     <choose>
-      <when condition="@(((IResponse)context.Variables["checkSessionResponse"]).StatusCode == 401)">
+      <when condition="@(((IResponse)context.Variables["checkSessionResponse"]).StatusCode != 200)">
         <return-response>
             <set-status code="401" reason="Unauthorized" />
             <set-header name="Content-Type" exists-action="override">
@@ -19,21 +19,6 @@
                     "title": "Unauthorized",
                     "status": 401,
                     "detail": "Invalid session token"
-                }
-            </set-body>
-        </return-response>
-      </when>
-      <when condition="@(((IResponse)context.Variables["checkSessionResponse"]).StatusCode != 200)">
-        <return-response>
-            <set-status code="502" reason="Bad Gateway" />
-            <set-header name="Content-Type" exists-action="override">
-                <value>application/json</value>
-            </set-header>
-            <set-body>
-                {
-                    "title": "Error checking session",
-                    "status": 502,
-                    "detail": "There was an error checking session for token"
                 }
             </set-body>
         </return-response>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
<!--- Describe your changes in detail -->
 * always return 401 when checking wallet token with PM is unsuccessful

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This covers a behaviour of the `start-session` endpoint of PM: it returns 500 both for invalid and expired tokens.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
