### PR TITLE
fix: Update `paSendRTV2-request-body`

### DIFF
--- a/src/domains/gps-app/api/payments-service/v1/soap/wisp-paSendRTV2.xml
+++ b/src/domains/gps-app/api/payments-service/v1/soap/wisp-paSendRTV2.xml
@@ -1,7 +1,7 @@
 <policies>
   <inbound>
     <base />
-    <set-variable name="paSendRTV2-request-body" value="@((string)context.Request.Body.As<XElement>(preserveContent: true))" />
+    <set-variable name="paSendRTV2-request-body" value="@((string)context.Request.Body.As<string>(preserveContent: true))" />
   </inbound>
   <backend>
     <base />


### PR DESCRIPTION
paSendRTV2-request-body is filtered if XElement is used

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
