### PR TITLE
 fix: Update policy decoupler algorithm xml [PAGOPA-1904]

### DIFF
--- a/src/core/api_product/nodo_pagamenti_api/decoupler/decoupler-algorithm.xml
+++ b/src/core/api_product/nodo_pagamenti_api/decoupler/decoupler-algorithm.xml
@@ -148,6 +148,16 @@ new JProperty("ttl", 1)
                                             var requestData = JObject.Parse((string) context.Variables["requestData"]);
                                             return (int) requestData["ttl"];
                                         }" caching-type="internal" />
+    <!-- dataToSet is used in decoupler-activate-outbound -->
+    <set-variable name="dataToSet" value="@{
+                                        var baseNodeId = context.Variables.GetValueOrDefault<string>("baseNodeId", "NONE");
+                                        var baseUrl = context.Variables.GetValueOrDefault<string>("baseUrl", "NONE");
+                                        return new JObject(
+                                            new JProperty("nodeId", baseNodeId),
+                                            new JProperty("nodeUri", baseUrl),
+                                            new JProperty("ttl", 3600)
+                                        ).ToString();
+                                    }" />
     <set-variable name="set_cache" value="false" /> <!-- set_cache to false indicates to skip LIST list algorithm -->
   </when>
 </choose>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Create `dataToSet` in `belongs_to_wisp` case

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

- Fix bug `Call Stack: ExpressionValueEvaluationFailure` when access to `dataToSet` that is used in `decoupler-activate-outbound`

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
