### PR TITLE
feat(decoupler-on-error): Add trace in on-error-soap fragment

### DIFF
--- a/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
+++ b/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
@@ -8,8 +8,8 @@
             <set-header name="Content-Type" exists-action="override">
                 <value>text/xml</value>
             </set-header>
-            <set-body>@{     
-                return (string) context.Variables["renewrequest"]; 
+            <set-body>@{
+                return (string) context.Variables["renewrequest"];
             }</set-body>
         </send-request>
         <set-variable name="leggirisposta" value="@((string)((IResponse)context.Variables["risposta"]).Body.As<string>(preserveContent: true))" />
@@ -17,11 +17,35 @@
             <set-header name="Content-Type" exists-action="override">
                 <value>text/xml</value>
             </set-header>
-            <set-body>@{     
+            <set-body>@{
                 string message = (string)context.Variables["leggirisposta"];
-                return message; 
+                return message;
             }</set-body>
         </return-response>
         </when>
+        <otherwise>
+            <trace source="on_soap_error" severity="error">
+                <message>
+                    A policy error has occured
+                    Reason: @(context.LastError.Reason)
+                </message>
+            </trace>
+            <trace source="on_soap_error" severity="error">
+                <message>
+                    A policy error has occurred
+                    Source: @(context.LastError.Source)
+                    Reason: @(context.LastError.Reason)
+                    Message: @(context.LastError.Message)
+                    Scope: @(context.LastError.Scope)
+                    Section: @(context.LastError.Section)
+                    Path: @(context.LastError.Path)
+                    PolicyId: @(context.LastError.PolicyId)
+                </message>
+                <!-- soapAction is required!  -->
+                <metadata name="Operation Name" value="@((context.Variables.ContainsKey("soapAction") ? (string)context.Variables["soapAction"] : "Unknown")"/>
+            </trace>
+            <!-- Include default on-error policies -->
+            <base />
+        </otherwise>
         </choose>
 </fragment>

--- a/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
+++ b/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
@@ -24,28 +24,28 @@
         </return-response>
         </when>
         <otherwise>
-            <trace source="on_soap_error" severity="error">
-                <message>
-                    A policy error has occurred
-                    Reason: @(context.LastError.Reason)
-                </message>
-            </trace>
-            <trace source="on_soap_error" severity="error">
-                <message>
-                    A policy error has occurred
-                    Source: @(context.LastError.Source)
-                    Reason: @(context.LastError.Reason)
-                    Message: @(context.LastError.Message)
-                    Scope: @(context.LastError.Scope)
-                    Section: @(context.LastError.Section)
-                    Path: @(context.LastError.Path)
-                    PolicyId: @(context.LastError.PolicyId)
-                </message>
-                <!-- soapAction is required!  -->
-                <metadata name="Operation Name" value="@((context.Variables.ContainsKey("soapAction") ? (string)context.Variables["soapAction"] : "Unknown")"/>
-            </trace>
-            <!-- Include default on-error policies -->
-            <base />
+          <trace source="on_soap_error" severity="error">
+            <message>@{
+              string error = "A policy error has occurred, " +
+              "Reason: " + context.LastError.Reason;
+              return error;
+              }</message>
+          </trace>
+          <trace source="on_soap_error" severity="error">
+            <message>@{
+              string error = "A policy error has occurred, " +
+              "Source: " + context.LastError.Source + ", " +
+              "Reason: " + context.LastError.Reason + ", " +
+              "Message: " + context.LastError.Message + ", " +
+              "Scope: " + context.LastError.Scope + ", " +
+              "Section: " + context.LastError.Section + ", " +
+              "Path: " + context.LastError.Path + ", " +
+              "PolicyId: " + context.LastError.PolicyId;
+              return error;
+              }</message>
+            <!-- soapAction is required!  -->
+            <metadata name="Operation Name" value="@((context.Variables.ContainsKey("soapAction") ? (string)context.Variables["soapAction"] : "Unknown"))"/>
+          </trace>
         </otherwise>
         </choose>
 </fragment>

--- a/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
+++ b/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
@@ -27,7 +27,7 @@
           <trace source="on_soap_error" severity="error">
             <message>@{
               string error = "[ALERT][ON-SOAP-ERROR][REASON] A policy error has occurred, " +
-              "Reason: " + context.LastError.Reason;
+              "Reason:" + context.LastError.Reason;
               return error;
               }</message>
           </trace>

--- a/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
+++ b/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
@@ -26,7 +26,7 @@
         <otherwise>
             <trace source="on_soap_error" severity="error">
                 <message>
-                    A policy error has occured
+                    A policy error has occurred
                     Reason: @(context.LastError.Reason)
                 </message>
             </trace>

--- a/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
+++ b/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
@@ -26,14 +26,14 @@
         <otherwise>
           <trace source="on_soap_error" severity="error">
             <message>@{
-              string error = "[ALERT][ON-SOAP-ERROR]A policy error has occurred, " +
+              string error = "[ALERT][ON-SOAP-ERROR][REASON] A policy error has occurred, " +
               "Reason: " + context.LastError.Reason;
               return error;
               }</message>
           </trace>
           <trace source="on_soap_error" severity="error">
             <message>@{
-              string error = "[ALERT][ON-SOAP-ERROR] A policy error has occurred, " +
+              string error = "[ALERT][ON-SOAP-ERROR][STACK-TRACE] A policy error has occurred, " +
               "Source: " + context.LastError.Source + ", " +
               "Reason: " + context.LastError.Reason + ", " +
               "Message: " + context.LastError.Message + ", " +

--- a/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
+++ b/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
@@ -26,14 +26,14 @@
         <otherwise>
           <trace source="on_soap_error" severity="error">
             <message>@{
-              string error = "A policy error has occurred, " +
+              string error = "[ALERT][ON-SOAP-ERROR]A policy error has occurred, " +
               "Reason: " + context.LastError.Reason;
               return error;
               }</message>
           </trace>
           <trace source="on_soap_error" severity="error">
             <message>@{
-              string error = "A policy error has occurred, " +
+              string error = "[ALERT][ON-SOAP-ERROR] A policy error has occurred, " +
               "Source: " + context.LastError.Source + ", " +
               "Reason: " + context.LastError.Reason + ", " +
               "Message: " + context.LastError.Message + ", " +


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- Add trace short with `A policy error has occurred`
- Add complete trace with `LastError` info

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

This fragment `src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml` is called in on-error section of decoupler base policy. The goal is improve policy error tracing and build dashboard to count and summarize policy error.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
