### PR TITLE
[PAGOPA-1912] feat(nodo): Add alert on fault-code

### DIFF
--- a/src/domains/nodo-app/00_alert_faultcode.tf
+++ b/src/domains/nodo-app/00_alert_faultcode.tf
@@ -15,7 +15,7 @@ locals {
         "p-node-for-psp-api;rev=1 - 61dedafc2a92e81a0c7a58fc", "p-node-for-psp-api-auth;rev=1 - 63b6e2daea7c4a25440fdaa0", "p-node-for-psp-api;rev=1 - 63c559672a92e811a8f33a00", "p-node-for-psp-api-auth;rev=1 - 63b6e2daea7c4a25440fdaa5"
       ]
       faults = [
-        "PPT_AUTENTICAZIONE", "PPT_SYSTEM_ERROR", "PPT_CANALE_IRRANGIUNGIBILE", "PPT_ERRORE_IDEMEMPOTENZA"
+        "PPT_AUTENTICAZIONE", "PPT_SYSTEM_ERROR", "PPT_CANALE_IRRANGIUNGIBILE", "PPT_ERRORE_IDEMPOTENZA"
       ]
       soapreq = "activatePaymentNoticeRes|activatePaymentNoticeV2Response"
     },
@@ -25,7 +25,7 @@ locals {
         "p-node-for-psp-api;rev=1 - 61dedafc2a92e81a0c7a58fd", "p-node-for-psp-api-auth;rev=1 - 63b6e2daea7c4a25440fdaa1", "p-node-for-psp-api;rev=1 - 63c559672a92e811a8f33a01", "p-node-for-psp-api-auth;rev=1 - 63b6e2daea7c4a25440fdaa6"
       ]
       faults = [
-        "PPT_AUTENTICAZIONE", "PPT_SYSTEM_ERROR", "PPT_ERRORE_IDEMEMPOTENZA"
+        "PPT_AUTENTICAZIONE", "PPT_SYSTEM_ERROR", "PPT_ERRORE_IDEMPOTENZA"
       ]
       soapreq = "sendPaymentOutcomeResponse|sendPaymentOutcomeV2Response"
     }

--- a/src/domains/nodo-app/README.md
+++ b/src/domains/nodo-app/README.md
@@ -155,6 +155,7 @@
 | [azurerm_monitor_metric_alert.aks_nodo_moetrics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.aks_nodo_moetrics_error](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.alert-fault-code-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert.alert-fault-code-availability-nodoInviaRPT](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.alert-fault-code-specific-threshold](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.alert-nodo-auth-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.alert-nodo-auth-responsetime](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |

--- a/src/domains/nodo-app/README.md
+++ b/src/domains/nodo-app/README.md
@@ -155,7 +155,6 @@
 | [azurerm_monitor_metric_alert.aks_nodo_moetrics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_metric_alert.aks_nodo_moetrics_error](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.alert-fault-code-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
-| [azurerm_monitor_scheduled_query_rules_alert.alert-fault-code-availability-nodoInviaRPT](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.alert-fault-code-specific-threshold](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.alert-nodo-auth-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.alert-nodo-auth-responsetime](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Alert by Primitiva and fault-code group:
api              = {`sendPaymentOutcome`, `activatePaymentNotice`, `nodoInviaRPT`, `nodoInviaCarrelloRPT`}
fault-code = {`PPT_AUTENTICAZIONE`, `PPT_SYSTEM_ERROR`, `PPT_CANALE_IRRANGIUNGIBILE`, `PPT_ERRORE_IDEMPOTENZA`}

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Improve fault-detection by fault-code

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
