### PR TITLE
[PAGOPA-1913] feat(nodo-app): Add WISP-dismantling alerts

### DIFF
--- a/src/domains/nodo-app/00_alert_wisp_dismantling.tf
+++ b/src/domains/nodo-app/00_alert_wisp_dismantling.tf
@@ -1,0 +1,35 @@
+resource "azurerm_monitor_scheduled_query_rules_alert" "opex_pagopa-wisp-converter-availability" {
+  count               = var.env_short == "p" ? 1 : 0
+  resource_group_name = "dashboards"
+  name                = "pagopa-${var.env_short}-opex_pagopa-wisp-converter-availability"
+  location            = var.location
+
+  action {
+    action_group           = [data.azurerm_monitor_action_group.email.id, data.azurerm_monitor_action_group.slack.id, data.azurerm_monitor_action_group.opsgenie[0].id]
+    email_subject          = "Alert pagopa-wisp-converter-availability"
+    custom_webhook_payload = "{}"
+  }
+
+  data_source_id = data.azurerm_api_management.apim.id
+  description    = "Availability for https://api.platform.pagopa.it/wisp-converter/ is less than or equal to 99% - https://portal.azure.com/?l=en.en-us#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourcegroups/dashboards/providers/microsoft.portal/dashboards/pagopa-p-opex_pagopa-wisp-converter"
+  enabled        = true
+  query = (<<-QUERY
+let threshold = 0.99;
+AzureDiagnostics
+| where url_s startswith "https://api.platform.pagopa.it/wisp-converter/"
+| summarize
+    Total=count(),
+    Success=count(responseCode_d < 500)
+    by bin(TimeGenerated, 5m)
+| extend availability=toreal(Success) / Total
+| where availability < threshold
+  QUERY
+  )
+  severity    = 1
+  frequency   = 5
+  time_window = 5
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 1
+  }
+}

--- a/src/domains/nodo-app/00_alert_wisp_dismantling.tf
+++ b/src/domains/nodo-app/00_alert_wisp_dismantling.tf
@@ -72,3 +72,35 @@ traces
     threshold = 1
   }
 }
+
+resource "azurerm_monitor_scheduled_query_rules_alert" "opex_pagopa-wisp-converter-ai-error" {
+  for_each = var.env_short == "p" ? toset(["receiptKo", "receiptOk", "createTimer", "deleteTimer"]) : []
+
+  resource_group_name = "dashboards"
+  name                = "pagopa-${var.env_short}-opex_pagopa-wisp-converter-${each.value}-error"
+  location            = var.location
+
+  action {
+    action_group           = local.action_groups
+    email_subject          = "Alert pagopa-wisp-converter-${each.value}-error"
+    custom_webhook_payload = "{}"
+  }
+
+  data_source_id = data.azurerm_application_insights.application_insights.id
+  description    = "Availability for wisp-converter API ${each.value} is less than or equal to 99% - https://portal.azure.com/?l=en.en-us#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourcegroups/dashboards/providers/microsoft.portal/dashboards/pagopa-p-opex_pagopa-wisp-converter"
+  enabled        = true
+  query = (<<-QUERY
+let threshold = 0.99;
+traces
+| where cloud_RoleName == "pagopawispconverter"
+| where message startswith "Failed API operation ${each.value}"
+  QUERY
+  )
+  severity    = 1
+  frequency   = 5
+  time_window = 5
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 1
+  }
+}

--- a/src/domains/nodo-app/00_alert_wisp_dismantling.tf
+++ b/src/domains/nodo-app/00_alert_wisp_dismantling.tf
@@ -59,7 +59,7 @@ traces
 | summarize
     Total=count(message startswith "Invoking API operation ${each.value}"),
     Success=count(message startswith "Failed API operation ${each.value}")
-    by bin(TimeGenerated, 5m)
+    by bin(timestamp, 5m)
 | extend availability=toreal(Success) / Total
 | where availability < threshold
   QUERY

--- a/src/domains/nodo-app/00_alert_wisp_dismantling.tf
+++ b/src/domains/nodo-app/00_alert_wisp_dismantling.tf
@@ -33,3 +33,42 @@ AzureDiagnostics
     threshold = 1
   }
 }
+
+// These API invoking and result are logged only on application insight
+// [receiptKo, receiptOk, createTimer, deleteTimer]
+resource "azurerm_monitor_scheduled_query_rules_alert" "opex_pagopa-wisp-converter-ai-availability" {
+  for_each = var.env_short == "p" ? toset(["receiptKo", "receiptOk", "createTimer", "deleteTimer"]) : []
+
+  resource_group_name = "dashboards"
+  name                = "pagopa-${var.env_short}-opex_pagopa-wisp-converter-${each.value}-availability"
+  location            = var.location
+
+  action {
+    action_group           = local.action_groups
+    email_subject          = "Alert pagopa-wisp-converter-${each.value}-availability"
+    custom_webhook_payload = "{}"
+  }
+
+  data_source_id = data.azurerm_application_insights.application_insights.id
+  description    = "Availability for wisp-converter API ${each.value} is less than or equal to 99% - https://portal.azure.com/?l=en.en-us#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourcegroups/dashboards/providers/microsoft.portal/dashboards/pagopa-p-opex_pagopa-wisp-converter"
+  enabled        = true
+  query = (<<-QUERY
+let threshold = 0.99;
+traces
+| where cloud_RoleName == "pagopawispconverter"
+| summarize
+    Total=count(message startswith "Invoking API operation ${each.value}"),
+    Success=count(message startswith "Failed API operation ${each.value}")
+    by bin(TimeGenerated, 5m)
+| extend availability=toreal(Success) / Total
+| where availability < threshold
+  QUERY
+  )
+  severity    = 1
+  frequency   = 5
+  time_window = 5
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 1
+  }
+}

--- a/src/domains/nodo-app/README.md
+++ b/src/domains/nodo-app/README.md
@@ -186,6 +186,7 @@
 | [azurerm_monitor_scheduled_query_rules_alert.nodo_verifyko_to_tablestorage_appexception](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.nodo_verifyko_to_tablestorage_appexception_lastretry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.nodo_verifyko_to_tablestorage_persistenceexception](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert.opex_pagopa-wisp-converter-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_resource_group.nodo_re_to_datastore_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.vmss_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_subnet_route_table_association.snet_vmss_to_sia](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_route_table_association) | resource |

--- a/src/domains/nodo-app/README.md
+++ b/src/domains/nodo-app/README.md
@@ -187,6 +187,7 @@
 | [azurerm_monitor_scheduled_query_rules_alert.nodo_verifyko_to_tablestorage_appexception_lastretry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.nodo_verifyko_to_tablestorage_persistenceexception](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.opex_pagopa-wisp-converter-ai-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert.opex_pagopa-wisp-converter-ai-error](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.opex_pagopa-wisp-converter-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_resource_group.nodo_re_to_datastore_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.vmss_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |

--- a/src/domains/nodo-app/README.md
+++ b/src/domains/nodo-app/README.md
@@ -186,6 +186,7 @@
 | [azurerm_monitor_scheduled_query_rules_alert.nodo_verifyko_to_tablestorage_appexception](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.nodo_verifyko_to_tablestorage_appexception_lastretry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.nodo_verifyko_to_tablestorage_persistenceexception](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert.opex_pagopa-wisp-converter-ai-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.opex_pagopa-wisp-converter-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_resource_group.nodo_re_to_datastore_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.vmss_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

-  Add `opex_pagopa-wisp-converter-availability`: query on APIM for `/redirect` monitoring
- Add `opex_pagopa-wisp-converter-ai-availability`: query on AI for `receiptKo`, `receiptOk`, `createTimer`, `deleteTimer` monitoring
- Add `opex_pagopa-wisp-converter-ai-error`: query on AI for `receiptKo`, `receiptOk`, `createTimer`, `deleteTimer` error monitoring

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

- WISP-dismantling services monitoring via OpsGenie alerts

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
