### PR TITLE
[VAS-1169] chore: Added definition of new table and views to config db

### DIFF
--- a/src/psql/nodo/liquibase/changelog/cfg/3.29.0/db.changelog-20240718000000_new_manutenzione_stazioni_table.xml
+++ b/src/psql/nodo/liquibase/changelog/cfg/3.29.0/db.changelog-20240718000000_new_manutenzione_stazioni_table.xml
@@ -1,0 +1,96 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+
+  <!-- create sequence section -->
+  <changeSet author="liquibase" id="2024071800000">
+    <validCheckSum>ANY</validCheckSum>
+    <createSequence cacheSize="2000000" cycle="false" incrementBy="1"
+                    maxValue="9223372036854775807" minValue="1"
+                    sequenceName="MANUTENZIONE_STAZIONE_SEQ" startValue="2000000"/>
+  </changeSet>
+
+
+  <!-- create table section -->
+  <changeSet author="liquibase" id="2024071800001">
+    <validCheckSum>ANY</validCheckSum>
+    <createTable tableName="MANUTENZIONE_STAZIONE">
+      <column defaultValueSequenceNext="MANUTENZIONE_STAZIONE_SEQ" name="OBJ_ID" type="NUMBER">
+        <constraints nullable="false" primaryKey="true"
+                     primaryKeyName="PK_MANUTENZIONE_STAZIONE"/>
+      </column>
+      <column name="DATA_ORA_INIZIO" type="TIMESTAMP WITH TIME ZONE">
+        <constraints nullable="false"/>
+      </column>
+      <column name="DATA_ORA_FINE" type="TIMESTAMP WITH TIME ZONE">
+        <constraints nullable="false"/>
+      </column>
+      <column name="STANDIN" type="BOOLEAN">
+        <constraints nullable="false"/>
+      </column>
+      <column name="FK_STAZIONE" type="NUMBER">
+        <constraints nullable="false"/>
+      </column>
+    </createTable>
+  </changeSet>
+
+  <!-- create fk section -->
+  <changeSet author="liquibase" id="2024071800002">
+    <addForeignKeyConstraint baseColumnNames="FK_STAZIONE"
+                             baseTableName="MANUTENZIONE_STAZIONE"
+                             constraintName="FK_MANUTENZIONE_STAZIONE_STAZIONE"
+                             deferrable="false" initiallyDeferred="false"
+                             onDelete="RESTRICT" onUpdate="RESTRICT"
+                             referencedColumnNames="obj_id"
+                             referencedTableName="STAZIONI" validate="true"/>
+  </changeSet>
+
+  <!-- create index section -->
+  <changeSet author="liquibase" id="2024071800003">
+      <createIndex indexName="MANUTENZIONE_STAZIONE_DATE_IDX1" tableName="MANUTENZIONE_STAZIONE">
+          <column name="DATA_ORA_INIZIO"/>
+          <column name="DATA_ORA_FINE"/>
+      </createIndex>
+  </changeSet>
+
+  <!-- create view section -->
+  <changeSet author="liquibase" id="2024071800004">
+    <createView replaceIfExists="true" fullDefinition="false" viewName="MANUTENZIONE_STAZIONE_ESPANSA">
+      SELECT mequal.OBJ_ID::varchar(255) AS ID, mequal.DATA_ORA_INIZIO, mequal.DATA_ORA_FINE, ipa.ID_INTERMEDIARIO_PA AS INTERMEDIARIO_PA_CODICE_FISCALE
+      FROM MANUTENZIONE_STAZIONE mequal JOIN STAZIONI s ON mequal.FK_STAZIONE = s.OBJ_ID JOIN INTERMEDIARI_PA ipa ON s.FK_INTERMEDIARIO_PA = ipa.OBJ_ID
+      WHERE EXTRACT('year' FROM mequal.DATA_ORA_INIZIO) = EXTRACT('year' FROM mequal.DATA_ORA_FINE )
+      UNION ALL
+      SELECT mdiffStart.OBJ_ID || 'start' AS ID, mdiffStart.DATA_ORA_INIZIO, (DATE_TRUNC('year', mdiffStart.DATA_ORA_INIZIO) + interval '1' year) AS DATA_ORA_FINE , ipa.ID_INTERMEDIARIO_PA AS INTERMEDIARIO_PA_CODICE_FISCALE
+      FROM MANUTENZIONE_STAZIONE mdiffStart JOIN STAZIONI s ON mdiffStart.FK_STAZIONE = s.OBJ_ID JOIN INTERMEDIARI_PA ipa ON s.FK_INTERMEDIARIO_PA = ipa.OBJ_ID
+      WHERE EXTRACT('year' FROM mdiffStart.DATA_ORA_INIZIO) != EXTRACT('year' FROM mdiffStart.DATA_ORA_FINE )
+      UNION ALL
+      SELECT mdiffEnd.OBJ_ID || 'end' AS ID, (DATE_TRUNC('year', mdiffEnd.DATA_ORA_FINE )) AS DATA_ORA_INIZIO, mdiffEnd.DATA_ORA_FINE , ipa.ID_INTERMEDIARIO_PA AS INTERMEDIARIO_PA_CODICE_FISCALE
+      FROM MANUTENZIONE_STAZIONE mdiffEnd JOIN STAZIONI s ON mdiffEnd.FK_STAZIONE = s.OBJ_ID JOIN INTERMEDIARI_PA ipa ON s.FK_INTERMEDIARIO_PA = ipa.OBJ_ID
+      WHERE EXTRACT('year' FROM mdiffEnd.DATA_ORA_INIZIO) != EXTRACT('year' FROM mdiffEnd.DATA_ORA_FINE );
+    </createView>
+  </changeSet>
+
+  <changeSet author="liquibase" id="2024071800005">
+    <createView replaceIfExists="true" fullDefinition="false" viewName="MANUTENZIONE_STAZIONE_RIEPILOGO">
+      SELECT INTERMEDIARIO_PA_CODICE_FISCALE, TO_CHAR(DATE_TRUNC('year', DATA_ORA_INIZIO), 'YYYY') AS ANNO_MANUTENZIONE,
+      SUM(COALESCE(
+        (
+          SELECT EXTRACT(epoch FROM DATA_ORA_FINE - DATA_ORA_INIZIO)/3600
+          FROM MANUTENZIONE_STAZIONE_ESPANSA AS maintenanceForUsedHours
+          WHERE maintenanceForUsedHours.DATA_ORA_FINE &lt; CURRENT_TIMESTAMP and maintenanceForUsedHours.ID = maintenanceBase.ID
+        ), 0)) AS ORE_UTILIZZATE,
+      SUM(COALESCE(
+        (
+          SELECT EXTRACT(epoch FROM DATA_ORA_FINE - DATA_ORA_INIZIO)/3600
+          FROM MANUTENZIONE_STAZIONE_ESPANSA AS maintenanceForScheduledHours
+          WHERE maintenanceForScheduledHours.DATA_ORA_INIZIO &gt; CURRENT_TIMESTAMP and maintenanceForScheduledHours.ID = maintenanceBase.ID
+        ), 0)) AS ORE_PROGRAMMATE
+      FROM MANUTENZIONE_STAZIONE_ESPANSA AS maintenanceBase
+      GROUP BY INTERMEDIARIO_PA_CODICE_FISCALE, ANNO_MANUTENZIONE;
+    </createView>
+  </changeSet>
+
+
+</databaseChangeLog>

--- a/src/psql/nodo/liquibase/changelog/cfg/db.changelog-master-3.29.0.xml
+++ b/src/psql/nodo/liquibase/changelog/cfg/db.changelog-master-3.29.0.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+  http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+  <property name="version" value="3.29.0" global="false"/>
+
+  <include file="./db.changelog-master-3.28.0.xml"/>
+
+  <include file="./${version}/db.changelog-20240718000000_new_manutenzione_stazioni_table.xml" labels="${version}"/>
+
+</databaseChangeLog>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- added `MANUTENZIONE_STAZIONE` table inside config db
- added `MANUTENZIONE_STAZIONE_ESPANSA` and `MANUTENZIONE_STAZIONE_RIEPILOGO` views inside config db

<!--- Describe your changes in detail -->

### Motivation and context
[VAS#1169](https://pagopa.atlassian.net/browse/VAS-1169)
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [X] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
