### PR TITLE
fix: set expiration time for token for onboarding wallets to 15 minutes

### DIFF
--- a/src/domains/pay-wallet-app/api/io-payment-wallet/v1/_post_wallets.xml.tpl
+++ b/src/domains/pay-wallet-app/api/io-payment-wallet/v1/_post_wallets.xml.tpl
@@ -93,7 +93,7 @@
                 var jti = Guid.NewGuid().ToString(); //sets the iat claim. Random uuid added to prevent the reuse of this token
                 var date = DateTime.Now;
                 var iat = new DateTimeOffset(date).ToUnixTimeSeconds(); // sets the issued time of the token now
-                var exp = new DateTimeOffset(date.AddMinutes(10)).ToUnixTimeSeconds();  // sets the expiration of the token to be 10 minutes from now
+                var exp = new DateTimeOffset(date.AddMinutes(15)).ToUnixTimeSeconds();  // sets the expiration of the token to be 15 minutes from now
                 var userId = ((string)context.Variables.GetValueOrDefault("xUserId","")); 
                 var walletId = ((string)context.Variables.GetValueOrDefault("walletId",""));
                 var payload = new { iat, exp, jti, userId, walletId }; 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
<!--- Describe your changes in detail -->
 * set expiration time for token for onboarding wallets to 15 minutes

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->

See also pagopa/pagopa-wallet-service#178

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
