### PR TITLE
[PAGOPA-1994] fix: changed wrong stations for WISP dismantling

### DIFF
--- a/src/domains/nodo-app/env/weu-uat/terraform.tfvars
+++ b/src/domains/nodo-app/env/weu-uat/terraform.tfvars
@@ -222,13 +222,13 @@ storage_account_info = {
 # WISP-dismantling-cfg
 create_wisp_converter = true
 wisp_converter = {
-  enable_apim_switch     = true
-  brokerPSP_whitelist    = "97735020584"                                                                                                                                                                                                                                                                                                                                                                                                                                                                # AGID
-  channel_whitelist      = "97735020584_02"                                                                                                                                                                                                                                                                                                                                                                                                                                                             # https://pagopa.atlassian.net/wiki/spaces/PAG/pages/135924270/Canali+Particolari
-  station_whitelist      = "15376371009-15376371009_09,80005570561-00799960158_05,80023530167-00799960158_03,12621570154-00053810149_01,77777777777-97735020584_01,93027230668-00838520880_03,80019530924-00838520880_03,80008750475-00838520880_03,92020910888-00838520880_01,02323170130-02818030369_01,00146330733-02818030369_01,01199840115-02818030369_01,02341640353-02818030369_01,03623810151-01484460587_01,03623810151-01378570350_01,03122360153-08543640158_01,02002380224-02695640421_01" # https://config.uat.platform.pagopa.it/stations/15376371009_09 in UAT x i test quella di MockEC
-  ci_whitelist           = "15376371009,80005570561,80023530167,12621570154,77777777777,93027230668,80019530924,80008750475,92020910888,02323170130,00146330733,01199840115,02341640353,03623810151,03122360153,02002380224"
+  enable_apim_switch                 = true
+  brokerPSP_whitelist                = "97735020584"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           # AGID
+  channel_whitelist                  = "97735020584_02"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        # https://pagopa.atlassian.net/wiki/spaces/PAG/pages/135924270/Canali+Particolari
+  station_whitelist                  = "15376371009-15376371009_09,80005570561-00799960158_05,80023530167-00799960158_03,12621570154-00053810149_01,77777777777-97735020584_01,93027230668-00838520880_03,80019530924-00838520880_03,80008750475-00838520880_03,92020910888-00838520880_01,02323170130-02818030369_01,00146330733-02818030369_01,01199840115-02818030369_01,02341640353-02818030369_01,03623810151-01484460587_01,03623810151-01378570350_01,03122360153-08543640158_04,02002380224-02695640421_02,02002380224-02695640421_03" # https://config.uat.platform.pagopa.it/stations/15376371009_09 in UAT x i test quella di MockEC
+  ci_whitelist                       = "15376371009,80005570561,80023530167,12621570154,77777777777,93027230668,80019530924,80008750475,92020910888,02323170130,00146330733,01199840115,02341640353,03623810151,03122360153,02002380224"
   nodoinviarpt_paymenttype_whitelist = "BBT"
-  dismantling_primitives = "nodoInviaRPT,nodoInviaCarrelloRPT"
+  dismantling_primitives             = "nodoInviaRPT,nodoInviaCarrelloRPT"
 }
 
 # 15376371009-15376371009_09 EC PagoPA di test
@@ -254,13 +254,14 @@ wisp_converter = {
 # 02341640353-02818030369_01 GPS Global Parking Solutions S.p.A./Argo
 # 03623810151-01484460587_01 Comune di Albairate/Unioncamere
 # 03623810151-01378570350_01 Comune di Albairate/Credemtel
-# 03122360153-08543640158_01 Comune di Corbetta/APKAPPA S.R.L.
-# 02002380224-02695640421_01 Ente Trentino Riscossioni/e-SED Società Cooperativa
+# 03122360153-08543640158_04 Comune di Corbetta/APKAPPA S.R.L.
+# 02002380224-02695640421_02 Ente Trentino Riscossioni/e-SED Società Cooperativa
+# 02002380224-02695640421_03 Ente Trentino Riscossioni/e-SED Società Cooperativa
 
 enable_sendPaymentResultV2_SWClient = true
 
 # WFESP-dismantling-cfg
 wfesp_dismantling = {
-  channel_list                       = "13212880150_90"
-  wfesp_fixed_url                    = "https://wfesp.pagopa.gov.it/redirect/wpl05/get?idSession="
+  channel_list    = "13212880150_90"
+  wfesp_fixed_url = "https://wfesp.pagopa.gov.it/redirect/wpl05/get?idSession="
 }


### PR DESCRIPTION
This PR contains some changes on CI-stations relation for WISP dismantling, where the previous confiuguration were wrong.

#### Apply
The changes were applied in UAT with the following command:  
```
terraform.sh apply weu-uat \
--target=azurerm_api_management_named_value.wisp_station_whitelist_named_value
```

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
