### PR TITLE
fix: add new collection for log event with partition key

### DIFF
--- a/src/domains/pay-wallet-common/03_cosmosdb.tf
+++ b/src/domains/pay-wallet-common/03_cosmosdb.tf
@@ -75,7 +75,7 @@ locals {
       ]
       shard_key = null
     },
-    {
+    { # collection with event until 25/08/2024, replaced by payment-wallet-log-events
       name = "wallet-log-events"
       indexes = [{
         keys   = ["_id"]
@@ -122,6 +122,19 @@ locals {
         }
       ]
       shard_key = "userId"
+    },
+    { # collection with event from 25/08/2024
+      name = "payment-wallet-log-events"
+      indexes = [{
+        keys   = ["_id"]
+        unique = true
+        },
+        {
+          keys   = ["walletId", "timestamp", "eventType"]
+          unique = true
+        }
+      ]
+      shard_key = "walletId"
     },
   ]
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- add new collection for log event with partitionKey

### Motivation and context

The goal of this PR is to introduce a first remediation for this [incident](https://pagopa.app.opsgenie.com/reports/post-mortem/445e9e31-9653-4396-a512-94b2e6b8b71c/detail).
The new collection is equals the last one but with partitionKey, in order to scale with new event (However, an analysis will be necessary to evaluate a retention policy).
 
### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
