### PR TITLE
fix: [PAGOPA-2263] temporarily added `/fdr-psp` under AppGW's upload domain

### DIFF
--- a/src/next-core/env/uat/terraform.tfvars
+++ b/src/next-core/env/uat/terraform.tfvars
@@ -784,3 +784,16 @@ monitor_env_test_urls = [
     path = "",
   }
 ]
+
+app_gateway_allowed_paths_upload = [
+  "/upload/gpd/.*",
+  "/nodo-auth/node-for-psp/.*",
+  "/nodo-auth/nodo-per-psp/.*",
+  "/nodo/nodo-per-psp/.*",
+  "/nodo/nodo-per-pa/.*",
+  "/nodo-auth/nodo-per-pa/.*",
+  "/nodo-auth/node-for-pa/.*",
+  "/nodo/node-for-psp/.*",
+  "/fdr-legacy/nodo-per-pa/.*",
+  "/fdr-psp/.*" # Added temporarily for bug https://pagopa.atlassian.net/browse/PAGOPA-2263
+]

--- a/src/next-core/env/uat/terraform.tfvars
+++ b/src/next-core/env/uat/terraform.tfvars
@@ -795,5 +795,5 @@ app_gateway_allowed_paths_upload = [
   "/nodo-auth/node-for-pa/.*",
   "/nodo/node-for-psp/.*",
   "/fdr-legacy/nodo-per-pa/.*",
-  "/fdr-psp/.*" # Added temporarily for bug https://pagopa.atlassian.net/browse/PAGOPA-2263
+  "/fdr-psp/.*" # Added temporarily as workaround for bug https://pagopa.atlassian.net/browse/PAGOPA-2263
 ]


### PR DESCRIPTION
This PR contains the registration of a new API set on `upload.uat.platform.pagopa.it` domain. This fix is a temporarily workaround made in order to resolve an issue on long-time communication on FdR flows. The same fix, on near future, will be rollbacked and the API set will use standard `api.uat.platform.pagopa.it` domain.

### List of changes
 - Add API set, starting with `/fdr-psp` to `upload.uat.platform.pagopa.it` domain

### Motivation and context
This change is required in order to temporarily and rapidly set a longer timeout on FdR APIs before a future major change on service logic.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
