### PR TITLE
fix: [PAGOPA-2280] datafactory-ingestion-gec

### DIFF
--- a/src/domains/observability/04_datafactory_dataset.tf
+++ b/src/domains/observability/04_datafactory_dataset.tf
@@ -40,7 +40,7 @@ resource "azurerm_data_factory_dataset_json" "afm_gec_bundle_cdc_json" {
   linked_service_name = azurerm_data_factory_linked_service_azure_blob_storage.afm_gec_storage_linked_service.name
 
   azure_blob_storage_location {
-    container = "pagopa-${var.env_short}-${var.location_short}-observ-az-blob-observability-container"
+    container = "pagopa-${var.env_short}-itn-observ-az-blob-observability-container"
     path = "bundles"
     filename = ""
   }
@@ -56,7 +56,7 @@ resource "azurerm_data_factory_dataset_json" "afm_gec_cibundle_cdc_json" {
   linked_service_name = azurerm_data_factory_linked_service_azure_blob_storage.afm_gec_storage_linked_service.name
 
   azure_blob_storage_location {
-    container = "pagopa-${var.env_short}-${var.location_short}-observ-az-blob-observability-container"
+    container = "pagopa-${var.env_short}-itn-observ-az-blob-observability-container"
     path = "cibundles"
     filename = ""
   }
@@ -72,7 +72,7 @@ resource "azurerm_data_factory_dataset_json" "afm_gec_touchpoints_cdc_json" {
   linked_service_name = azurerm_data_factory_linked_service_azure_blob_storage.afm_gec_storage_linked_service.name
 
   azure_blob_storage_location {
-    container = "pagopa-${var.env_short}-${var.location_short}-observ-az-blob-observability-container"
+    container = "pagopa-${var.env_short}-itn-observ-az-blob-observability-container"
     path = "touchpoints"
     filename = ""
   }
@@ -88,7 +88,7 @@ resource "azurerm_data_factory_dataset_json" "afm_gec_paymenttypes_cdc_json" {
   linked_service_name = azurerm_data_factory_linked_service_azure_blob_storage.afm_gec_storage_linked_service.name
 
   azure_blob_storage_location {
-    container = "pagopa-${var.env_short}-${var.location_short}-observ-az-blob-observability-container"
+    container = "pagopa-${var.env_short}-itn-observ-az-blob-observability-container"
     path = "paymenttypes"
     filename = ""
   }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

 - fix datasets container name the location was `weu` instead of `itn`

depend on https://github.com/pagopa/pagopa-infra/pull/2507


<!--- Describe your changes in detail -->

### Motivation and context

GEC data ingestion

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
