### PR TITLE
feat: [PAYMCLOUD-138] aks platform add tls checker under opsgenie monitor group

### DIFF
--- a/src/aks-platform/05_tls_checker.tf
+++ b/src/aks-platform/05_tls_checker.tf
@@ -16,7 +16,8 @@ module "tls_checker" {
   application_insights_id             = data.azurerm_application_insights.application_insights.id
   application_insights_action_group_ids = [
     data.azurerm_monitor_action_group.slack.id,
-    data.azurerm_monitor_action_group.email.id
+    data.azurerm_monitor_action_group.email.id,
+    data.azurerm_monitor_action_group.opsgenie.0.id
   ]
   kv_secret_name_for_application_insights_connection_string = "ai-${var.env_short}-connection-string"
   keyvault_name                                             = data.azurerm_key_vault.kv.name

--- a/src/aks-platform/05_tls_checker.tf
+++ b/src/aks-platform/05_tls_checker.tf
@@ -14,11 +14,18 @@ module "tls_checker" {
   location_string                     = var.location_string
   application_insights_resource_group = data.azurerm_resource_group.monitor_rg.name
   application_insights_id             = data.azurerm_application_insights.application_insights.id
-  application_insights_action_group_ids = [
-    data.azurerm_monitor_action_group.slack.id,
-    data.azurerm_monitor_action_group.email.id,
-    data.azurerm_monitor_action_group.opsgenie.0.id
-  ]
+
+  application_insights_action_group_ids = flatten([
+    [
+      data.azurerm_monitor_action_group.slack.id,
+      data.azurerm_monitor_action_group.email.id,
+    ],
+    # Under here only production deployment monitor action group
+    (var.env == "prod" ? [
+      data.azurerm_monitor_action_group.opsgenie.0.id,
+    ] : [])
+  ])
+
   kv_secret_name_for_application_insights_connection_string = "ai-${var.env_short}-connection-string"
   keyvault_name                                             = data.azurerm_key_vault.kv.name
   keyvault_tenant_id                                        = data.azurerm_client_config.current.tenant_id


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

Add OpsGenie action group to TLS checker alerts

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Included OpsGenie in the list of action groups for Application Insights alerts. This ensures critical TLS checker alerts are sent to OpsGenie, enhancing incident response capability.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
