### PR TITLE
fix: remove UUID format constraint on bundle id

### DIFF
--- a/src/core/api/nodopagamenti_api/nodoPerPM/v2/_openapi.json.tpl
+++ b/src/core/api/nodopagamenti_api/nodoPerPM/v2/_openapi.json.tpl
@@ -526,7 +526,6 @@
           "idBundle": {
             "type": "string",
             "description": "Bundle id",
-            "format": "uuid",
             "example": "733a12e7-5bc7-41f8-a5f1-a693bf57011f"
           },
           "transactionDetails": {
@@ -621,7 +620,6 @@
           "idBundle": {
             "type": "string",
             "description": "Bundle id",
-            "format": "uuid",
             "example": "733a12e7-5bc7-41f8-a5f1-a693bf57011f"
           },
           "transactionDetails": {
@@ -716,7 +714,6 @@
           "idBundle": {
             "type": "string",
             "description": "Bundle id",
-            "format": "uuid",
             "example": "733a12e7-5bc7-41f8-a5f1-a693bf57011f"
           },
           "transactionDetails": {
@@ -811,7 +808,6 @@
           "idBundle": {
             "type": "string",
             "description": "Bundle id",
-            "format": "uuid",
             "example": "733a12e7-5bc7-41f8-a5f1-a693bf57011f"
           },
           "transactionDetails": {
@@ -906,7 +902,6 @@
           "idBundle": {
             "type": "string",
             "description": "Bundle id",
-            "format": "uuid",
             "example": "733a12e7-5bc7-41f8-a5f1-a693bf57011f"
           },
           "transactionDetails": {
@@ -1001,7 +996,6 @@
           "idBundle": {
             "type": "string",
             "description": "Bundle id",
-            "format": "uuid",
             "example": "733a12e7-5bc7-41f8-a5f1-a693bf57011f"
           },
           "transactionDetails": {
@@ -1096,7 +1090,6 @@
           "idBundle": {
             "type": "string",
             "description": "Bundle id",
-            "format": "uuid",
             "example": "733a12e7-5bc7-41f8-a5f1-a693bf57011f"
           },
           "transactionDetails": {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Remove UUUD format constraint since GEC idBundle has no constraint into it's bundleId field
<!--- Describe your changes in detail -->

### Motivation and context
Remove UUUD format constraint since GEC idBundle has no constraint into it's bundleId field
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
