### PR TITLE
feat(recaptcha): CHK-3589 Add double recaptcha check for ecommerce enterprise

### DIFF
--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_payment_request_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_payment_request_policy.xml.tpl
@@ -2,6 +2,7 @@
   <inbound>
     <!-- Check google reCAPTCHA token validity START -->
     <set-variable name="recaptchaSecret" value="{{google-recaptcha-secret}}" />
+    <set-variable name="recaptchaEnterpriseSecret" value="{{ecommerce-for-checkout-google-recaptcha-secret}}" />
     <set-variable name="recaptchaToken" value="@(context.Request.OriginalUrl.Query.GetValueOrDefault("recaptchaResponse"))" />
     <choose>
         <when condition="@(context.Variables["recaptchaToken"] == null || context.Variables["recaptchaToken"] == "")">
@@ -21,9 +22,24 @@
     <set-variable name="recaptcha-check-body" value="@(((IResponse)context.Variables["recaptcha-check"]).Body.As<JObject>())" />
     <choose>
       <when condition="@(((IResponse)context.Variables["recaptcha-check"]).StatusCode != 200 || ((bool) ((JObject) context.Variables["recaptcha-check-body"])["success"]) != true)">
-        <return-response>
-          <set-status code="401" reason="Unauthorized" />
-          </return-response>
+          <!-- Double Check google reCAPTCHA Enterprise token validity START -->
+           <send-request ignore-error="true" timeout="10" response-variable-name="recaptcha-enterprise-check" mode="new">
+              <set-url>https://www.google.com/recaptcha/api/siteverify</set-url>
+              <set-method>POST</set-method>
+              <set-header name="Content-Type" exists-action="override">
+                  <value>application/x-www-form-urlencoded</value>
+              </set-header>
+              <set-body>@($"secret={(string)context.Variables["recaptchaEnterpriseSecret"]}&response={(string)context.Variables["recaptchaToken"]}")</set-body>
+          </send-request>
+          <set-variable name="recaptcha-enterprise-check-body" value="@(((IResponse)context.Variables["recaptcha-enterprise-check"]).Body.As<JObject>())" />
+          <choose>
+              <when condition="@(((IResponse)context.Variables["recaptcha-enterprise-check"]).StatusCode != 200 || ((bool) ((JObject) context.Variables["recaptcha-enterprise-check-body"])["success"]) != true)">
+                <return-response>
+                  <set-status code="401" reason="Unauthorized" />
+                </return-response>
+              </when>  
+          </choose>  
+          <!-- Double Check google reCAPTCHA Enterprise token validity END -->
       </when>
     </choose>
     <!-- Check google reCAPTCHA token validity END -->

--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_transaction_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_transaction_policy.xml.tpl
@@ -2,6 +2,7 @@
     <inbound>
     <!-- Check google reCAPTCHA token validity START -->
     <set-variable name="recaptchaSecret" value="{{google-recaptcha-secret}}" />
+    <set-variable name="recaptchaEnterpriseSecret" value="{{ecommerce-for-checkout-google-recaptcha-secret}}" />
     <set-variable name="recaptchaToken" value="@(context.Request.OriginalUrl.Query.GetValueOrDefault("recaptchaResponse"))" />
     <choose>
         <when condition="@(context.Variables["recaptchaToken"] == null || context.Variables["recaptchaToken"] == "")">
@@ -21,9 +22,24 @@
     <set-variable name="recaptcha-check-body" value="@(((IResponse)context.Variables["recaptcha-check"]).Body.As<JObject>())" />
     <choose>
       <when condition="@(((IResponse)context.Variables["recaptcha-check"]).StatusCode != 200 || ((bool) ((JObject) context.Variables["recaptcha-check-body"])["success"]) != true)">
-        <return-response>
-          <set-status code="401" reason="Unauthorized" />
-          </return-response>
+          <!-- Double Check google reCAPTCHA Enterprise token validity START -->
+           <send-request ignore-error="true" timeout="10" response-variable-name="recaptcha-enterprise-check" mode="new">
+              <set-url>https://www.google.com/recaptcha/api/siteverify</set-url>
+              <set-method>POST</set-method>
+              <set-header name="Content-Type" exists-action="override">
+                  <value>application/x-www-form-urlencoded</value>
+              </set-header>
+              <set-body>@($"secret={(string)context.Variables["recaptchaEnterpriseSecret"]}&response={(string)context.Variables["recaptchaToken"]}")</set-body>
+          </send-request>
+          <set-variable name="recaptcha-enterprise-check-body" value="@(((IResponse)context.Variables["recaptcha-enterprise-check"]).Body.As<JObject>())" />
+          <choose>
+              <when condition="@(((IResponse)context.Variables["recaptcha-enterprise-check"]).StatusCode != 200 || ((bool) ((JObject) context.Variables["recaptcha-enterprise-check-body"])["success"]) != true)">
+                <return-response>
+                  <set-status code="401" reason="Unauthorized" />
+                </return-response>
+              </when>  
+          </choose>  
+          <!-- Double Check google reCAPTCHA Enterprise token validity END -->
       </when>
     </choose>
     <!-- Check google reCAPTCHA token validity END -->

--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v2/_transaction_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v2/_transaction_policy.xml.tpl
@@ -3,6 +3,7 @@
         <base />
         <!-- Check google reCAPTCHA token validity START -->
         <set-variable name="recaptchaSecret" value="{{google-recaptcha-secret}}" />
+        <set-variable name="recaptchaEnterpriseSecret" value="{{ecommerce-for-checkout-google-recaptcha-secret}}" />
         <set-variable name="recaptchaToken" value="@(context.Request.OriginalUrl.Query.GetValueOrDefault("recaptchaResponse"))" />
         <choose>
             <when condition="@(context.Variables["recaptchaToken"] == null || context.Variables["recaptchaToken"] == "")">
@@ -22,9 +23,24 @@
         <set-variable name="recaptcha-check-body" value="@(((IResponse)context.Variables["recaptcha-check"]).Body.As<JObject>())" />
         <choose>
         <when condition="@(((IResponse)context.Variables["recaptcha-check"]).StatusCode != 200 || ((bool) ((JObject) context.Variables["recaptcha-check-body"])["success"]) != true)">
-            <return-response>
-            <set-status code="401" reason="Unauthorized" />
-            </return-response>
+          <!-- Double Check google reCAPTCHA Enterprise token validity START -->
+           <send-request ignore-error="true" timeout="10" response-variable-name="recaptcha-enterprise-check" mode="new">
+              <set-url>https://www.google.com/recaptcha/api/siteverify</set-url>
+              <set-method>POST</set-method>
+              <set-header name="Content-Type" exists-action="override">
+                  <value>application/x-www-form-urlencoded</value>
+              </set-header>
+              <set-body>@($"secret={(string)context.Variables["recaptchaEnterpriseSecret"]}&response={(string)context.Variables["recaptchaToken"]}")</set-body>
+          </send-request>
+          <set-variable name="recaptcha-enterprise-check-body" value="@(((IResponse)context.Variables["recaptcha-enterprise-check"]).Body.As<JObject>())" />
+          <choose>
+              <when condition="@(((IResponse)context.Variables["recaptcha-enterprise-check"]).StatusCode != 200 || ((bool) ((JObject) context.Variables["recaptcha-enterprise-check-body"])["success"]) != true)">
+                <return-response>
+                  <set-status code="401" reason="Unauthorized" />
+                </return-response>
+              </when>  
+          </choose>  
+          <!-- Double Check google reCAPTCHA Enterprise token validity END -->
         </when>
         </choose>
         <!-- Check google reCAPTCHA token validity END -->


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- add double check for recaptcha enterprise

### Motivation and context

The goal of this PR is to create a  policy that allows to manage and orchestrate the reCAPTCHA validation for both account versions. The policy should invoke reCAPTCHA using both the old and the new secret keys, and the validity test will be considered successful if at least one of the two reCAPTCHA calls returns a valid result. This fallback logic helps reduce the risk of service disruptions, as the system will still accept the validation if either of the two reCAPTCHAs (the new one or the previous one) is functioning.


### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
