### PR TITLE
feat: [PAGOPA-2425] add alert on D-WISP's redirect API availability

### DIFF
--- a/src/domains/nodo-app/00_alert_wisp_dismantling.tf
+++ b/src/domains/nodo-app/00_alert_wisp_dismantling.tf
@@ -34,6 +34,53 @@ AzureDiagnostics
   }
 }
 
+// Query explanation: https://pagopa.atlassian.net/wiki/spaces/I/pages/574751186/Razionalizzazione+Alert
+resource "azurerm_monitor_scheduled_query_rules_alert" "opex_pagopa-wisp-converter-redirect-availability" {
+  count               = var.env_short == "p" ? 1 : 0
+  resource_group_name = "dashboards"
+  name                = "pagopa-${var.env_short}-opex_pagopa-wisp-converter-redirect-availability"
+  location            = var.location
+
+  action {
+    action_group           = [data.azurerm_monitor_action_group.email.id, data.azurerm_monitor_action_group.slack.id, data.azurerm_monitor_action_group.opsgenie[0].id]
+    email_subject          = "Alert pagopa-wisp-converter-redirect-availability"
+    custom_webhook_payload = "{}"
+  }
+
+  data_source_id = data.azurerm_api_management.apim.id
+  description    = "Availability for https://api.platform.pagopa.it/wisp-converter/redirect/api/v1/payments is less than or equal to threshold - https://portal.azure.com/?l=en.en-us#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourcegroups/dashboards/providers/microsoft.portal/dashboards/pagopa-p-opex_pagopa-wisp-converter"
+  enabled        = true
+  query = (<<-QUERY
+let lowTrafficThreshold = 80; // the lower threshold that can be calculated regarding the number of invocations
+let highTrafficThreshold = 99; // the upper threshold that can be calculated regarding the number of invocations
+let trafficMin = 100; // the minimum number of invocations (traffic) below which 'lowTrafficThreshold' guideline is used
+let trafficLinear = 500;  // the minimum number of invocations (traffic) above which 'highTrafficThreshold' guideline is used
+let thresholdDelta = trafficLinear - trafficMin; // the difference of the traffic guideline on which the expected availability is calculated
+let availabilityDelta = highTrafficThreshold - lowTrafficThreshold; // the difference of the threshold limits on which the expected availability is calculated
+// -----------------------------------------
+AzureDiagnostics
+| where url_s startswith "https://api.platform.pagopa.it/wisp-converter/redirect/api/v1/payments"
+| summarize
+    total=count(),
+    success=count(responseCode_d == 302)
+    by timeslot = bin(TimeGenerated, 5m)
+| extend trafficUp = total - trafficMin
+| extend deltaRatio = todouble(todouble(trafficUp) / todouble(thresholdDelta))
+| extend expectedAvailability = iff(total >= trafficLinear, toreal(highTrafficThreshold), iff(total <= trafficMin, toreal(lowTrafficThreshold), (deltaRatio * (availabilityDelta)) + lowTrafficThreshold))
+| extend availability = ((success * 1.0) / total) * 100
+| project timeslot, availability, threshold=expectedAvailability
+| where availability < threshold
+  QUERY
+  )
+  severity    = 1
+  frequency   = 5
+  time_window = 10
+  trigger {
+    operator  = "GreaterThanOrEqual"
+    threshold = 2
+  }
+}
+
 // These API invoking and result are logged only on application insight
 // [receiptKo, receiptOk, createTimer, deleteTimer]
 resource "azurerm_monitor_scheduled_query_rules_alert" "opex_pagopa-wisp-converter-ai-availability" {

--- a/src/domains/nodo-app/00_alert_wisp_dismantling.tf
+++ b/src/domains/nodo-app/00_alert_wisp_dismantling.tf
@@ -51,8 +51,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "opex_pagopa-wisp-convert
   description    = "Availability for https://api.platform.pagopa.it/wisp-converter/redirect/api/v1/payments is less than or equal to threshold - https://portal.azure.com/?l=en.en-us#@pagopait.onmicrosoft.com/dashboard/arm/subscriptions/b9fc9419-6097-45fe-9f74-ba0641c91912/resourcegroups/dashboards/providers/microsoft.portal/dashboards/pagopa-p-opex_pagopa-wisp-converter"
   enabled        = true
   query = (<<-QUERY
-let lowTrafficThreshold = 80; // the lower threshold that can be calculated regarding the number of invocations
-let highTrafficThreshold = 99; // the upper threshold that can be calculated regarding the number of invocations
+let lowTrafficThreshold = 70; // the lower threshold that can be calculated regarding the number of invocations
+let highTrafficThreshold = 95; // the upper threshold that can be calculated regarding the number of invocations
 let trafficMin = 100; // the minimum number of invocations (traffic) below which 'lowTrafficThreshold' guideline is used
 let trafficLinear = 500;  // the minimum number of invocations (traffic) above which 'highTrafficThreshold' guideline is used
 let thresholdDelta = trafficLinear - trafficMin; // the difference of the traffic guideline on which the expected availability is calculated
@@ -173,7 +173,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "opex_pagopa-wisp-convert
 let errorsToExclude = dynamic([
   "WIC-1300", // payment position already paid
   "WIC-2001", // RPT timer creation
-  "WIC-3004" // client errors
+  "WIC-3004"  // CLIENT_CHECKOUT error
 ]);
 traces
 | where cloud_RoleName == "pagopawispconverter"

--- a/src/domains/nodo-app/00_alert_wisp_dismantling.tf
+++ b/src/domains/nodo-app/00_alert_wisp_dismantling.tf
@@ -173,7 +173,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "opex_pagopa-wisp-convert
 let errorsToExclude = dynamic([
   "WIC-1300", // payment position already paid
   "WIC-2001", // RPT timer creation
-  "WIC-3001", "WIC-3002", "WIC-3003", "WIC-3004", "WIC-3005", "WIC-3006" // client errors
+  "WIC-3004" // client errors
 ]);
 traces
 | where cloud_RoleName == "pagopawispconverter"

--- a/src/domains/nodo-app/README.md
+++ b/src/domains/nodo-app/README.md
@@ -206,6 +206,7 @@
 | [azurerm_monitor_scheduled_query_rules_alert.opex_pagopa-wisp-converter-ai-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.opex_pagopa-wisp-converter-ai-error](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.opex_pagopa-wisp-converter-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert.opex_pagopa-wisp-converter-redirect-availability](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.opex_pagopa-wisp-converter-wic-error](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_resource_group.nodo_re_to_datastore_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.vmss_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |


### PR DESCRIPTION
This PR contains a new alert made for WISP Dismantling in order to generate an alarm if the redirect API call ends too much with an unsuccess.

### List of changes
 - Add new Opsgenie alert for WISP Dismantling project
 - Updated existing one, removing client errors from excluded exceptions

### Motivation and context
This feature is required in order to enhance alarms on WISP dismantling project

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
