### PR TITLE
fix(on-error): [MAIN-14] fix content-type

### DIFF
--- a/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
+++ b/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
@@ -44,11 +44,9 @@
   </choose>
   <set-variable name="leggirisposta" value="@((string)((IResponse)context.Variables["risposta"]).Body.As<string>(preserveContent: true))" />
   <return-response>
-    <!--
-<set-header name="Content-Type" exists-action="override">
-<value>text/xml</value>
-</set-header>
-    -->
+    <set-header name="Content-Type" exists-action="override">
+      <value>@(context.Response.Headers.GetValueOrDefault("Content-Type","")</value>
+    </set-header>
     <set-body>@{
       string message = (string)context.Variables["leggirisposta"];
       return message;

--- a/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
+++ b/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
@@ -44,9 +44,13 @@
   </choose>
   <set-variable name="leggirisposta" value="@((string)((IResponse)context.Variables["risposta"]).Body.As<string>(preserveContent: true))" />
   <return-response>
-    <set-header name="Content-Type" exists-action="override">
-      <value>@(context.Response.Headers.GetValueOrDefault("Content-Type","")</value>
-    </set-header>
+    <choose>
+      <when condition="@(!((string)context.Response.Headers.GetValueOrDefault("Content-Type","NONE")).Equals("NONE"))">
+        <set-header name="Content-Type" exists-action="override">
+          <value>@(context.Response.Headers.GetValueOrDefault("Content-Type","")</value>
+        </set-header>
+      </when>
+    </choose>
     <set-body>@{
       string message = (string)context.Variables["leggirisposta"];
       return message;

--- a/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
+++ b/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
@@ -7,6 +7,7 @@
     <trace source="first-when" severity="information">execute on-error request</trace>
     <choose>
       <when condition="@(context.Variables.ContainsKey("soapAction") && context.Variables.GetValueOrDefault<string>("soapAction", "")!= "")">
+      <set-variable name="contentType" value="text/xml"/>
       <!-- SOAP requests -->
       <send-request mode="new" ignore-error="true" response-variable-name="risposta">
         <set-url>@{return ((string) context.Variables["baseUrl"]+"/webservices/input"); }</set-url>
@@ -26,6 +27,7 @@
       </send-request>
     </when>
     <otherwise>
+      <set-variable name="contentType" value="application/json"/>
       <!-- REST requests -->
       <send-request mode="new" ignore-error="true" response-variable-name="risposta">
         <set-url>@{return (string) context.Variables["baseUrl"] + "/" + (string)context.Request.Url.Path; }</set-url>
@@ -44,13 +46,9 @@
   </choose>
   <set-variable name="leggirisposta" value="@((string)((IResponse)context.Variables["risposta"]).Body.As<string>(preserveContent: true))" />
   <return-response>
-    <choose>
-      <when condition="@(!((string)context.Response.Headers.GetValueOrDefault("Content-Type","NONE")).Equals("NONE"))">
-        <set-header name="Content-Type" exists-action="override">
-          <value>@(context.Response.Headers.GetValueOrDefault("Content-Type","")</value>
-        </set-header>
-      </when>
-    </choose>
+    <set-header name="Content-Type" exists-action="override">
+        <value>@((string)context.Variables["contentType"])</value>
+    </set-header>
     <set-body>@{
       string message = (string)context.Variables["leggirisposta"];
       return message;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Fixed content-type in case of response coming from the on-error api product policy

```
sh terraform.sh apply <ENV> \
-target=terraform_data.sha256_on_erro_soap_handler \
-target=azapi_resource.on_erro_soap_handler
```

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
In case of some kind of error in the main api policy, the on-error policy inherited from the product didn't set the content-type correctly, causing problems to those clients who have strict checks on it.
### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
