### PR TITLE
fix: [CHK-3593] Parametric percentage threshold for delayed processing queue alert

### DIFF
--- a/src/domains/ecommerce-common/03_storage.tf
+++ b/src/domains/ecommerce-common/03_storage.tf
@@ -477,7 +477,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "ecommerce_enqueue_rate_a
         | project PutCount, DeleteCount, Diff
     };
     MessageRateForQueue("%s", startPut, endPut, startDelete, endDelete)
-    | where Diff > ${each.value.threshold}
+    | where Diff > max_of(PutCount/100, ${each.value.threshold})
     QUERY
     , "/${module.ecommerce_storage_transient.name}/${local.project}-${each.value.queue_key}"
   )


### PR DESCRIPTION
Use percentage threshold in place of fixed value for high traffic

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
