### PR TITLE
feat: [PAYMCLOUD-185] Enable cost analysis feature in UAT and PROD environments

### DIFF
--- a/src/aks-platform/02_aks.tf
+++ b/src/aks-platform/02_aks.tf
@@ -20,8 +20,8 @@ module "aks" {
   workload_identity_enabled = var.aks_enable_workload_identity
   oidc_issuer_enabled       = var.aks_enable_workload_identity
 
-  # ff: Enabled only in UAT ( Testing in progress... )
-  cost_analysis_enabled = var.env_short != "d" ? (var.env_short == "p" ? false : true) : false
+  # ff: Enabled cost analysis on UAT/PROD
+  cost_analysis_enabled = var.env_short != "d" ? true : false
 
   #
   # 🤖 System node pool


### PR DESCRIPTION
**Description:**
### List of changes
- Updated the `cost_analysis_enabled` flag to ensure it is active in both UAT and PROD environments.

### Motivation and context
This change is required to enable the cost analysis feature in both the UAT and PROD environments. Ensuring that the `cost_analysis_enabled` flag is active aligns with the intended feature rollout.

### Type of changes
- [x] Update configuration to existing resources

### Does this introduce a change to production resources with possible user impact?
- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [x] No

### Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)