### PR TITLE
feat: [PAYMCLOUD-253] Add Azure Monitor Workspace and Prometheus integration

### DIFF
--- a/src/aks-platform/.terraform.lock.hcl
+++ b/src/aks-platform/.terraform.lock.hcl
@@ -23,7 +23,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
 
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.110.0"
-  constraints = "~> 3.30, ~> 3.100, ~> 3.110, <= 3.110.0"
+  constraints = "~> 3.30, ~> 3.105, ~> 3.110, <= 3.110.0, <= 3.116.0"
   hashes = [
     "h1:uxeKsqfI9LjvYkcMCiFwlDpQzZvrB83pVJIoG9s4t54=",
     "zh:1a1fe9e1a4c08453f249352d135349f7a06f2973dbb839375c7b802523a87351",
@@ -63,7 +63,7 @@ provider "registry.terraform.io/hashicorp/helm" {
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.30.0"
-  constraints = "~> 2.30, <= 2.30.0"
+  constraints = "~> 2.30, <= 2.30.0, <= 2.33.0"
   hashes = [
     "h1:+Je5UPTWMmO4eG5ep1WfujkXQI9tDk0OsMU4olU76Bg=",
     "zh:06531333a72fe6d2829f37a328e08a3fc4ed66226344a003b62418a834ac6c69",

--- a/src/aks-platform/02_aks.tf
+++ b/src/aks-platform/02_aks.tf
@@ -7,7 +7,7 @@ resource "azurerm_resource_group" "aks_rg" {
 
 
 module "aks" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster?ref=PAYMCLOUD-222-Add-prometheus-managed-on-terraform-module-v3"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster?ref=v8.80.0"
 
   name                       = local.aks_name
   location                   = var.location

--- a/src/aks-platform/02_aks.tf
+++ b/src/aks-platform/02_aks.tf
@@ -7,7 +7,7 @@ resource "azurerm_resource_group" "aks_rg" {
 
 
 module "aks" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster?ref=v8.69.0"
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster?ref=PAYMCLOUD-222-Add-prometheus-managed-on-terraform-module-v3"
 
   name                       = local.aks_name
   location                   = var.location
@@ -19,6 +19,10 @@ module "aks" {
 
   workload_identity_enabled = var.aks_enable_workload_identity
   oidc_issuer_enabled       = var.aks_enable_workload_identity
+
+  ## Prometheus managed
+  # ff: enabled on DEV
+  enable_prometheus_monitor_metrics = var.env_short == "d" ? true : false
 
   # ff: Enabled cost analysis on UAT/PROD
   cost_analysis_enabled = var.env_short != "d" ? true : false

--- a/src/aks-platform/05_monitoring.tf
+++ b/src/aks-platform/05_monitoring.tf
@@ -133,3 +133,21 @@ resource "kubernetes_manifest" "service_monitor" {
     }
   }
 }
+
+# Refer: Resource created on next-core 02_monitor.tf
+data "azurerm_monitor_workspace" "workspace" {
+  name                = "pagopa-${var.env_short}-${var.location}-monitor-workspace"
+  resource_group_name = "pagopa-${var.env_short}-monitor-rg"
+}
+
+module "prometheus_managed_addon" {
+  source                 = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_prometheus_managed?ref=v8.80.0"
+  cluster_name           = module.aks.name
+  resource_group_name    = module.aks.aks_resource_group_name
+  location               = var.location
+  monitor_workspace_name = data.azurerm_monitor_workspace.workspace.name
+  monitor_workspace_rg   = data.azurerm_monitor_workspace.workspace.resource_group_name
+  grafana_name           = "pagopa-${var.env_short}-${var.location_short}-grafana"
+  grafana_resource_group = "pagopa-${var.env_short}-${var.location_short}-grafana-rg"
+  tags                   = var.tags
+}

--- a/src/aks-platform/README.md
+++ b/src/aks-platform/README.md
@@ -15,13 +15,14 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aks"></a> [aks](#module\_aks) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster | v8.69.0 |
+| <a name="module_aks"></a> [aks](#module\_aks) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster | PAYMCLOUD-222-Add-prometheus-managed-on-terraform-module-v3 |
 | <a name="module_aks_snet"></a> [aks\_snet](#module\_aks\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v8.53.0 |
 | <a name="module_keda_pod_identity"></a> [keda\_pod\_identity](#module\_keda\_pod\_identity) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_pod_identity | v8.53.0 |
 | <a name="module_kubernetes_event_exporter"></a> [kubernetes\_event\_exporter](#module\_kubernetes\_event\_exporter) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_event_exporter | v8.76.0 |
 | <a name="module_monitoring_pod_identity"></a> [monitoring\_pod\_identity](#module\_monitoring\_pod\_identity) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_pod_identity | v8.53.0 |
 | <a name="module_nginx_ingress"></a> [nginx\_ingress](#module\_nginx\_ingress) | terraform-module/release/helm | 2.8.0 |
 | <a name="module_opencosts"></a> [opencosts](#module\_opencosts) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_opencosts | v8.71.0 |
+| <a name="module_prometheus_managed_addon"></a> [prometheus\_managed\_addon](#module\_prometheus\_managed\_addon) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_prometheus_managed | v8.80.0 |
 | <a name="module_tls_checker"></a> [tls\_checker](#module\_tls\_checker) | git::https://github.com/pagopa/terraform-azurerm-v3.git//tls_checker | v8.54.0 |
 | <a name="module_tls_checker_workload_identity_configuration"></a> [tls\_checker\_workload\_identity\_configuration](#module\_tls\_checker\_workload\_identity\_configuration) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_workload_identity_configuration | v8.54.0 |
 | <a name="module_tls_checker_workload_identity_init"></a> [tls\_checker\_workload\_identity\_init](#module\_tls\_checker\_workload\_identity\_init) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_workload_identity_init | v8.54.0 |
@@ -66,6 +67,7 @@
 | [azurerm_monitor_action_group.email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.opsgenie](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.slack](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
+| [azurerm_monitor_workspace.workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_workspace) | data source |
 | [azurerm_resource_group.monitor_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.vnet_core_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.vnet_integration_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/src/aks-platform/README.md
+++ b/src/aks-platform/README.md
@@ -15,7 +15,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aks"></a> [aks](#module\_aks) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster | PAYMCLOUD-222-Add-prometheus-managed-on-terraform-module-v3 |
+| <a name="module_aks"></a> [aks](#module\_aks) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster | v8.80.0 |
 | <a name="module_aks_snet"></a> [aks\_snet](#module\_aks\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v8.53.0 |
 | <a name="module_keda_pod_identity"></a> [keda\_pod\_identity](#module\_keda\_pod\_identity) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_pod_identity | v8.53.0 |
 | <a name="module_kubernetes_event_exporter"></a> [kubernetes\_event\_exporter](#module\_kubernetes\_event\_exporter) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_event_exporter | v8.76.0 |

--- a/src/next-core/02_monitor.tf
+++ b/src/next-core/02_monitor.tf
@@ -24,6 +24,16 @@ resource "azurerm_log_analytics_workspace" "log_analytics_workspace" {
   }
 }
 
+# Azure Monitor Workspace
+resource "azurerm_monitor_workspace" "monitor_workspace" {
+  count               = var.env == "dev" ? 1 : 0
+  name                = "pagopa-${var.env_short}-${var.location}-monitor-workspace"
+  resource_group_name = "pagopa-${var.env_short}-monitor-rg"
+  location            = var.location
+
+  tags = var.tags
+}
+
 # Application insights
 resource "azurerm_application_insights" "application_insights" {
   name                = format("%s-appinsights", local.product)

--- a/src/next-core/README.md
+++ b/src/next-core/README.md
@@ -178,6 +178,7 @@
 | [azurerm_monitor_metric_alert.snat_connection_over_10K](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_metric_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.opex_pagopa-node-forwarder-availability-upd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert.opex_pagopa-node-forwarder-responsetime-upd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert) | resource |
+| [azurerm_monitor_workspace.monitor_workspace](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_workspace) | resource |
 | [azurerm_network_security_group.apimv2_snet_nsg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
 | [azurerm_network_security_rule.apimv2_snet_nsg_rules](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
 | [azurerm_private_dns_a_record.platform_dns_a_private_apim](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_a_record) | resource |


### PR DESCRIPTION
### List of changes

- Added Azure Monitor Workspace for development environments to `next-core`.
- Enabled Prometheus managed addon in `aks-platform` DEV with integration to the Azure Monitor Workspace.
- Updated Terraform module and provider constraints to accommodate the new features.

### Motivation and context

This change introduces enhanced monitoring capabilities for development environments via Azure Monitor Workspace. Prometheus integration helps in unified metrics collection and visualization, improving infrastructure observability.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

N/A