### PR TITLE
chore: [PAYMCLOUD-253] Enable conditional deployment of Prometheus addon for aks weu dev environment

### DIFF
--- a/src/aks-platform/05_monitoring.tf
+++ b/src/aks-platform/05_monitoring.tf
@@ -136,6 +136,7 @@ resource "kubernetes_manifest" "service_monitor" {
 
 # Refer: Resource created on next-core 02_monitor.tf
 data "azurerm_monitor_workspace" "workspace" {
+  count               = var.env == "dev" ? 1 : 0
   name                = "pagopa-${var.env_short}-${var.location}-monitor-workspace"
   resource_group_name = "pagopa-${var.env_short}-monitor-rg"
 }
@@ -146,8 +147,8 @@ module "prometheus_managed_addon" {
   cluster_name           = module.aks.name
   resource_group_name    = module.aks.aks_resource_group_name
   location               = var.location
-  monitor_workspace_name = data.azurerm_monitor_workspace.workspace.name
-  monitor_workspace_rg   = data.azurerm_monitor_workspace.workspace.resource_group_name
+  monitor_workspace_name = data.azurerm_monitor_workspace.workspace.0.name
+  monitor_workspace_rg   = data.azurerm_monitor_workspace.workspace.0.resource_group_name
   grafana_name           = "pagopa-${var.env_short}-${var.location_short}-grafana"
   grafana_resource_group = "pagopa-${var.env_short}-${var.location_short}-grafana-rg"
   tags                   = var.tags

--- a/src/aks-platform/05_monitoring.tf
+++ b/src/aks-platform/05_monitoring.tf
@@ -141,6 +141,7 @@ data "azurerm_monitor_workspace" "workspace" {
 }
 
 module "prometheus_managed_addon" {
+  count                  = var.env == "dev" ? 1 : 0
   source                 = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_prometheus_managed?ref=v8.80.0"
   cluster_name           = module.aks.name
   resource_group_name    = module.aks.aks_resource_group_name


### PR DESCRIPTION

**Description:**

### List of changes
- Added a conditional `count` to the `prometheus_managed_addon` module.
- Ensures the addon is deployed only in the development environment.

### Motivation and context
The change prevents unnecessary deployment of the Prometheus addon in non-development environments, optimizing resource usage.

### Type of changes
- [x] Update configuration to existing resources

### Does this introduce a change to production resources with possible user impact?
- [ ] Yes
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [x] No

###