### PR TITLE
feat: [PAGOPA-2647] defining response caching for `nodoChiediElencoFlussiRendicontazione` primitive

### DIFF
--- a/src/domains/fdr-app/00_data.tf
+++ b/src/domains/fdr-app/00_data.tf
@@ -19,6 +19,11 @@ data "azurerm_storage_account" "fdr_flows_sa" {
   resource_group_name = data.azurerm_resource_group.data.name
 }
 
+data "azurerm_storage_account" "fdr_conversion_sa" {
+  name                = replace("${local.project}-sa", "-", "")
+  resource_group_name = data.azurerm_resource_group.fdr_rg.name
+}
+
 data "azurerm_resource_group" "data" {
   name = "${local.product}-data-rg"
 }
@@ -26,6 +31,11 @@ data "azurerm_resource_group" "data" {
 data "azurerm_storage_container" "fdr_rend_flow" {
   name                 = "${data.azurerm_storage_account.fdr_flows_sa.name}xmlfdrflow"
   storage_account_name = data.azurerm_storage_account.fdr_flows_sa.name
+}
+
+data "azurerm_storage_container" "fdr1_cached_response" {
+  name                 = "fdr1-cached-response"
+  storage_account_name = data.azurerm_storage_account.fdr_conversion_sa.name
 }
 
 data "azurerm_container_registry" "common-acr" {

--- a/src/domains/fdr-app/04_apim_aux.tf
+++ b/src/domains/fdr-app/04_apim_aux.tf
@@ -54,3 +54,28 @@ resource "azurerm_api_management_named_value" "fdrsaname" {
   display_name        = "fdrsaname"
   value               = data.azurerm_storage_account.fdr_flows_sa.name
 }
+
+
+resource "azurerm_api_management_named_value" "fdr_cachedresponse_saname" {
+  name                = "fdr_cachedresponse_saname"
+  api_management_name = data.azurerm_api_management.apim.name
+  resource_group_name = data.azurerm_resource_group.rg_api.name
+  display_name        = "fdr_cachedresponse_saname"
+  value               = data.azurerm_storage_account.fdr_conversion_sa.name
+}
+
+resource "azurerm_api_management_named_value" "fdr_cachedresponse_containername" {
+  name                = "fdr_cachedresponse_containername"
+  api_management_name = data.azurerm_api_management.apim.name
+  resource_group_name = data.azurerm_resource_group.rg_api.name
+  display_name        = "fdr_cachedresponse_containername"
+  value               = data.azurerm_storage_container.fdr1_cached_response.name
+}
+
+resource "azurerm_api_management_named_value" "fdr1_cache_duration" {
+  name                = "fdr1_cache_duration"
+  api_management_name = data.azurerm_api_management.apim.name
+  resource_group_name = data.azurerm_resource_group.rg_api.name
+  display_name        = "fdr1_cache_duration"
+  value               = var.fdr1_cache_duration
+}

--- a/src/domains/fdr-app/04_apim_fdr_fase1.tf
+++ b/src/domains/fdr-app/04_apim_fdr_fase1.tf
@@ -82,7 +82,7 @@ resource "azurerm_api_management_api_operation_policy" "fdr_pagopa_policy_nodoCh
   operation_id        = var.env_short == "d" ? "6218976195aa0303ccfcf901" : var.env_short == "u" ? "61e96321e0f4ba04a49d1285" : "61e9633dea7c4a07cc7d480d"
 
   #tfsec:ignore:GEN005
-  xml_content = templatefile("./api/fdr-fase1/nodoPerPa/v1/fdr_pagopa.xml.tpl", {
+  xml_content = templatefile("./api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_cached_response.xml.tpl", {
     is-fdr-nodo-pagopa-enable = var.apim_fdr_nodo_pagopa_enable
     base-url                  = "https://${local.fdr_hostname}/pagopa-fdr-nodo-service"
   })

--- a/src/domains/fdr-app/04_apim_fdr_fase1.tf
+++ b/src/domains/fdr-app/04_apim_fdr_fase1.tf
@@ -82,7 +82,7 @@ resource "azurerm_api_management_api_operation_policy" "fdr_pagopa_policy_nodoCh
   operation_id        = var.env_short == "d" ? "6218976195aa0303ccfcf901" : var.env_short == "u" ? "61e96321e0f4ba04a49d1285" : "61e9633dea7c4a07cc7d480d"
 
   #tfsec:ignore:GEN005
-  xml_content = templatefile("./api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_cached_response.xml.tpl", {
+  xml_content = templatefile("./api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_nodoChiediElencoFlussiRendicontazione.xml.tpl", {
     is-fdr-nodo-pagopa-enable = var.apim_fdr_nodo_pagopa_enable
     base-url                  = "https://${local.fdr_hostname}/pagopa-fdr-nodo-service"
   })

--- a/src/domains/fdr-app/04_apim_fdr_fase1_auth.tf
+++ b/src/domains/fdr-app/04_apim_fdr_fase1_auth.tf
@@ -86,7 +86,7 @@ resource "azurerm_api_management_api_operation_policy" "fdr_pagopa_policy_nodoCh
   operation_id        = var.env_short == "d" ? "6352c3bcc257810f183b398b" : var.env_short == "u" ? "636cb7e9451c1c01c4186998" : "63b6e2da2a92e811a8f338f8"
 
   #tfsec:ignore:GEN005
-  xml_content = templatefile("./api/fdr-fase1/nodoPerPa/v1/fdr_pagopa.xml.tpl", {
+  xml_content = templatefile("./api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_nodoChiediElencoFlussiRendicontazione.xml.tpl", {
     is-fdr-nodo-pagopa-enable = var.apim_fdr_nodo_pagopa_enable
     base-url                  = "https://${local.fdr_hostname}/pagopa-fdr-nodo-service"
   })

--- a/src/domains/fdr-app/99_variables.tf
+++ b/src/domains/fdr-app/99_variables.tf
@@ -494,3 +494,9 @@ variable "fdr_soap_request_ci_whitelist" {
   default     = "*" // * means accept-all
   description = "String list comma separated"
 }
+
+variable "fdr1_cache_duration" {
+  type        = string
+  default     = "1800" // 30 minutes
+  description = "The TTL of keys stored in internal cache for FdR1's cached responses"
+}

--- a/src/domains/fdr-app/README.md
+++ b/src/domains/fdr-app/README.md
@@ -56,6 +56,9 @@
 | [azurerm_api_management_api_version_set.fdr_per_pa_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_version_set) | resource |
 | [azurerm_api_management_named_value.enable_fdr_ci_soap_request](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
 | [azurerm_api_management_named_value.enable_fdr_psp_soap_request](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
+| [azurerm_api_management_named_value.fdr1_cache_duration](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
+| [azurerm_api_management_named_value.fdr_cachedresponse_containername](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
+| [azurerm_api_management_named_value.fdr_cachedresponse_saname](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
 | [azurerm_api_management_named_value.fdr_ci_soap_request_ci_list](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
 | [azurerm_api_management_named_value.fdr_psp_soap_request_psp_list](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
 | [azurerm_api_management_named_value.fdrcontainername](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
@@ -121,8 +124,10 @@
 | [azurerm_resource_group.msg_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.rg_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 | [azurerm_resource_group.rg_vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_storage_account.fdr_conversion_sa](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.fdr_flows_sa](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
 | [azurerm_storage_account.fdr_storage_account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_account) | data source |
+| [azurerm_storage_container.fdr1_cached_response](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container) | data source |
 | [azurerm_storage_container.fdr_rend_flow](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container) | data source |
 | [azurerm_storage_container.fdr_rend_flow_out](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/storage_container) | data source |
 | [azurerm_subnet.apim_snet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
@@ -152,6 +157,7 @@
 | <a name="input_event_name"></a> [event\_name](#input\_event\_name) | Event name related to an EventHub | `string` | `null` | no |
 | <a name="input_eventhub_name"></a> [eventhub\_name](#input\_eventhub\_name) | EventHub name | `string` | `null` | no |
 | <a name="input_external_domain"></a> [external\_domain](#input\_external\_domain) | Domain for delegation | `string` | `null` | no |
+| <a name="input_fdr1_cache_duration"></a> [fdr1\_cache\_duration](#input\_fdr1\_cache\_duration) | The TTL of keys stored in internal cache for FdR1's cached responses | `string` | `"1800"` | no |
 | <a name="input_fdr_json_to_xml_function"></a> [fdr\_json\_to\_xml\_function](#input\_fdr\_json\_to\_xml\_function) | FdR JSON to XML function | <pre>object({<br/>    always_on                    = bool<br/>    kind                         = string<br/>    sku_size                     = string<br/>    sku_tier                     = string<br/>    maximum_elastic_worker_count = number<br/>  })</pre> | <pre>{<br/>  "always_on": true,<br/>  "kind": "Linux",<br/>  "maximum_elastic_worker_count": 1,<br/>  "sku_size": "B1",<br/>  "sku_tier": "Basic"<br/>}</pre> | no |
 | <a name="input_fdr_json_to_xml_function_app_image_tag"></a> [fdr\_json\_to\_xml\_function\_app\_image\_tag](#input\_fdr\_json\_to\_xml\_function\_app\_image\_tag) | FdR JSON to XML function app docker image tag. Defaults to 'latest' | `string` | `"latest"` | no |
 | <a name="input_fdr_json_to_xml_function_autoscale"></a> [fdr\_json\_to\_xml\_function\_autoscale](#input\_fdr\_json\_to\_xml\_function\_autoscale) | FdR JSON to XML function autoscaling parameters | <pre>object({<br/>    default = number<br/>    minimum = number<br/>    maximum = number<br/>  })</pre> | n/a | yes |

--- a/src/domains/fdr-app/api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_cached_response.xml.tpl
+++ b/src/domains/fdr-app/api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_cached_response.xml.tpl
@@ -1,0 +1,180 @@
+<policies>
+    <inbound>
+        <base />
+        <set-variable name="enable_fdr_ci_soap_request_switch" value="{{enable-fdr-ci-soap-request-switch}}" />
+        <set-variable name="is_fdr_nodo_pagopa_enable" value="@(${is-fdr-nodo-pagopa-enable})" />
+        <choose>
+            <when condition="@( context.Variables.GetValueOrDefault<bool>("is_fdr_nodo_pagopa_enable", false) && context.Variables.GetValueOrDefault<string>("enable_fdr_ci_soap_request_switch", "").Equals("true") )">
+
+              <!-- ##### START CACHE RETRIEVE PROCESS - READ PHASE #### -->
+
+              <!-- Extracting values for fields domainId, station and PSP -->
+              <set-variable name="readrequest" value="@(context.Request.Body.As<string>(preserveContent: true))" />
+              <set-variable name="station_id" value="@{
+                var dom2parse = ((string) context.Variables["readrequest"]);
+                String[] separator = {"identificativoStazioneIntermediarioPA"};
+                String[] result = dom2parse.Split(separator, StringSplitOptions.RemoveEmptyEntries);
+                var value = result.Length > 2 ? result[1].Substring(1,result[1].Length-3).Replace("xmlns=\"\">", "") : "ND";
+                return value;
+              }" />
+              <set-variable name="domain_id" value="@{
+                var dom2parse = ((string) context.Variables["readrequest"]);
+                String[] separator = {"identificativoDominio"};
+                String[] result = dom2parse.Split(separator, StringSplitOptions.RemoveEmptyEntries);
+                var value = result.Length > 2 ? result[1].Substring(1,result[1].Length-3).Replace("xmlns=\"\">", "") : "ND";
+                return value;
+              }" />
+              <set-variable name="psp_id" value="@{
+                var dom2parse = ((string) context.Variables["readrequest"]);
+                String[] separator = {"identificativoPSP"};
+                String[] result = dom2parse.Split(separator, StringSplitOptions.RemoveEmptyEntries);
+                var value = result.Length > 2 ? result[1].Substring(1,result[1].Length-3).Replace("xmlns=\"\">", "") : "ND";
+                return value;
+              }" />
+
+              <!-- Generating cache key in format fdr::fase1::cachereq::domainId-stationId-pspId, then read it from internal cache -->
+              <set-variable name="cached_response_key" value="@{
+                String prefix = "fdr::fase1::cachereq::";
+                String domainId = ((string) context.Variables["domain_id"]);
+                String stationId = ((string) context.Variables["station_id"]);
+                String pspId = ((string) context.Variables["psp_id"]);
+                return prefix + domainId + "-" + stationId + "-" + pspId;
+              }" />
+              <cache-lookup-value variable-name="cached_response_uuid" key="@((string) context.Variables["cached_response_key"])" caching-type="internal" default-value="NONE"/>
+
+              <!-- If cached response UUID exists, it's time to search the cached response in blob-storage -->
+              <choose>
+                <when condition="@( !"NONE".Equals((string) context.Variables["cached_response_uuid"]) )">
+
+                  <!-- Execute a GET call on blob-storage using the UUID as "search filter" -->
+                  <authentication-managed-identity resource="https://storage.azure.com/" output-token-variable-name="msi-access-token" ignore-error="false" />
+                  <send-request mode="new" response-variable-name="cached_response_content" timeout="300" ignore-error="true">
+                    <set-url>@{ return "https://{{fdr_cachedresponse_saname}}.blob.core.windows.net/" + "{{fdr_cachedresponse_containername}}" + "/" + ((string) context.Variables["cached_response_uuid"]) + ".txt"; }</set-url>
+                    <set-method>GET</set-method>
+                    <set-header name="Host" exists-action="override">
+                      <value>{{fdr_cachedresponse_saname}}.blob.core.windows.net</value>
+                    </set-header>
+                    <set-header name="X-Ms-Blob-Type" exists-action="override">
+                      <value>BlockBlob</value>
+                    </set-header>
+                    <set-header name="X-Ms-Version" exists-action="override">
+                      <value>2019-12-12</value>
+                    </set-header>
+                    <set-header name="Accept" exists-action="override">
+                      <value>*/*</value>
+                    </set-header>
+                    <set-header name="Authorization" exists-action="override">
+                      <value>@("Bearer " + (string) context.Variables["msi-access-token"])</value>
+                    </set-header>
+                  </send-request>
+
+                  <!-- If a valid blob content is found in blob-storage, return the response and the related headers -->
+                  <!-- This check is required because the persistence on blob-storage (made in async way) can end unsuccessfully and the cached key is stored anyway. -->
+                  <choose>
+                    <when condition="@(context.Variables["cached_response_content"] != null && ((IResponse) context.Variables["cached_response_content"]).StatusCode == 200)">
+                      <!-- Log a little tracing message and generate the response with headers and content -->
+                      <trace source="cached_content_found_on_blobstorage" severity="information">
+                        <message>@{ return "BLOB content found for cached response with UUID [" + ((string) context.Variables["cached_response_uuid"]) + "]"; }</message>
+                      </trace>
+                      <set-variable name="cached_response_blob" value="@(((IResponse) context.Variables["cached_response_content"]).Body.As<string>())" />
+                      <set-variable name="cached_response_status_code" value="@(((IResponse) context.Variables["cached_response_content"]).Headers.GetValueOrDefault("X-Response-Status-Code", "200"))" />
+                      <set-variable name="cached_response_status_reason" value="@(((IResponse) context.Variables["cached_response_content"]).Headers.GetValueOrDefault("X-Response-Status-Reason", "OK"))" />
+                      <set-variable name="cached_response_content_type" value="@(((IResponse) context.Variables["cached_response_content"]).Headers.GetValueOrDefault("X-Response-Content-Type", "text/xml"))" />
+                      <return-response>
+                        <set-status code="@((int) context.Variables["cached_response_status_code"])" reason="@((string) context.Variables["cached_response_status_reason"])" />
+                        <set-header name="Content-Type" exists-action="override">
+                          <value>@((string) context.Variables["cached_response_content_type"])</value>
+                        </set-header>
+                        <set-body>@((string) context.Variables["cached_response_blob"])</set-body>
+                      </return-response>
+                    </when>
+                    <!-- If no valid blob content is found in blob-storage, at least log an error and continue processing request -->
+                    <otherwise>
+                      <trace source="cached_content_not_found_on_blobstorage" severity="error">
+                        <message>@{ return "No valid BLOB content found for cached response with UUID [" + ((string) context.Variables["cached_response_uuid"]) + "]"; }</message>
+                      </trace>
+                    </otherwise>
+                  </choose>
+
+                </when>
+              </choose>
+
+              <!-- ##### END CACHE RETRIEVE PROCESS - READ PHASE #### -->
+
+              <set-backend-service base-url="${base-url}" />
+            </when>
+        </choose>
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+
+        <!-- ##### START CACHE RETRIEVE PROCESS - WRITE PHASE #### -->
+
+        <!-- Extracting alll needed variables from response in order to use them on BLOB content file -->
+        <set-variable name="response_body_to_cache" value="@(((IResponse) context.Response).Body.As<string>())" />
+        <set-variable name="response_status_code_to_cache" value="@(((IResponse) context.Response).StatusCode)" />
+        <set-variable name="response_content_type_to_cache" value="@(((IResponse) context.Response).Headers.GetValueOrDefault("Content-Type", "text/xml"))" />
+        <set-variable name="response_status_reason_to_cache" value="@(((IResponse) context.Response).StatusReason)" />
+
+        <!-- Generate the UUID value in order to be used for BLOB identifier -->
+        <set-variable name="cached_response_uuid_value" value="@{ return System.Guid.NewGuid().ToString(); }" />
+
+        <!-- Store generated key with UUID value for GET phase -->
+        <cache-store-value key="@((string) context.Variables["cached_response_key"])" value="@((string) context.Variables["cached_response_uuid_value"])" caching-type="internal" duration="{{fdr1_cache_duration}}" />
+
+        <!-- Finally, send response in BLOB storage in asyncronous way. If an error occurred during persistence, -->
+        <!-- in read phase the absence of BLOB file is considered equivalent to no-cached-response, so the request is sent to backend.  -->
+        <authentication-managed-identity resource="https://storage.azure.com/" output-token-variable-name="msi-access-token" ignore-error="true" />
+        <send-one-way-request mode="new" timeout="300">
+          <set-url>@{ return "https://{{fdr_cachedresponse_saname}}.blob.core.windows.net/" + "{{fdr_cachedresponse_containername}}" + "/" + ((string) context.Variables["cached_response_uuid_value"]) + ".txt"; }</set-url>
+          <set-method>PUT</set-method>
+          <set-header name="Host" exists-action="override">
+            <value>{{fdr_cachedresponse_saname}}.blob.core.windows.net</value>
+          </set-header>
+          <set-header name="X-Ms-Blob-Type" exists-action="override">
+            <value>BlockBlob</value>
+          </set-header>
+          <set-header name="X-Ms-Blob-Cache-Control" exists-action="override">
+            <value />
+          </set-header>
+          <set-header name="X-Ms-Blob-Content-Disposition" exists-action="override">
+            <value />
+          </set-header>
+          <set-header name="X-Ms-Blob-Content-Encoding" exists-action="override">
+            <value />
+          </set-header>
+          <set-header name="X-Ms-Blob-Content-Language" exists-action="override">
+            <value />
+          </set-header>
+          <set-header name="X-Ms-Version" exists-action="override">
+            <value>2019-12-12</value>
+          </set-header>
+          <set-header name="Accept" exists-action="override">
+            <value>text/xml</value>
+          </set-header>
+          <set-header name="Authorization" exists-action="override">
+            <value>@("Bearer " + (string)context.Variables["msi-access-token"])</value>
+          </set-header>
+          <!-- Setting the custom headers, required for cached response -->
+          <set-header name="X-Response-Status-Code" exists-action="override">
+            <value>@((string) context.Variables["response_status_code_to_cache"])</value>
+          </set-header>
+          <set-header name="X-Response-Status-Reason" exists-action="override">
+            <value>@((string) context.Variables["response_status_reason_to_cache"])</value>
+          </set-header>
+          <set-header name="X-Response-Content-Type" exists-action="override">
+            <value>@((string) context.Variables["response_content_type_to_cache"])</value>
+          </set-header>
+          <!-- Set the file content from the original request body data -->
+          <set-body>@((string) context.Variables["response_body_to_cache"])</set-body>
+        </send-one-way-request>
+
+        <!-- ##### END CACHE RETRIEVE PROCESS - WRITE PHASE #### -->
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/src/domains/fdr-app/api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_nodoChiediElencoFlussiRendicontazione.xml.tpl
+++ b/src/domains/fdr-app/api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_nodoChiediElencoFlussiRendicontazione.xml.tpl
@@ -178,7 +178,7 @@
           <!-- If no valid blob content is found in blob-storage, at least log an error and continue processing request -->
           <otherwise>
             <trace source="response_not_cached_for_error" severity="information">
-              <message>@{ return "Not caching response with UUID [" + ((string) context.Variables["fdr_cached_response_uuid"]) + "] because the response returned a fault code."; }</message>
+              <message>@{ return "Not caching response because the response returned a fault code."; }</message>
             </trace>
           </otherwise>
         </choose>

--- a/src/domains/fdr-app/api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_nodoChiediElencoFlussiRendicontazione.xml.tpl
+++ b/src/domains/fdr-app/api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_nodoChiediElencoFlussiRendicontazione.xml.tpl
@@ -180,11 +180,11 @@
             </send-one-way-request>
           </when>
           <!-- If no valid blob content is found in blob-storage, at least log an error and continue processing request -->
-          <otherwise>
+          <!--<otherwise>
             <trace source="response_not_cached_for_error" severity="information">
               <message>@{ return "Not caching response because the response returned a fault code."; }</message>
             </trace>
-          </otherwise>
+          </otherwise>-->
         </choose>
 
         <!-- ##### END CACHE RETRIEVE PROCESS - WRITE PHASE #### -->

--- a/src/domains/fdr-app/api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_nodoChiediElencoFlussiRendicontazione.xml.tpl
+++ b/src/domains/fdr-app/api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_nodoChiediElencoFlussiRendicontazione.xml.tpl
@@ -10,46 +10,39 @@
 
               <!-- Extracting values for fields domainId, station and PSP -->
               <set-variable name="readrequest" value="@(context.Request.Body.As<string>(preserveContent: true))" />
-              <set-variable name="station_id" value="@{
-                var dom2parse = ((string) context.Variables["readrequest"]);
-                String[] separator = {"identificativoStazioneIntermediarioPA"};
-                String[] result = dom2parse.Split(separator, StringSplitOptions.RemoveEmptyEntries);
-                var value = result.Length > 2 ? result[1].Substring(1,result[1].Length-3).Replace("xmlns=\"\">", "") : "ND";
-                return value;
-              }" />
-              <set-variable name="domain_id" value="@{
-                var dom2parse = ((string) context.Variables["readrequest"]);
-                String[] separator = {"identificativoDominio"};
-                String[] result = dom2parse.Split(separator, StringSplitOptions.RemoveEmptyEntries);
-                var value = result.Length > 2 ? result[1].Substring(1,result[1].Length-3).Replace("xmlns=\"\">", "") : "ND";
-                return value;
-              }" />
-              <set-variable name="psp_id" value="@{
-                var dom2parse = ((string) context.Variables["readrequest"]);
-                String[] separator = {"identificativoPSP"};
-                String[] result = dom2parse.Split(separator, StringSplitOptions.RemoveEmptyEntries);
-                var value = result.Length > 2 ? result[1].Substring(1,result[1].Length-3).Replace("xmlns=\"\">", "") : "ND";
-                return value;
-              }" />
 
-              <!-- Generating cache key in format fdr::fase1::cachereq::domainId-stationId-pspId, then read it from internal cache -->
+              <!-- Generating cache key in format fdr::fase1::cachereq::brokerId-stationId-domainId-pspId, then read it from internal cache -->
               <set-variable name="cached_response_key" value="@{
-                String prefix = "fdr::fase1::cachereq::";
-                String domainId = ((string) context.Variables["domain_id"]);
-                String stationId = ((string) context.Variables["station_id"]);
-                String pspId = ((string) context.Variables["psp_id"]);
-                return prefix + domainId + "-" + stationId + "-" + pspId;
+                var dom2parse = ((string) context.Variables["readrequest"]);
+
+                String[] tagBrokerId = {"identificativoIntermediarioPA"};
+                String[] result = dom2parse.Split(tagBrokerId, StringSplitOptions.RemoveEmptyEntries);
+                String brokerId = result.Length > 2 ? result[1].Substring(1,result[1].Length-3).Replace("xmlns=\"\">", "") : "ND";
+
+                String[] tagStationId = {"identificativoStazioneIntermediarioPA"};
+                result = dom2parse.Split(tagStationId, StringSplitOptions.RemoveEmptyEntries);
+                String stationId = result.Length > 2 ? result[1].Substring(1,result[1].Length-3).Replace("xmlns=\"\">", "") : "ND";
+
+                String[] tagDomainId = {"identificativoDominio"};
+                result = dom2parse.Split(tagDomainId, StringSplitOptions.RemoveEmptyEntries);
+                String domainId = result.Length > 2 ? result[1].Substring(1,result[1].Length-3).Replace("xmlns=\"\">", "") : "ND";
+
+                String[] tagPspId = {"identificativoPSP"};
+                result = dom2parse.Split(tagPspId, StringSplitOptions.RemoveEmptyEntries);
+                String pspId = result.Length > 2 ? result[1].Substring(1,result[1].Length-3).Replace("xmlns=\"\">", "") : "ND";
+
+                return "fdr::fase1::cachereq::" + brokerId + "-" + stationId + "-" + domainId + "-" + pspId;
               }" />
-              <cache-lookup-value variable-name="cached_response_uuid" key="@((string) context.Variables["cached_response_key"])" caching-type="internal" default-value="NONE"/>
+              <cache-lookup-value variable-name="fdr_cached_response_uuid" key="@((string) context.Variables["cached_response_key"])" caching-type="internal" default-value="NONE"/>
 
               <!-- If cached response UUID exists, it's time to search the cached response in blob-storage -->
               <choose>
-                <when condition="@( !"NONE".Equals((string) context.Variables["cached_response_uuid"]) )">
+                <when condition="@( !"NONE".Equals((string) context.Variables["fdr_cached_response_uuid"]) )">
 
                   <!-- Execute a GET call on blob-storage using the UUID as "search filter" -->
                   <authentication-managed-identity resource="https://storage.azure.com/" output-token-variable-name="msi-access-token" ignore-error="false" />
                   <send-request mode="new" response-variable-name="cached_response_content" timeout="300" ignore-error="true">
-                    <set-url>@{ return "https://{{fdr_cachedresponse_saname}}.blob.core.windows.net/" + "{{fdr_cachedresponse_containername}}" + "/" + ((string) context.Variables["cached_response_uuid"]) + ".txt"; }</set-url>
+                    <set-url>@{ return "https://{{fdr_cachedresponse_saname}}.blob.core.windows.net/" + "{{fdr_cachedresponse_containername}}" + "/" + ((string) context.Variables["fdr_cached_response_uuid"]) + ".txt"; }</set-url>
                     <set-method>GET</set-method>
                     <set-header name="Host" exists-action="override">
                       <value>{{fdr_cachedresponse_saname}}.blob.core.windows.net</value>
@@ -74,7 +67,7 @@
                     <when condition="@(context.Variables["cached_response_content"] != null && ((IResponse) context.Variables["cached_response_content"]).StatusCode == 200)">
                       <!-- Log a little tracing message and generate the response with headers and content -->
                       <trace source="cached_content_found_on_blobstorage" severity="information">
-                        <message>@{ return "BLOB content found for cached response with UUID [" + ((string) context.Variables["cached_response_uuid"]) + "]"; }</message>
+                        <message>@{ return "BLOB content found for cached response with UUID [" + ((string) context.Variables["fdr_cached_response_uuid"]) + "]"; }</message>
                       </trace>
                       <set-variable name="cached_response_blob" value="@(((IResponse) context.Variables["cached_response_content"]).Body.As<string>())" />
                       <set-variable name="cached_response_status_code" value="@(((IResponse) context.Variables["cached_response_content"]).Headers.GetValueOrDefault("X-Response-Status-Code", "200"))" />
@@ -91,7 +84,7 @@
                     <!-- If no valid blob content is found in blob-storage, at least log an error and continue processing request -->
                     <otherwise>
                       <trace source="cached_content_not_found_on_blobstorage" severity="error">
-                        <message>@{ return "No valid BLOB content found for cached response with UUID [" + ((string) context.Variables["cached_response_uuid"]) + "]"; }</message>
+                        <message>@{ return "No valid BLOB content found for cached response with UUID [" + ((string) context.Variables["fdr_cached_response_uuid"]) + "]"; }</message>
                       </trace>
                     </otherwise>
                   </choose>
@@ -113,23 +106,23 @@
 
         <!-- ##### START CACHE RETRIEVE PROCESS - WRITE PHASE #### -->
 
-        <!-- Extracting alll needed variables from response in order to use them on BLOB content file -->
+        <!-- Extracting all needed variables from response in order to use them on BLOB content file -->
         <set-variable name="response_body_to_cache" value="@(((IResponse) context.Response).Body.As<string>())" />
         <set-variable name="response_status_code_to_cache" value="@(((IResponse) context.Response).StatusCode)" />
         <set-variable name="response_content_type_to_cache" value="@(((IResponse) context.Response).Headers.GetValueOrDefault("Content-Type", "text/xml"))" />
         <set-variable name="response_status_reason_to_cache" value="@(((IResponse) context.Response).StatusReason)" />
 
         <!-- Generate the UUID value in order to be used for BLOB identifier -->
-        <set-variable name="cached_response_uuid_value" value="@{ return System.Guid.NewGuid().ToString(); }" />
+        <set-variable name="fdr_cached_response_uuid_value" value="@{ return System.Guid.NewGuid().ToString(); }" />
 
         <!-- Store generated key with UUID value for GET phase -->
-        <cache-store-value key="@((string) context.Variables["cached_response_key"])" value="@((string) context.Variables["cached_response_uuid_value"])" caching-type="internal" duration="{{fdr1_cache_duration}}" />
+        <cache-store-value key="@((string) context.Variables["cached_response_key"])" value="@((string) context.Variables["fdr_cached_response_uuid_value"])" caching-type="internal" duration="{{fdr1_cache_duration}}" />
 
         <!-- Finally, send response in BLOB storage in asyncronous way. If an error occurred during persistence, -->
         <!-- in read phase the absence of BLOB file is considered equivalent to no-cached-response, so the request is sent to backend.  -->
         <authentication-managed-identity resource="https://storage.azure.com/" output-token-variable-name="msi-access-token" ignore-error="true" />
         <send-one-way-request mode="new" timeout="300">
-          <set-url>@{ return "https://{{fdr_cachedresponse_saname}}.blob.core.windows.net/" + "{{fdr_cachedresponse_containername}}" + "/" + ((string) context.Variables["cached_response_uuid_value"]) + ".txt"; }</set-url>
+          <set-url>@{ return "https://{{fdr_cachedresponse_saname}}.blob.core.windows.net/" + "{{fdr_cachedresponse_containername}}" + "/" + ((string) context.Variables["fdr_cached_response_uuid_value"]) + ".txt"; }</set-url>
           <set-method>PUT</set-method>
           <set-header name="Host" exists-action="override">
             <value>{{fdr_cachedresponse_saname}}.blob.core.windows.net</value>
@@ -160,7 +153,7 @@
           </set-header>
           <!-- Setting the custom headers, required for cached response -->
           <set-header name="X-Response-Status-Code" exists-action="override">
-            <value>@((string) context.Variables["response_status_code_to_cache"])</value>
+            <value>@(((int) context.Variables["response_status_code_to_cache"]).ToString())</value>
           </set-header>
           <set-header name="X-Response-Status-Reason" exists-action="override">
             <value>@((string) context.Variables["response_status_reason_to_cache"])</value>

--- a/src/domains/fdr-app/api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_nodoChiediElencoFlussiRendicontazione.xml.tpl
+++ b/src/domains/fdr-app/api/fdr-fase1/nodoPerPa/v1/fdr_pagopa_nodoChiediElencoFlussiRendicontazione.xml.tpl
@@ -106,64 +106,82 @@
 
         <!-- ##### START CACHE RETRIEVE PROCESS - WRITE PHASE #### -->
 
-        <!-- Extracting all needed variables from response in order to use them on BLOB content file -->
-        <set-variable name="response_body_to_cache" value="@(((IResponse) context.Response).Body.As<string>())" />
-        <set-variable name="response_status_code_to_cache" value="@(((IResponse) context.Response).StatusCode)" />
-        <set-variable name="response_content_type_to_cache" value="@(((IResponse) context.Response).Headers.GetValueOrDefault("Content-Type", "text/xml"))" />
-        <set-variable name="response_status_reason_to_cache" value="@(((IResponse) context.Response).StatusReason)" />
+        <set-variable name="response_body_to_cache" value="@(((IResponse) context.Response).Body.As<string>(preserveContent: true))" />
+        <set-variable name="is_in_error" value="@{
+          var dom2parse = ((string) context.Variables["response_body_to_cache"]);
+          String[] tagFaultCode = {"faultCode"};
+          String[] result = dom2parse.Split(tagFaultCode, StringSplitOptions.RemoveEmptyEntries);
+          return result[1].Substring(1,result[1].Length-3) != null;
+        }" />
 
-        <!-- Generate the UUID value in order to be used for BLOB identifier -->
-        <set-variable name="fdr_cached_response_uuid_value" value="@{ return System.Guid.NewGuid().ToString(); }" />
+        <choose>
+          <when condition="@(!context.Variables.GetValueOrDefault<bool>("is_in_error", false))">
 
-        <!-- Store generated key with UUID value for GET phase -->
-        <cache-store-value key="@((string) context.Variables["cached_response_key"])" value="@((string) context.Variables["fdr_cached_response_uuid_value"])" caching-type="internal" duration="{{fdr1_cache_duration}}" />
+            <!-- Extracting all needed variables from response in order to use them on BLOB content file -->
+            <set-variable name="response_status_code_to_cache" value="@(((IResponse) context.Response).StatusCode)" />
+            <set-variable name="response_content_type_to_cache" value="@(((IResponse) context.Response).Headers.GetValueOrDefault("Content-Type", "text/xml"))" />
+            <set-variable name="response_status_reason_to_cache" value="@(((IResponse) context.Response).StatusReason)" />
 
-        <!-- Finally, send response in BLOB storage in asyncronous way. If an error occurred during persistence, -->
-        <!-- in read phase the absence of BLOB file is considered equivalent to no-cached-response, so the request is sent to backend.  -->
-        <authentication-managed-identity resource="https://storage.azure.com/" output-token-variable-name="msi-access-token" ignore-error="true" />
-        <send-one-way-request mode="new" timeout="300">
-          <set-url>@{ return "https://{{fdr_cachedresponse_saname}}.blob.core.windows.net/" + "{{fdr_cachedresponse_containername}}" + "/" + ((string) context.Variables["fdr_cached_response_uuid_value"]) + ".txt"; }</set-url>
-          <set-method>PUT</set-method>
-          <set-header name="Host" exists-action="override">
-            <value>{{fdr_cachedresponse_saname}}.blob.core.windows.net</value>
-          </set-header>
-          <set-header name="X-Ms-Blob-Type" exists-action="override">
-            <value>BlockBlob</value>
-          </set-header>
-          <set-header name="X-Ms-Blob-Cache-Control" exists-action="override">
-            <value />
-          </set-header>
-          <set-header name="X-Ms-Blob-Content-Disposition" exists-action="override">
-            <value />
-          </set-header>
-          <set-header name="X-Ms-Blob-Content-Encoding" exists-action="override">
-            <value />
-          </set-header>
-          <set-header name="X-Ms-Blob-Content-Language" exists-action="override">
-            <value />
-          </set-header>
-          <set-header name="X-Ms-Version" exists-action="override">
-            <value>2019-12-12</value>
-          </set-header>
-          <set-header name="Accept" exists-action="override">
-            <value>text/xml</value>
-          </set-header>
-          <set-header name="Authorization" exists-action="override">
-            <value>@("Bearer " + (string)context.Variables["msi-access-token"])</value>
-          </set-header>
-          <!-- Setting the custom headers, required for cached response -->
-          <set-header name="X-Response-Status-Code" exists-action="override">
-            <value>@(((int) context.Variables["response_status_code_to_cache"]).ToString())</value>
-          </set-header>
-          <set-header name="X-Response-Status-Reason" exists-action="override">
-            <value>@((string) context.Variables["response_status_reason_to_cache"])</value>
-          </set-header>
-          <set-header name="X-Response-Content-Type" exists-action="override">
-            <value>@((string) context.Variables["response_content_type_to_cache"])</value>
-          </set-header>
-          <!-- Set the file content from the original request body data -->
-          <set-body>@((string) context.Variables["response_body_to_cache"])</set-body>
-        </send-one-way-request>
+            <!-- Generate the UUID value in order to be used for BLOB identifier -->
+            <set-variable name="fdr_cached_response_uuid_value" value="@{ return System.Guid.NewGuid().ToString(); }" />
+
+            <!-- Store generated key with UUID value for GET phase -->
+            <cache-store-value key="@((string) context.Variables["cached_response_key"])" value="@((string) context.Variables["fdr_cached_response_uuid_value"])" caching-type="internal" duration="{{fdr1_cache_duration}}" />
+
+            <!-- Finally, send response in BLOB storage in asyncronous way. If an error occurred during persistence, -->
+            <!-- in read phase the absence of BLOB file is considered equivalent to no-cached-response, so the request is sent to backend.  -->
+            <authentication-managed-identity resource="https://storage.azure.com/" output-token-variable-name="msi-access-token" ignore-error="true" />
+            <send-one-way-request mode="new" timeout="300">
+              <set-url>@{ return "https://{{fdr_cachedresponse_saname}}.blob.core.windows.net/" + "{{fdr_cachedresponse_containername}}" + "/" + ((string) context.Variables["fdr_cached_response_uuid_value"]) + ".txt"; }</set-url>
+              <set-method>PUT</set-method>
+              <set-header name="Host" exists-action="override">
+                <value>{{fdr_cachedresponse_saname}}.blob.core.windows.net</value>
+              </set-header>
+              <set-header name="X-Ms-Blob-Type" exists-action="override">
+                <value>BlockBlob</value>
+              </set-header>
+              <set-header name="X-Ms-Blob-Cache-Control" exists-action="override">
+                <value />
+              </set-header>
+              <set-header name="X-Ms-Blob-Content-Disposition" exists-action="override">
+                <value />
+              </set-header>
+              <set-header name="X-Ms-Blob-Content-Encoding" exists-action="override">
+                <value />
+              </set-header>
+              <set-header name="X-Ms-Blob-Content-Language" exists-action="override">
+                <value />
+              </set-header>
+              <set-header name="X-Ms-Version" exists-action="override">
+                <value>2019-12-12</value>
+              </set-header>
+              <set-header name="Accept" exists-action="override">
+                <value>text/xml</value>
+              </set-header>
+              <set-header name="Authorization" exists-action="override">
+                <value>@("Bearer " + (string)context.Variables["msi-access-token"])</value>
+              </set-header>
+              <!-- Setting the custom headers, required for cached response -->
+              <set-header name="X-Response-Status-Code" exists-action="override">
+                <value>@(((int) context.Variables["response_status_code_to_cache"]).ToString())</value>
+              </set-header>
+              <set-header name="X-Response-Status-Reason" exists-action="override">
+                <value>@((string) context.Variables["response_status_reason_to_cache"])</value>
+              </set-header>
+              <set-header name="X-Response-Content-Type" exists-action="override">
+                <value>@((string) context.Variables["response_content_type_to_cache"])</value>
+              </set-header>
+              <!-- Set the file content from the original request body data -->
+              <set-body>@((string) context.Variables["response_body_to_cache"])</set-body>
+            </send-one-way-request>
+          </when>
+          <!-- If no valid blob content is found in blob-storage, at least log an error and continue processing request -->
+          <otherwise>
+            <trace source="response_not_cached_for_error" severity="information">
+              <message>@{ return "Not caching response with UUID [" + ((string) context.Variables["fdr_cached_response_uuid"]) + "] because the response returned a fault code."; }</message>
+            </trace>
+          </otherwise>
+        </choose>
 
         <!-- ##### END CACHE RETRIEVE PROCESS - WRITE PHASE #### -->
     </outbound>

--- a/src/domains/fdr-app/env/weu-dev/terraform.tfvars
+++ b/src/domains/fdr-app/env/weu-dev/terraform.tfvars
@@ -134,3 +134,4 @@ enable_fdr_ci_soap_request     = true
 enable_fdr_psp_soap_request    = true
 fdr_soap_request_psp_whitelist = "*"
 fdr_soap_request_ci_whitelist  = "*"
+fdr1_cache_duration            = "1800"

--- a/src/domains/fdr-app/env/weu-prod/terraform.tfvars
+++ b/src/domains/fdr-app/env/weu-prod/terraform.tfvars
@@ -137,3 +137,4 @@ ftp_organization = "80078750587,00488410010,97532760580,12300020158"
 enable_fdr3_features        = false
 enable_fdr_ci_soap_request  = false
 enable_fdr_psp_soap_request = false
+fdr1_cache_duration         = "1800"

--- a/src/domains/fdr-app/env/weu-uat/terraform.tfvars
+++ b/src/domains/fdr-app/env/weu-uat/terraform.tfvars
@@ -131,3 +131,4 @@ ftp_organization = "99999999999,80078750587,88888888888,97532760580,12300020158,
 enable_fdr3_features        = true
 enable_fdr_ci_soap_request  = true
 enable_fdr_psp_soap_request = true
+fdr1_cache_duration         = "1800"

--- a/src/domains/fdr-common/03_storage_account_fdr.tf
+++ b/src/domains/fdr-common/03_storage_account_fdr.tf
@@ -146,3 +146,70 @@ resource "azurerm_storage_container" "fdr1_cached_response_blob_file" {
   name                 = "fdr1-cached-response"
   storage_account_name = module.fdr_conversion_sa.name
 }
+
+
+
+
+## 🐞https://github.com/hashicorp/terraform-provider-azurerm/pull/15832
+## blob lifecycle policy
+# https://azure.microsoft.com/it-it/blog/azure-blob-storage-lifecycle-management-now-generally-available/
+resource "azurerm_storage_management_policy" "fdr1_cached_response_blob_file_management_policy" {
+  storage_account_id = module.fdr_conversion_sa.id
+
+  rule {
+    name    = "deleteafterdays"
+    enabled = true
+    filters {
+      prefix_match = ["${azurerm_storage_container.fdr1_cached_response_blob_file.name}/"]
+      blob_types   = ["blockBlob"]
+    }
+
+    # https://docs.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview
+    actions {
+      # https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy#delete_after_days_since_modification_greater_than
+      base_blob {
+        delete_after_days_since_modification_greater_than = var.fdr1_cached_response_blob_file_retention_days
+      }
+      snapshot {
+        delete_after_days_since_creation_greater_than = 30
+      }
+    }
+  }
+
+}
+
+
+# https://medium.com/marcus-tee-anytime/secure-azure-blob-storage-with-azure-api-management-managed-identities-b0b82b53533c
+
+# 1 - add Blob Data Contributor to apim for FDR1's Cached response blob storage
+resource "azurerm_role_assignment" "fdrconversionsa_data_contributor_role" {
+  scope                = module.fdr_conversion_sa.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = data.azurerm_api_management.apim.identity[0].principal_id
+
+  depends_on = [
+    module.fdr_conversion_sa
+  ]
+}
+
+# 2 - Change container Authentication method to Azure AD authentication
+resource "null_resource" "change_auth_fdr1_cached_response_blob_file" {
+
+  triggers = {
+    apim_principal_id = data.azurerm_api_management.apim.identity[0].principal_id
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+              az storage container set-permission \
+                --name ${azurerm_storage_container.fdr1_cached_response_blob_file.name} \
+                --account-name ${module.fdr_conversion_sa.name} \
+                --account-key ${module.fdr_conversion_sa.primary_access_key}
+
+          EOT
+  }
+
+  depends_on = [
+    azurerm_storage_container.fdr1_cached_response_blob_file
+  ]
+}

--- a/src/domains/fdr-common/03_storage_account_fdr.tf
+++ b/src/domains/fdr-common/03_storage_account_fdr.tf
@@ -141,3 +141,8 @@ resource "azurerm_storage_table" "fdr1_conversion_error_table" {
   storage_account_name = module.fdr_conversion_sa.name
 }
 
+## fdr 1 cached responses blob container
+resource "azurerm_storage_container" "fdr1_cached_response_blob_file" {
+  name                 = "fdr1-cached-response"
+  storage_account_name = module.fdr_conversion_sa.name
+}

--- a/src/domains/fdr-common/99_variables.tf
+++ b/src/domains/fdr-common/99_variables.tf
@@ -343,6 +343,13 @@ variable "reporting_fdr_blobs_retention_days" {
   default     = 30
 }
 
+
+variable "fdr1_cached_response_blob_file_retention_days" {
+  type        = number
+  description = "The number of day for storage_management_policy"
+  default     = 30
+}
+
 variable "fdr_re_versioning" {
   type        = bool
   description = "Enable sa versioning"

--- a/src/domains/fdr-common/README.md
+++ b/src/domains/fdr-common/README.md
@@ -77,14 +77,17 @@
 | [azurerm_resource_group.db_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.fdr_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.data_contributor_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.fdrconversionsa_data_contributor_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_storage_container.fdr1_cached_response_blob_file](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.fdr1_flows_blob_file](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.fdr3_flows_blob_file](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.fdr_rend_flow](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.fdr_rend_flow_out](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.re_payload_blob_file](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_management_policy.fdr1_cached_response_blob_file_management_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) | resource |
 | [azurerm_storage_management_policy.storage_account_fdr_management_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) | resource |
 | [azurerm_storage_table.fdr1_conversion_error_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_table) | resource |
+| [null_resource.change_auth_fdr1_cached_response_blob_file](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.change_auth_fdr_blob_container](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.github_runner_app_permissions_to_namespace_cd_01](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.github_runner_app_permissions_to_namespace_ci_01](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
@@ -140,6 +143,7 @@
 | <a name="input_env"></a> [env](#input\_env) | n/a | `string` | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
 | <a name="input_external_domain"></a> [external\_domain](#input\_external\_domain) | Domain for delegation | `string` | `null` | no |
+| <a name="input_fdr1_cached_response_blob_file_retention_days"></a> [fdr1\_cached\_response\_blob\_file\_retention\_days](#input\_fdr1\_cached\_response\_blob\_file\_retention\_days) | The number of day for storage\_management\_policy | `number` | `30` | no |
 | <a name="input_fdr_convertion_delete_retention_days"></a> [fdr\_convertion\_delete\_retention\_days](#input\_fdr\_convertion\_delete\_retention\_days) | Number of days to retain deleted. | `number` | `30` | no |
 | <a name="input_fdr_history_storage_account"></a> [fdr\_history\_storage\_account](#input\_fdr\_history\_storage\_account) | n/a | <pre>object({<br/>    account_kind                       = string<br/>    account_tier                       = string<br/>    account_replication_type           = string<br/>    advanced_threat_protection         = bool<br/>    advanced_threat_protection_enabled = bool<br/>    blob_versioning_enabled            = bool<br/>    public_network_access_enabled      = bool<br/>    blob_delete_retention_days         = number<br/>    enable_low_availability_alert      = bool<br/>    backup_enabled                     = optional(bool, false)<br/>    backup_retention                   = optional(number, 0)<br/>  })</pre> | <pre>{<br/>  "account_kind": "StorageV2",<br/>  "account_replication_type": "LRS",<br/>  "account_tier": "Standard",<br/>  "advanced_threat_protection": true,<br/>  "advanced_threat_protection_enabled": true,<br/>  "backup_enabled": false,<br/>  "backup_retention": 0,<br/>  "blob_delete_retention_days": 30,<br/>  "blob_versioning_enabled": false,<br/>  "enable_low_availability_alert": false,<br/>  "public_network_access_enabled": false<br/>}</pre> | no |
 | <a name="input_fdr_re_advanced_threat_protection"></a> [fdr\_re\_advanced\_threat\_protection](#input\_fdr\_re\_advanced\_threat\_protection) | Enable contract threat advanced protection | `bool` | `false` | no |

--- a/src/domains/fdr-common/README.md
+++ b/src/domains/fdr-common/README.md
@@ -77,6 +77,7 @@
 | [azurerm_resource_group.db_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_resource_group.fdr_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.data_contributor_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_storage_container.fdr1_cached_response_blob_file](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.fdr1_flows_blob_file](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.fdr3_flows_blob_file](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
 | [azurerm_storage_container.fdr_rend_flow](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- added inbound and outbound policies to manage caching for `nodoChiediElencoFlussiRendicontazione`. Cache is executed saving response on a blob storage, while on redis is saved the name of the related blob file according to the request.

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
