### PR TITLE
fix: [PQ-317] fix openapi for perf-data endpoint

### DIFF
--- a/src/domains/qi-app/api/qi-observability-perf-kpi/v1/_openapi.yaml.tpl
+++ b/src/domains/qi-app/api/qi-observability-perf-kpi/v1/_openapi.yaml.tpl
@@ -9,7 +9,7 @@ tags:
   - name: bdi
   - name: observability
 paths:
-  /perfData:
+  /perf-data:
     get:
       summary: Collect Performance Data
       description: Collect KPI performance data based on given parameters.

--- a/src/domains/qi-app/api/qi-observability-perf-kpi/v1/_openapi.yaml.tpl
+++ b/src/domains/qi-app/api/qi-observability-perf-kpi/v1/_openapi.yaml.tpl
@@ -31,9 +31,10 @@ paths:
         - name: kpiId
           in: query
           required: false
-          description: KPI ID to collect. Default is ALL_KPI.
+          description: KPI ID to collect. Default is ALL.
           schema:
             type: string
+            enum: ["PERF-01", "PERF-02", "PERF-03", "PERF-04", "PERF-05", "PERF-06", "ALL"]
       responses:
         '200':
           description: Successful response with KPI data.
@@ -48,6 +49,8 @@ paths:
                     type: string
                   details:
                     type: string
+        '401':
+          description: Unauthorized. Authentication required or invalid credentials.
         '500':
           description: Internal server error.
 
@@ -69,6 +72,8 @@ paths:
                     type: string
                   name:
                     type: string
+        '401':
+          description: Unauthorized. Authentication required or invalid credentials.
         '500':
           description: Internal server error.
 
@@ -80,9 +85,10 @@ paths:
         - name: quarter
           in: path
           required: true
-          description: Quarter identifier (e.g., Q1, Q2, Q3, Q4, or LAST).
+          description: Quarter identifier.
           schema:
             type: string
+            enum: ["Q1", "Q2", "Q3", "Q4", "LAST"]
         - name: year
           in: query
           required: false
@@ -107,5 +113,7 @@ paths:
                       type: string
         '400':
           description: Bad request due to invalid quarter or year.
+        '401':
+          description: Unauthorized. Authentication required or invalid credentials.
         '500':
           description: Internal server error.

--- a/src/domains/qi-app/api/qi-observability-perf-kpi/v1/_openapi.yaml.tpl
+++ b/src/domains/qi-app/api/qi-observability-perf-kpi/v1/_openapi.yaml.tpl
@@ -10,46 +10,6 @@ tags:
   - name: observability
 paths:
   /perf-data:
-    get:
-      summary: Collect Performance Data
-      description: Collect KPI performance data based on given parameters.
-      parameters:
-        - name: startDate
-          in: query
-          required: false
-          description: Start date in 'yyyy-MM-dd HH:mm:ss' format.
-          schema:
-            type: string
-            format: date-time
-        - name: endDate
-          in: query
-          required: false
-          description: End date in 'yyyy-MM-dd HH:mm:ss' format.
-          schema:
-            type: string
-            format: date-time
-        - name: kpiId
-          in: query
-          required: false
-          description: KPI ID to collect. Default is ALL_KPI.
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Successful response with KPI data.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                  message:
-                    type: string
-                  details:
-                    type: string
-        '500':
-          description: Internal server error.
     post:
       summary: Collect Performance Data (POST)
       description: Same as GET but allows POST requests.

--- a/src/domains/qi-secrets/secret/weu-prod/noedit_secret_enc.json
+++ b/src/domains/qi-secrets/secret/weu-prod/noedit_secret_enc.json
@@ -3,7 +3,7 @@
 	"jira-url": "ENC[AES256_GCM,data:brDn/yyOicQdiSKTN8nJq2d9QU0xwIiSk/NEcA==,iv:X3d21wcpzUyE0OsHWDO2mcYXcBcEvBW6YONGglUj2xo=,tag:LWDe/ZjtqMPKp+laO5YwOw==,type:str]",
 	"jira-username": "ENC[AES256_GCM,data:gLVjfIkYaKAnFcYx1xcABQ60Ow==,iv:UtwKXT4UB5xxkobMVtgcVp+p53NopPxHNv9NGsScHhg=,tag:wR3tWAf4dCzSIqMEjsGQ6A==,type:str]",
 	"betterstack-api-key": "ENC[AES256_GCM,data:zNAYztQ6M0+qZBL5uC863QscIS6t7JzA,iv:5m4v6pcPIzY7AwuI4qWe0avZmb/5rdOLHWC5VHCv9nE=,tag:EPFVgrAe4SNMttB3LvUc7A==,type:str]",
-	"azure-ad-client-secret": "ENC[AES256_GCM,data:CsQbSIlV0HrxztFrkSRzgAUQB9U98i9jwTdw0lKUecojU/2j7FiL9w==,iv:0xG7ZcFrOnFspsCeuVkYk4fjW0MukSXhyn2nQzTWDUI=,tag:coTNuJpBKC3J0fxGTFXNkw==,type:str]",
+	"azure-ad-client-secret": "ENC[AES256_GCM,data:E9tCksIRzVsGkq0tIWUrhehjGcgs/wHxF3H8iU4BEttWPaFBpuuDeQ==,iv:dE+ArGamAqoBMlfE5w7plCX+EusUws5BTlg2IUGQRlg=,tag:iqFxFm+xjjgV4Gju9NcOzw==,type:str]",
 	"bdi-ai-api-key": "ENC[AES256_GCM,data:+tQkXM9bqr8IgDEFz+IenLvWSs0VI6Yy7xDs0glKq+ZjRskcg7YVLg==,iv:8UapL4AxFRtOjRUdGzaFs43+vpysqEpEYye2g3NbInE=,tag:xRbdsjIBtWkskg6eVlWczg==,type:str]",
 	"sops": {
 		"kms": null,
@@ -19,8 +19,8 @@
 		],
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2025-01-31T10:55:15Z",
-		"mac": "ENC[AES256_GCM,data:9TU5fzl6PB04ic4NXPFSNA9A1uNrz1NyNjLQ+5KGWZWywS0hiU9/oJj9Bvt5q5h7Up4nyjP2DA1uVO5Rkjy5dESdu58vGLmuKF+xz7ZXmml6WUpK501MTjcAw7nVVEB2WQqES1sGjomiIspkcSKKWUNRG5jFE6wvjfoAL7nNuh0=,iv:Qrsc4gY8wjCW/H9o/uN7Asyhu8/Kr+gcMbx+45Cqe94=,tag:m9XkgajDL0u3k6n190Igvg==,type:str]",
+		"lastmodified": "2025-02-19T10:54:31Z",
+		"mac": "ENC[AES256_GCM,data:I3SF/88VU+myoDFhE6j6mrpG26nm5aywlcbNOR6BT1NczuCXh6pFs+/O4uKFWmLgLMKE+rYIedttaYAjGbIV7pazphGBzBPY1dgHpNe2Xk6o0gCUkmvXaRvLfAAE9O5IG45f5VDj3QRxpnWfqXfM3yGaqGa45ocTpYtPjucMPoI=,iv:vceUVFcv3MG41Ibz4uoRCkM1rF9GWcTdAP6g8OkX2MQ=,tag:xyKGPkbSoCfnHu2IOiYBlA==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.9.0"

--- a/src/domains/qi-secrets/secret/weu-uat/noedit_secret_enc.json
+++ b/src/domains/qi-secrets/secret/weu-uat/noedit_secret_enc.json
@@ -3,7 +3,7 @@
 	"jira-url": "ENC[AES256_GCM,data:b428PDB+IxgFDuMv7qu4vKgELo7Izwvi88JHZg==,iv:1+txW9LG43m3IBqPVYfYbfWo06jaz+b6YsAfjt38BbE=,tag:6wHpWifIH0Fdm96OIIoIJA==,type:str]",
 	"jira-username": "ENC[AES256_GCM,data:FraHKLxvlq+cR5IYvsVnPcs1hA==,iv:s4cTtSoH1A8VAsfnbqZV1+N4t9v7P2v3BJqg+PGUSSM=,tag:IHhHa3yIJCyEoq6yqau5sg==,type:str]",
 	"betterstack-api-key": "ENC[AES256_GCM,data:oRNfAfaMmoFvO2UuXRVUOtWQtmWV8TkZ,iv:U8LDFK2i/6c4yHwT9YeimDJyHLIp41dn5n1JDyViEAg=,tag:2f045agxjY/zl4T2vvIV+w==,type:str]",
-	"azure-ad-client-secret": "ENC[AES256_GCM,data:qMwzQBfLqqEFcoACM/B0wifbKFK7r1Ck0G7AMZnKimKptTL+7RnFsg==,iv:OqghajpphwL/uSbyANUL+4VDRIyN5w6IBOFBi3u+W3E=,tag:J8jY0fWA6/BULNOq8iLLUg==,type:str]",
+	"azure-ad-client-secret": "ENC[AES256_GCM,data:xcPFkebxaQuTiIvjQ3bPM/CEaCd5ruo2JerN0V4Q2qD6DTmcEQ4g3A==,iv:KYPxuXTz0PxNlD3cNJWUZw1KZRqmerAh/wiMFYik0og=,tag:cZZkWGwOzfMElcwCv42GOQ==,type:str]",
 	"bdi-ai-api-key": "ENC[AES256_GCM,data:eGrdKwZa9sGoFpiEwwpoVP9gyO41ZcakQXzpZrjqV3RRB+NKIoapBA==,iv:SzsI0x3iBl9MjNiRLydMFU+XbcvldO9skwOTJ6fyaY4=,tag:Oq0sh/ObcwenmLbMGXOVtA==,type:str]",
 	"sops": {
 		"kms": null,
@@ -19,8 +19,8 @@
 		],
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2025-01-31T10:54:35Z",
-		"mac": "ENC[AES256_GCM,data:WE4HTFAovr8MK6UA2JjEw6qh3VoCScVNYyxv4+gShas6heWUNAMfOwkapg7FlQ1wa2SG9YWds+o+lALuysi7bwZ38lCovkzFb5Rc+1oveQvAQtQVeFbnO/RN0fvzSwUAud4N0yOnGsIdDNx3TLtx2Jw9yXXVt3+ZrDQ6vI2ilr4=,iv:JLdT2YtLY2TUMSuk2FeWkiH9CWY5uHl+3YmXI5i2HdY=,tag:U2MFlhjKzxdsmKwWOV15LA==,type:str]",
+		"lastmodified": "2025-02-19T10:53:04Z",
+		"mac": "ENC[AES256_GCM,data:EwlltT23AhL4I3Uvq0MqmuqupHhlBwD9DiRn+nRtaRqX1B5ebBmdjw13jGrEqeT+7HjiLvkGqbEJ8UiXBoV8MqJYWALXKpj+cb1yGlUHq/cwfPxYgwe5XLSLXaQp9tYkZJRWK4fUFnQzkM/79onS2YQ7/eoK+/5Uit1CotapnXA=,iv:ozn/VR9a3hyUBct+YjKJNvm45nLyyK5TJgHXX7zHeDY=,tag:J1e8nTtWi6ymega7XAuEAg==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.9.0"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- [x] Fix api endpoint (snake-case)
- [x] Add enum in openapi for fields `kpiId` and `quarter`
- [x] Fix secrets `azure-ad-client-secret` with the right principal for `uat` (`pagopa-dataexp-u-ingest-db`) and `prod` (`pagopa-dataexp-u-ingest-db`)

### Motivation and context

Some minor fix

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [n] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
