### PR TITLE
fix: [PIDM-192] Add missing permission on biz event GHA

### DIFF
--- a/src/domains/bizevents-common/10_github_identity.tf
+++ b/src/domains/bizevents-common/10_github_identity.tf
@@ -7,6 +7,11 @@ data "azurerm_kubernetes_cluster" "aks" {
   resource_group_name = "${local.product}-${var.location_short}-${var.instance}-aks-rg"
 }
 
+data "azurerm_key_vault" "key_vault" {
+  name                = "${local.product}-${var.domain}-kv"
+  resource_group_name = "${local.product}-${var.domain}-sec-rg"
+}
+
 # repos must be lower than 20 items
 locals {
   repos_01 = [
@@ -59,6 +64,21 @@ module "identity_cd_01" {
   depends_on = [
     data.azurerm_resource_group.identity_rg
   ]
+}
+
+resource "azurerm_key_vault_access_policy" "gha_iac_managed_identities" {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = module.identity_cd_01.identity_principal_id
+
+  secret_permissions = ["Get", "List", "Set", ]
+
+  certificate_permissions = ["SetIssuers", "DeleteIssuers", "Purge", "List", "Get"]
+  key_permissions = [
+    "Get", "List", "Update", "Create", "Import", "Delete", "Encrypt", "Decrypt", "GetRotationPolicy"
+  ]
+
+  storage_permissions = []
 }
 
 resource "null_resource" "github_runner_app_permissions_to_namespace_cd_01" {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- added missing permission con key vault for GHA on `biz-event` domain

<!--- Describe your changes in detail -->

### Motivation and context
[PIDM-192](https://pagopa.atlassian.net/browse/PIDM-192)
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->


[PIDM-192]: https://pagopa.atlassian.net/browse/PIDM-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ