### PR TITLE
fix: [PAYMCLOUD-222] Add vNet link for Prometheus private DNS zone in non-prod

### DIFF
--- a/src/core-itn/70_monitoring.tf
+++ b/src/core-itn/70_monitoring.tf
@@ -50,6 +50,14 @@ resource "azurerm_private_dns_zone_virtual_network_link" "prometheus_dns_zone_vn
   private_dns_zone_name = azurerm_private_dns_zone.prometheus_dns_zone.0.name
 }
 
+resource "azurerm_private_dns_zone_virtual_network_link" "prometheus_core_dns_zone_vnet_link" {
+  count                 = var.env != "prod" ? 1 : 0
+  name                  = data.azurerm_virtual_network.vnet_core.name
+  resource_group_name   = module.vnet_italy.0.resource_group_name
+  virtual_network_id    = data.azurerm_virtual_network.vnet_core.id
+  private_dns_zone_name = azurerm_private_dns_zone.prometheus_dns_zone.0.name
+}
+
 resource "azurerm_private_endpoint" "monitor_workspace_private_endpoint" {
   count               = var.env != "prod" ? 1 : 0
   name                = "${var.prefix}-${var.location}-monitor-workspace-pe"

--- a/src/core-itn/README.md
+++ b/src/core-itn/README.md
@@ -146,6 +146,7 @@ No outputs.
 | [azurerm_private_dns_zone_virtual_network_link.privatelink_servicebus_windows_net_vnet_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.privatelink_table_core_windows_net_vnet_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.privatelink_table_cosmos_azure_com_vnet_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.prometheus_core_dns_zone_vnet_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_dns_zone_virtual_network_link.prometheus_dns_zone_vnet_link](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
 | [azurerm_private_endpoint.monitor_workspace_private_endpoint](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_public_ip.aks_leonardo_public_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |


### PR DESCRIPTION
**Description:**

This pull request introduces a new resource to link the Prometheus private DNS zone to the virtual network in non-production environments. This addition ensures proper DNS resolution for Prometheus services while maintaining isolation in production. 

### List of changes
- Added configuration for the vNet link to the Prometheus private DNS zone in non-production.

### Motivation and context
This change is required to enable accurate DNS resolution for Prometheus services in non-production environments, improving development and testing workflows while preserving production environment integrity.

### Type of changes
- [x] Add new resources  
- [ ] Update configuration to existing resources  
- [ ] Remove existing resources  

### Does this introduce a change to production resources with possible user impact?
- [ ] Yes, users may be impacted applying this change  
- [x] No  

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes  
- [x] No  

### Other information
No additional information.