### PR TITLE
chore: [PAYMCLOD-35] Adjust severity level for abnormal failed requests alerts

### DIFF
--- a/src/next-core/04_appgw.tf
+++ b/src/next-core/04_appgw.tf
@@ -659,7 +659,7 @@ module "app_gw" {
       description   = "${module.app_gw.name} Abnormal failed requests"
       frequency     = "PT5M"
       window_size   = "PT5M"
-      severity      = 1
+      severity      = 2
       auto_mitigate = true
 
       criteria = []

--- a/src/next-core/04_appgw_integration.tf
+++ b/src/next-core/04_appgw_integration.tf
@@ -326,7 +326,7 @@ module "app_gw_integration" {
       description   = "${module.app_gw_integration.name} Abnormal failed requests"
       frequency     = "PT5M"
       window_size   = "PT5M"
-      severity      = 1
+      severity      = 2
       auto_mitigate = true
 
       criteria = []


### PR DESCRIPTION
### List of changes

- Updated the severity level from 1 to 2 for abnormal failed request alerts in both `appgw` and `appgw_integration` modules.

### Motivation and context

This change was made to align the alerting configuration with the updated incident management policy. It ensures appropriate handling of abnormal failed requests. No other settings have been modified.

### Type of changes

- [ ] Add new resources  
- [x] Update configuration to existing resources  
- [ ] Remove existing resources  

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change  
- [ ] No  

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes  
- [x] No  

### Other information

No additional changes or considerations identified for this update.