### PR TITLE
feat: [PAYMCLOUD-278] Enable cost analysis outside development environment

### DIFF
--- a/src/aks-leonardo/03_aks_0.tf
+++ b/src/aks-leonardo/03_aks_0.tf
@@ -21,7 +21,7 @@ module "aks_leonardo" {
   enable_prometheus_monitor_metrics = var.env_short != "p" ? true : false
 
   # ff: Enabled cost analysis on UAT/PROD
-  # cost_analysis_enabled = var.env_short != "d" ? true : false
+  cost_analysis_enabled = var.env_short != "d" ? true : false
 
   #
   # 🤖 System node pool


### PR DESCRIPTION
### List of changes
- Activated cost analysis for all environments except development (when `env_short == "d`").
- Uncommented the necessary line of code to apply the functionality.

### Motivation and context
This change improves monitoring and budgeting across non-development environments like UAT and PROD, ensuring better resource management.

### Type of changes
- [x] Update configuration to existing resources

### Does this introduce a change to production resources with possible user impact?
- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [x] No

### Other information
No further information is necessary as there are no UI changes or new resources