### PR TITLE
feat: Add lifecycle ignore_changes and update GitHub Action version  

### DIFF
--- a/.github/workflows/static_analysis_pr.yml
+++ b/.github/workflows/static_analysis_pr.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: 🔨 Get Modified Paths
         id: get-paths
-        uses: pagopa/eng-github-actions-iac-template/global/get-modifed-folders@v1.19.0
+        uses: pagopa/eng-github-actions-iac-template/global/get-modifed-folders@v1.22.0
         with:
           start_folder: "src"
           default_end_folder_depth: 3

--- a/src/aks-platform/05_monitoring.tf
+++ b/src/aks-platform/05_monitoring.tf
@@ -41,6 +41,12 @@ resource "helm_release" "kube_prometheus_stack" {
     "${file("${var.kube_prometheus_stack_helm.values_file}")}"
   ]
 
+  lifecycle {
+    ignore_changes = [
+      metadata
+    ]
+  }
+
 }
 
 resource "helm_release" "monitoring_reloader" {


### PR DESCRIPTION
### List of changes
- Added a lifecycle block to the Helm release configuration to ignore metadata changes, improving resource management stability.
- Updated the GitHub Action for modified folders to version 1.22.0 for incorporating the latest enhancements and bug fixes.

### Motivation and context
This update ensures consistent behavior in the Helm deployment by ignoring unnecessary metadata changes. Additionally, the GitHub Action version update provides access to recent performance improvements and fixes.

### Type of changes
- [ ] Add new resources  
- [x] Update configuration to existing resources  
- [ ] Remove existing resources  

### Does this introduce a change to production resources with possible user impact?  
- [ ] Yes, users may be impacted applying this change  
- [x] No  

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result  
- [ ] Yes  
- [x] No  

### Other information
