### PR TITLE
feat: [PAYMCLOUD-305] Remove Kubernetes Event Exporter module

### DIFF
--- a/src/aks-leonardo/03_monitoring.tf
+++ b/src/aks-leonardo/03_monitoring.tf
@@ -39,29 +39,6 @@ module "elastic_agent" {
 
 }
 
-#
-# Kubernetes Event Exporter
-#
-module "kubernetes_event_exporter" {
-  count     = var.env_short != "p" ? 0 : 1
-  source    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_event_exporter?ref=v8.76.0"
-  namespace = "monitoring"
-
-  custom_config = "env/itn-prod/exporter/kubernetes-event-exporter-config.yml.tftpl"
-  custom_variables = {
-    enable_slack           = false
-    enable_opsgenie        = true
-    opsgenie_receiver_name = "opsgenie"
-    opsgenie_api_key       = data.azurerm_key_vault_secret.opsgenie_kubexporter_api_key.0.value
-  }
-}
-
-data "azurerm_key_vault_secret" "opsgenie_kubexporter_api_key" {
-  count        = var.env_short != "p" ? 0 : 1
-  key_vault_id = data.azurerm_key_vault.kv_italy.id
-  name         = "opsgenie-infra-kubexporter-webhook-token"
-}
-
 // TODO mettere nel kv il secret quickstart-es-elastic-user tramite sops
 
 

--- a/src/aks-leonardo/README.md
+++ b/src/aks-leonardo/README.md
@@ -45,7 +45,6 @@ Re-enable all the resource, commented before to complete the procedure
 | <a name="module_aks_storage_class"></a> [aks\_storage\_class](#module\_aks\_storage\_class) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_storage_class | v8.17.1 |
 | <a name="module_elastic_agent"></a> [elastic\_agent](#module\_elastic\_agent) | git::https://github.com/pagopa/terraform-azurerm-v3.git//elastic_agent | v8.50.0 |
 | <a name="module_keda_pod_identity"></a> [keda\_pod\_identity](#module\_keda\_pod\_identity) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_pod_identity | v8.17.1 |
-| <a name="module_kubernetes_event_exporter"></a> [kubernetes\_event\_exporter](#module\_kubernetes\_event\_exporter) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_event_exporter | v8.76.0 |
 | <a name="module_nginx_ingress"></a> [nginx\_ingress](#module\_nginx\_ingress) | terraform-module/release/helm | 2.7.0 |
 | <a name="module_prometheus_managed_addon"></a> [prometheus\_managed\_addon](#module\_prometheus\_managed\_addon) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_prometheus_managed | v8.84.0 |
 
@@ -87,7 +86,6 @@ Re-enable all the resource, commented before to complete the procedure
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_registry) | data source |
 | [azurerm_key_vault.kv_italy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
-| [azurerm_key_vault_secret.opsgenie_kubexporter_api_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.vm_debug_ssh_pass](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.vm_debug_ssh_user](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_log_analytics_workspace.log_analytics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |

--- a/src/aks-platform/05_monitoring.tf
+++ b/src/aks-platform/05_monitoring.tf
@@ -70,27 +70,6 @@ resource "helm_release" "monitoring_reloader" {
   }
 }
 
-# Kubernetes Event Exporter
-module "kubernetes_event_exporter" {
-  count     = var.env_short != "p" ? 0 : 1
-  source    = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_event_exporter?ref=v8.76.0"
-  namespace = "monitoring"
-
-  custom_config = "env/weu-prod/exporter/kubernetes-event-exporter-config.yml.tftpl"
-  custom_variables = {
-    enable_slack           = false
-    enable_opsgenie        = true
-    opsgenie_receiver_name = "opsgenie"
-    opsgenie_api_key       = data.azurerm_key_vault_secret.opsgenie_kubexporter_api_key.0.value
-  }
-}
-
-data "azurerm_key_vault_secret" "opsgenie_kubexporter_api_key" {
-  count        = var.env_short != "p" ? 0 : 1
-  key_vault_id = data.azurerm_key_vault.kv.id
-  name         = "opsgenie-infra-kubexporter-webhook-token"
-}
-
 module "opencosts" {
   enable_opencost      = var.env_short == "d" ? true : false
   source               = "git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_opencosts?ref=v8.71.0"

--- a/src/aks-platform/README.md
+++ b/src/aks-platform/README.md
@@ -18,7 +18,6 @@
 | <a name="module_aks"></a> [aks](#module\_aks) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_cluster | v8.84.1 |
 | <a name="module_aks_snet"></a> [aks\_snet](#module\_aks\_snet) | git::https://github.com/pagopa/terraform-azurerm-v3.git//subnet | v8.53.0 |
 | <a name="module_keda_pod_identity"></a> [keda\_pod\_identity](#module\_keda\_pod\_identity) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_pod_identity | v8.53.0 |
-| <a name="module_kubernetes_event_exporter"></a> [kubernetes\_event\_exporter](#module\_kubernetes\_event\_exporter) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_event_exporter | v8.76.0 |
 | <a name="module_monitoring_pod_identity"></a> [monitoring\_pod\_identity](#module\_monitoring\_pod\_identity) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_pod_identity | v8.53.0 |
 | <a name="module_nginx_ingress"></a> [nginx\_ingress](#module\_nginx\_ingress) | terraform-module/release/helm | 2.8.0 |
 | <a name="module_opencosts"></a> [opencosts](#module\_opencosts) | git::https://github.com/pagopa/terraform-azurerm-v3.git//kubernetes_opencosts | v8.71.0 |
@@ -62,7 +61,6 @@
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_registry) | data source |
 | [azurerm_key_vault.kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
-| [azurerm_key_vault_secret.opsgenie_kubexporter_api_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_log_analytics_workspace.log_analytics](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/log_analytics_workspace) | data source |
 | [azurerm_monitor_action_group.email](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |
 | [azurerm_monitor_action_group.opsgenie](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/monitor_action_group) | data source |

--- a/src/next-core-secrets/secret/prod/noedit_secret_enc.json
+++ b/src/next-core-secrets/secret/prod/noedit_secret_enc.json
@@ -1,6 +1,5 @@
 {
 	"opsgenie-infra-webhook-token": "ENC[AES256_GCM,data:LYnWUk4XgpYkIMyrg3sg+eGi3Xptn2zWj9Ay4ARn1mXFGewK,iv:F+O5mwLEmDN9Yn34az1iVyS8M2KE2HWM007S9ijlR1E=,tag:Kk3X5GwzOtwDowh/LmEBuQ==,type:str]",
-	"opsgenie-infra-kubexporter-webhook-token": "ENC[AES256_GCM,data:lVOA8oMZ93D4kuvMYE4QYAaLoAxdT/CBvZ2Zv1uxNKuhNNOJ,iv:3UIrc6FD8NKntVzAdzAmqKWSP/I3PY1bMWccF9OtQ8s=,tag:CMjNGmKVW7eiBZGPr1GA4g==,type:str]",
 	"gh-runner-job-pat": "ENC[AES256_GCM,data:77kooAdxm6QCRfqJN43iVq4+tREnZBOvGviLvO29rjD3AdBwp2EAvQ==,iv:c4UQv/OsR3O7awpaUbLdgYckLPpWJaknSq7zRkP4DTY=,tag:nMWiGukQPDSCx0ZdmOMXrg==,type:str]",
 	"synthetic-monitoring-nodo-subscription-key": "ENC[AES256_GCM,data:JyfBRS4JwBFZmhYCveiUDgi6PzUgjPmlk6NqLsUtsgg=,iv:P2DNfqO9lg8ghX+YyCkH5XeHo5xEprJ2YcsG2gAxi+A=,tag:g/sEimtMIVsFZH2fFFtDTQ==,type:str]",
 	"monitor-notification-slack-pagamenti-alert-email": "ENC[AES256_GCM,data:a88R3pFfDoZBn6JI2blg6mJaWE/qeecmxHppRtiTdMuOhzqLmqzzBgJFDJAb6UlxIfvmEUHc2pXgDH6tqZ7hNoBjncA=,iv:+pChcw1+auIkDvMQ89JZcBRmMCqO3KRvQtgThssT5J4=,tag:oRtH0l16VDLb/bNkYxwLbw==,type:str]",
@@ -18,10 +17,10 @@
 		],
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2025-02-11T15:59:46Z",
-		"mac": "ENC[AES256_GCM,data:mzm4nb4O4uGQRD2XApqB9xQkU7sZBPwIzUgHkDAJYu4Cebvf3e93ivu0tzQYV9/KKWG0pDpJboM56ll8q1/k79eE8h2nWD3vh9Fs8uEl7mb8+OoTARUDXusNmqADbeS+7W6O5ThXbjU1ZWPlIkVS24zuiPiAcW/HA92VAVW+HlQ=,iv:QCuCDi82PHp5mEHbgIAcBBMAIBXGKUkpr34snC8YF5E=,tag:8hayl6AKRVwstdIujeR7lA==,type:str]",
+		"lastmodified": "2025-03-13T08:55:46Z",
+		"mac": "ENC[AES256_GCM,data:Di0mUgOSZLtnUzal856m3xLEZYUmedP3wEh3wMIgoIQrpiTxFv8nVzMMqrSued8ly9hTvLb4fIBZl9UfuyKEbF58BDQEv9GGbtCGpZj/1B9zLh6TO/QJzaYzlAe44aYkxqlOALvfjT/KUNL8N2Vd0c+LjCsgZjX3eVEVYqedPcw=,iv:JzPyG3c3ZqTBARyd1b6f8pGyyDOICLPtwzE0vOBIzaA=,tag:5UV7iX+iho8c4Lqeaqx5TQ==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.9.3"
+		"version": "3.9.4"
 	}
 }


### PR DESCRIPTION
### List of changes

- Removed the Kubernetes Event Exporter module from the configuration.
- Deleted related webhook token and updated the encrypted secrets file.

### Motivation and context

This change aims to simplify monitoring configurations and improve maintainability by removing obsolete components.

### Type of changes

- [ ] Add new resources  
- [ ] Update configuration to existing resources  
- [x] Remove existing resources  

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change  
- [x] No  

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes  
- [x] No  

### Other information

No further updates or additional modifications needed.