### PR TITLE
Update severity level of app gateway alerts to priority 1

### DIFF
--- a/src/next-core/04_appgw.tf
+++ b/src/next-core/04_appgw.tf
@@ -598,7 +598,7 @@ module "app_gw" {
       description   = "${module.app_gw.name} Abnormal compute units usage, probably an high traffic peak"
       frequency     = "PT5M"
       window_size   = "PT5M"
-      severity      = 2
+      severity      = 1
       auto_mitigate = true
 
       criteria = []

--- a/src/next-core/04_appgw_integration.tf
+++ b/src/next-core/04_appgw_integration.tf
@@ -264,7 +264,7 @@ module "app_gw_integration" {
       description   = "${module.app_gw_integration.name} Abnormal compute units usage, probably an high traffic peak"
       frequency     = "PT5M"
       window_size   = "PT5M"
-      severity      = 2
+      severity      = 1
       auto_mitigate = true
 
       criteria = []


### PR DESCRIPTION
### List of changes

- Set alert severity level from 2 to 1 in app gateway and app gateway integration configurations.

### Motivation and context

This update ensures higher priority for abnormal compute unit usage alerts on the app gateway, critical for handling potential high traffic peaks effectively.

### Type of changes

- [X] Update configuration to existing resources

### Does this introduce a change to production resources with possible user impact?

- [X] Yes, users may be impacted applying this change

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

N/A