### PR TITLE
fix: Update static analysis workflow to optimize folder checks

### DIFF
--- a/.github/workflows/static_analysis_pr.yml
+++ b/.github/workflows/static_analysis_pr.yml
@@ -17,6 +17,7 @@ jobs:
         id: get-paths
         uses: pagopa/eng-github-actions-iac-template/global/get-modifed-folders@v1.22.0
         with:
+          ignore_patterns: ".github,.devops,.vscode,.terraform-version"
           start_folder: "src"
           default_end_folder_depth: 3
           include_patterns: "src,domains"


### PR DESCRIPTION
### List of changes

- Added `.github`, `.devops`, `.vscode`, and `.terraform-version` to ignored patterns in the `get-modified-folders` action.
- Prevents unnecessary checks on these folders during workflow execution.

### Motivation and context

This change ensures that the static analysis workflow targets only necessary folders, improving accuracy and efficiency by ignoring unrelated patterns.

### Type of changes

- [x] Update configuration to existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

No additional impact or changes beyond the targeted workflow optimization.