### PR TITLE
fix: use wallet session pdv api key for CF tokenization

### DIFF
--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v3/_transaction_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v3/_transaction_policy.xml.tpl
@@ -56,7 +56,7 @@
             <set-url>${pdv_api_base_path}/tokens</set-url>
             <set-method>PUT</set-method>
             <set-header name="x-api-key" exists-action="override">
-                <value>{{ecommerce-personal-data-vault-api-key}}</value>
+                <value>{{wallet-session-personal-data-vault-api-key}}</value>
             </set-header>
             <set-body>@(new JObject(new JProperty("pii",  (((JObject)context.Variables["userResponseJson"])["userId"]))).ToString())</set-body>
         </send-request>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Use same api key used for IO wallet flows so that user id is tokenized as for IO flow and can be de-tokenized successfully during close payment processing eCommerce side 
<!--- Describe your changes in detail -->

### Motivation and context
Use same api key used for IO wallet flows so that user id is tokenized as for IO flow and can be de-tokenized successfully during close payment processing eCommerce side
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
