### PR TITLE
feat: [PAYMCLOUD-336] Add critical alert for high compute units usage

### DIFF
--- a/src/next-core/04_appgw.tf
+++ b/src/next-core/04_appgw.tf
@@ -619,11 +619,30 @@ module "app_gw" {
   # https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkapplicationgateways
   monitor_metric_alert_criteria = {
 
+    compute_units_usage_critical = {
+      description   = "${module.app_gw_integration.name} Critical compute units usage, probably an high traffic peak"
+      frequency     = "PT5M"
+      window_size   = "PT5M"
+      severity      = 1
+      auto_mitigate = true
+
+      criteria = [
+        {
+          aggregation = "Average"
+          metric_name = "ComputeUnits"
+          operator    = "GreaterThan"
+          threshold   = 45
+          dimension   = []
+        }
+      ]
+      dynamic_criteria = []
+    }
+
     compute_units_usage = {
       description   = "${module.app_gw.name} Abnormal compute units usage, probably an high traffic peak"
       frequency     = "PT5M"
       window_size   = "PT5M"
-      severity      = 1
+      severity      = 2
       auto_mitigate = true
 
       criteria = []

--- a/src/next-core/04_appgw_integration.tf
+++ b/src/next-core/04_appgw_integration.tf
@@ -260,21 +260,39 @@ module "app_gw_integration" {
   # https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-supported#microsoftnetworkapplicationgateways
   monitor_metric_alert_criteria = {
 
-    compute_units_usage = {
-      description   = "${module.app_gw_integration.name} Abnormal compute units usage, probably an high traffic peak"
+    compute_units_usage_critical = {
+      description   = "${module.app_gw_integration.name} Critical compute units usage, probably an high traffic peak"
       frequency     = "PT5M"
       window_size   = "PT5M"
       severity      = 1
       auto_mitigate = true
 
+      criteria = [
+        {
+          aggregation = "Average"
+          metric_name = "ComputeUnits"
+          operator    = "GreaterThan"
+          threshold   = 45
+          dimension   = []
+        }
+      ]
+      dynamic_criteria = []
+    }
+
+    compute_units_usage = {
+      description   = "${module.app_gw.name} Abnormal compute units usage, probably an high traffic peak"
+      frequency     = "PT5M"
+      window_size   = "PT5M"
+      severity      = 2
+      auto_mitigate = true
+
       criteria = []
       dynamic_criteria = [
         {
-          aggregation       = "Average"
-          metric_name       = "ComputeUnits"
-          operator          = "GreaterOrLessThan"
-          alert_sensitivity = "Low"
-          # todo after api app migration change to High
+          aggregation              = "Average"
+          metric_name              = "ComputeUnits"
+          operator                 = "GreaterOrLessThan"
+          alert_sensitivity        = "Low" # todo after api app migration change to High
           evaluation_total_count   = 2
           evaluation_failure_count = 2
           dimension                = []


### PR DESCRIPTION
### List of changes

- Introduced a critical `severity 1` alert for compute units exceeding a threshold of 45.
- Adjusted the severity of an existing alert from 1 to 2 for better prioritization.
- Modified `04_appgw.tf` and `04_appgw_integration.tf` to incorporate the changes.

### Motivation and context

This change ensures a critical alert is raised when compute unit usage surpasses a defined threshold, addressing potential issues caused by traffic spikes. Updating severity levels helps improve alert prioritization and response.

### Type of changes

- [ ] Add new resources  
- [x] Update configuration to existing resources  
- [ ] Remove existing resources  

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change  
- [ ] No  

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes  
- [x] No  

### Other information

Ensure that all relevant stakeholders are informed of these configuration changes to align with updated alerting and response protocols.