### PR TITLE
chore: [PAYMCLOUD-338] Set dynamic thresholds for App Gateway alert rules

### DIFF
--- a/src/domains/gps-common/README.md
+++ b/src/domains/gps-common/README.md
@@ -5,7 +5,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | <= 1.13.1 |
-| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | <= 2.47.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | <= 3.0.2 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.116.0, < 4.0.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | <= 3.2.2 |
 
@@ -30,6 +30,7 @@
 | <a name="module_postgres_flexible_snet_replica"></a> [postgres\_flexible\_snet\_replica](#module\_postgres\_flexible\_snet\_replica) | ./.terraform/modules/__v3__/subnet | n/a |
 | <a name="module_postgresql_gpd_replica_db"></a> [postgresql\_gpd\_replica\_db](#module\_postgresql\_gpd\_replica\_db) | ./.terraform/modules/__v3__/postgres_flexible_server_replica | n/a |
 | <a name="module_storage_account_snet"></a> [storage\_account\_snet](#module\_storage\_account\_snet) | ./.terraform/modules/__v3__/subnet | n/a |
+| <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ./.terraform/modules/__v3__/kubernetes_workload_identity_init | n/a |
 
 ## Resources
 

--- a/src/next-core/04_appgw.tf
+++ b/src/next-core/04_appgw.tf
@@ -631,7 +631,7 @@ module "app_gw" {
           aggregation = "Average"
           metric_name = "ComputeUnits"
           operator    = "GreaterThan"
-          threshold   = 45
+          threshold   = floor(var.app_gateway_max_capacity * 90 / 100)
           dimension   = []
         }
       ]

--- a/src/next-core/04_appgw_integration.tf
+++ b/src/next-core/04_appgw_integration.tf
@@ -272,7 +272,7 @@ module "app_gw_integration" {
           aggregation = "Average"
           metric_name = "ComputeUnits"
           operator    = "GreaterThan"
-          threshold   = 45
+          threshold   = floor(var.integration_app_gateway_max_capacity * 90 / 100)
           dimension   = []
         }
       ]


### PR DESCRIPTION
### List of changes
- Updated alert rule thresholds to dynamically calculate 90% of the respective App Gateway's max capacity.

### Motivation and context
This change ensures more adaptable and environment-specific alerting by dynamically setting alert thresholds based on actual resource capacity. It reduces manual configuration and improves alert accuracy.

### Type of changes
- [x] Update configuration to existing resources

### Does this introduce a change to production resources with possible user impact?
- [ ] Yes, users may be impacted applying this change

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result
- [ ] Yes
- [x] No

### Other information
N/A