### PR TITLE
fix: modify retry nodoInviaFlusso to nexi FdR PAGOPA-2985

### DIFF
--- a/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
+++ b/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
@@ -10,22 +10,10 @@
       <set-variable name="contentType" value="text/xml"/>
       <!-- SOAP requests -->
       <choose>
-        <!-- TODO is it possible to substitute the baseUrl with Request.Url in the future when we will detach from NEXI?-->
+        <!-- TODO is it possible to substitute the baseUrl with Request.Url in case you want to redirect the call to an internal URI.?-->
         <when condition="@(context.Request.Url.ToString().Contains("/pagopa-fdr-nodo-service/webservices/input/"))">
           <trace source="debugFdR" severity="information">"FDR"</trace>
-          <send-request mode="new" ignore-error="true" response-variable-name="risposta">
-            <set-url>@(context.Request.Url.ToString())</set-url>
-            <set-method>@(context.Request.Method.ToString())</set-method>
-            <set-header name="Content-Type" exists-action="override">
-              <value>text/xml</value>
-            </set-header>
-            <set-header name="SOAPAction" exists-action="override">
-              <value>@(context.Variables.GetValueOrDefault<string>("soapAction", ""))</value>
-            </set-header>
-            <set-body>@{
-              return (string) context.Variables["renewrequest"];
-              }</set-body>
-          </send-request>
+          <set-variable name="leggirisposta" value='test'/>
         </when>
         <otherwise>
           <trace source="debugFdR" severity="information">"NOT_FDR"</trace>
@@ -45,6 +33,7 @@
               return (string) context.Variables["renewrequest"];
               }</set-body>
           </send-request>
+          <set-variable name="leggirisposta" value="@((string)((IResponse)context.Variables["risposta"]).Body.As<string>(preserveContent: true))" />
         </otherwise>
       </choose>
     </when>
@@ -64,9 +53,9 @@
           return (string) context.Variables["renewrequest"];
           }</set-body>
       </send-request>
+      <set-variable name="leggirisposta" value="@((string)((IResponse)context.Variables["risposta"]).Body.As<string>(preserveContent: true))" />
     </otherwise>
   </choose>
-  <set-variable name="leggirisposta" value="@((string)((IResponse)context.Variables["risposta"]).Body.As<string>(preserveContent: true))" />
   <return-response>
     <set-header name="Content-Type" exists-action="override">
         <value>@((string)context.Variables["contentType"])</value>

--- a/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
+++ b/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
@@ -9,22 +9,44 @@
       <when condition="@(context.Variables.ContainsKey("soapAction") && context.Variables.GetValueOrDefault<string>("soapAction", "")!= "")">
       <set-variable name="contentType" value="text/xml"/>
       <!-- SOAP requests -->
-      <send-request mode="new" ignore-error="true" response-variable-name="risposta">
-        <set-url>@{return ((string) context.Variables["baseUrl"]+"/webservices/input"); }</set-url>
-        <set-method>POST</set-method>
-        <set-header name="Content-Type" exists-action="override">
-          <value>text/xml</value>
-        </set-header>
-        <set-header name="ndphost" exists-action="override">
-          <value>@(context.Variables.GetValueOrDefault<string>("ndphost", ""))</value>
-        </set-header>
-        <set-header name="SOAPAction" exists-action="override">
-          <value>@(context.Variables.GetValueOrDefault<string>("soapAction", ""))</value>
-        </set-header>
-        <set-body>@{
-          return (string) context.Variables["renewrequest"];
-          }</set-body>
-      </send-request>
+      <choose>
+        <!-- TODO is it possible to substitute the baseUrl with Request.Url in the future when we will detach from NEXI?-->
+        <when condition="@(context.Request.Url.ToString().Contains("/pagopa-fdr-nodo-service/webservices/input/"))">
+          <trace source="debugFdR" severity="information">"FDR"</trace>
+          <send-request mode="new" ignore-error="true" response-variable-name="risposta">
+            <set-url>@(context.Request.Url.ToString())</set-url>
+            <set-method>@(context.Request.Method.ToString())</set-method>
+            <set-header name="Content-Type" exists-action="override">
+              <value>text/xml</value>
+            </set-header>
+            <set-header name="SOAPAction" exists-action="override">
+              <value>@(context.Variables.GetValueOrDefault<string>("soapAction", ""))</value>
+            </set-header>
+            <set-body>@{
+              return (string) context.Variables["renewrequest"];
+              }</set-body>
+          </send-request>
+        </when>
+        <otherwise>
+          <trace source="debugFdR" severity="information">"NOT_FDR"</trace>
+          <send-request mode="new" ignore-error="true" response-variable-name="risposta">
+            <set-url>@{return ((string) context.Variables["baseUrl"]+"/webservices/input"); }</set-url>
+            <set-method>POST</set-method>
+            <set-header name="Content-Type" exists-action="override">
+              <value>text/xml</value>
+            </set-header>
+            <set-header name="ndphost" exists-action="override">
+              <value>@(context.Variables.GetValueOrDefault<string>("ndphost", ""))</value>
+            </set-header>
+            <set-header name="SOAPAction" exists-action="override">
+              <value>@(context.Variables.GetValueOrDefault<string>("soapAction", ""))</value>
+            </set-header>
+            <set-body>@{
+              return (string) context.Variables["renewrequest"];
+              }</set-body>
+          </send-request>
+        </otherwise>
+      </choose>
     </when>
     <otherwise>
       <set-variable name="contentType" value="application/json"/>

--- a/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
+++ b/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
@@ -12,7 +12,6 @@
       <choose>
         <!-- TODO is it possible to substitute the baseUrl with Request.Url in case you want to redirect the call to an internal URI.?-->
         <when condition="@(context.Request.Url.ToString().Contains("/pagopa-fdr-nodo-service/webservices/input/"))">
-          <trace source="debugFdR" severity="information">"FDR"</trace>
           <return-response>
             <set-header name="Content-Type" exists-action="override">
               <value>@((string)context.Variables["contentType"])</value>
@@ -36,7 +35,6 @@
           </return-response>
         </when>
         <otherwise>
-          <trace source="debugFdR" severity="information">"NOT_FDR"</trace>
           <send-request mode="new" ignore-error="true" response-variable-name="risposta">
             <set-url>@{return ((string) context.Variables["baseUrl"]+"/webservices/input"); }</set-url>
             <set-method>POST</set-method>

--- a/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
+++ b/src/core/api_product/nodo_pagamenti_api/on_error_soap_req.xml
@@ -13,7 +13,27 @@
         <!-- TODO is it possible to substitute the baseUrl with Request.Url in case you want to redirect the call to an internal URI.?-->
         <when condition="@(context.Request.Url.ToString().Contains("/pagopa-fdr-nodo-service/webservices/input/"))">
           <trace source="debugFdR" severity="information">"FDR"</trace>
-          <set-variable name="leggirisposta" value='test'/>
+          <return-response>
+            <set-header name="Content-Type" exists-action="override">
+              <value>@((string)context.Variables["contentType"])</value>
+            </set-header>
+            <set-body template="liquid">
+              <soapenv:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:bc="http://PuntoAccessoPSP.spcoop.gov.it/BarCode_GS1_128_Modified" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:pay_i="http://www.digitpa.gov.it/schemas/2011/Pagamenti/" xmlns:ppt="http://ws.pagamenti.telematici.gov/" xmlns:tns="http://PuntoAccessoPSP.spcoop.gov.it/servizi/PagamentiTelematiciPspNodo" xmlns:qrc="http://PuntoAccessoPSP.spcoop.gov.it/QrCode">
+                <soapenv:Header /> 
+                <soapenv:Body>
+                  <ppt:nodoInviaFlussoRendicontazioneRisposta>
+                    <fault>
+                      <faultCode>PPT_SYSTEM_ERROR</faultCode>
+                      <faultString>Errore generico.</faultString>
+                      <id>NodoDeiPagamentiSPC</id>
+                      <description>Errore generico Flussi di Rendicontazione.</description>
+                    </fault>
+                    <esito>KO</esito>
+                  </ppt:nodoInviaFlussoRendicontazioneRisposta>
+                </soapenv:Body>
+              </soapenv:Envelope>
+            </set-body>
+          </return-response>
         </when>
         <otherwise>
           <trace source="debugFdR" severity="information">"NOT_FDR"</trace>
@@ -33,7 +53,6 @@
               return (string) context.Variables["renewrequest"];
               }</set-body>
           </send-request>
-          <set-variable name="leggirisposta" value="@((string)((IResponse)context.Variables["risposta"]).Body.As<string>(preserveContent: true))" />
         </otherwise>
       </choose>
     </when>
@@ -53,9 +72,9 @@
           return (string) context.Variables["renewrequest"];
           }</set-body>
       </send-request>
-      <set-variable name="leggirisposta" value="@((string)((IResponse)context.Variables["risposta"]).Body.As<string>(preserveContent: true))" />
     </otherwise>
   </choose>
+  <set-variable name="leggirisposta" value="@((string)((IResponse)context.Variables["risposta"]).Body.As<string>(preserveContent: true))" />
   <return-response>
     <set-header name="Content-Type" exists-action="override">
         <value>@((string)context.Variables["contentType"])</value>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Fixing retry to nexi for apis soap in FdR
<!--- Describe your changes in detail -->

### Motivation and context
Needed in order to avoid retries to nexi nodo for FdR soap calls
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
