### PR TITLE
fix: Update action to use get-modified-folders v1.22.3

### DIFF
--- a/.github/workflows/static_analysis_pr.yml
+++ b/.github/workflows/static_analysis_pr.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: 🔨 Get Modified Paths
         id: get-paths
-        uses: pagopa/eng-github-actions-iac-template/global/get-modifed-folders@84db073e6ae48f141ffce4c52d16a67ef5c4662d #v1.22.2
+        uses: pagopa/eng-github-actions-iac-template/global/get-modifed-folders@f10814b649ecd6e5d97c489084d2a107e2f1b2ee #v1.22.3
         with:
           ignore_patterns: ".github,.devops,.vscode,.terraform-version"
           start_folder: "src"

--- a/src/aks-platform/05_monitoring.tf
+++ b/src/aks-platform/05_monitoring.tf
@@ -36,7 +36,7 @@ resource "helm_release" "kube_prometheus_stack" {
   chart      = "kube-prometheus-stack"
   version    = var.kube_prometheus_stack_helm.chart_version
   namespace  = "elastic-system" #kubernetes_namespace.monitoring.metadata[0].name
-  #test
+
   values = [
     "${file("${var.kube_prometheus_stack_helm.values_file}")}"
   ]

--- a/src/aks-platform/05_monitoring.tf
+++ b/src/aks-platform/05_monitoring.tf
@@ -36,7 +36,7 @@ resource "helm_release" "kube_prometheus_stack" {
   chart      = "kube-prometheus-stack"
   version    = var.kube_prometheus_stack_helm.chart_version
   namespace  = "elastic-system" #kubernetes_namespace.monitoring.metadata[0].name
-
+  #test
   values = [
     "${file("${var.kube_prometheus_stack_helm.values_file}")}"
   ]


### PR DESCRIPTION
### List of changes

- Updated the GitHub Action reference for `get-modified-folders` to version v1.22.3 to ensure compatibility with the latest improvements and bug fixes.
- No additional changes have been made to the workflow.

### Motivation and context

The update is necessary to leverage the latest features and fixes provided in `get-modified-folders` v1.22.3, ensuring optimal performance and compatibility of the workflow.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

None.

---

### If PR is partially applied, why? (reserved to mantainers)

