### PR TITLE
fix(amount-ecommerce): PIDM-614 update amount max for eCommerce workflow

### DIFF
--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl
@@ -1150,7 +1150,7 @@
             "description": "Payment notice amount",
             "type": "integer",
             "minimum": 0,
-            "maximum": 99999999
+            "maximum": 999999999
           },
           "dueDate": {
             "description": "Payment notice due date",

--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v1/_openapi.json.tpl
@@ -2081,7 +2081,7 @@
         "description": "Amount for payments, in euro cents",
         "type": "integer",
         "minimum": 0,
-        "maximum": 99999999
+        "maximum": 999999999
       },
       "AuthorizationResult": {
         "description": "Authorization result",

--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v2/_openapi.json.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v2/_openapi.json.tpl
@@ -1082,7 +1082,7 @@
         "description": "Amount for payments, in euro cents",
         "type": "integer",
         "minimum": 0,
-        "maximum": 99999999
+        "maximum": 999999999
       },
       "TransactionStatus": {
         "type": "string",

--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v3/_openapi.json.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v3/_openapi.json.tpl
@@ -535,7 +535,7 @@
             "description": "Payment notice amount",
             "type": "integer",
             "minimum": 0,
-            "maximum": 99999999
+            "maximum": 999999999
           },
           "dueDate": {
             "description": "Payment notice due date",

--- a/src/domains/ecommerce-app/api/ecommerce-checkout/v3/_openapi.json.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout/v3/_openapi.json.tpl
@@ -1099,7 +1099,7 @@
         "description": "Amount for payments, in euro cents",
         "type": "integer",
         "minimum": 0,
-        "maximum": 99999999
+        "maximum": 999999999
       },
       "TransactionStatus": {
         "type": "string",

--- a/src/domains/ecommerce-app/api/ecommerce-io/v2/_openapi.json.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-io/v2/_openapi.json.tpl
@@ -1008,7 +1008,7 @@
             "description": "Payment notice amount",
             "type": "integer",
             "minimum": 0,
-            "maximum": 99999999
+            "maximum": 999999999
           },
           "dueDate": {
             "description": "Payment notice due date",

--- a/src/domains/ecommerce-app/api/ecommerce-payment-requests-service/v1/_openapi.json.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-payment-requests-service/v1/_openapi.json.tpl
@@ -182,7 +182,7 @@
             "description": "Payment notice amount",
             "type": "integer",
             "minimum": 0,
-            "maximum": 99999999
+            "maximum": 999999999
           },
           "dueDate": {
             "description": "Payment notice due date",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- update api spec for eCommerce

### Motivation and context

The goal of thi PR is to update max amount to `999999999` for eCommerce  specification according to nodo `VerifyPaymentNotice` and `ActivatePaymentNotice`.


### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
