### PR TITLE
fix: remove duplicated named values

### DIFF
--- a/src/domains/checkout-app/04_apim_checkout_carts_auth.tf
+++ b/src/domains/checkout-app/04_apim_checkout_carts_auth.tf
@@ -65,17 +65,3 @@ module "apim_checkout_carts_auth_v1" {
     ecommerce_ingress_hostname = var.ecommerce_ingress_hostname,
   })
 }
-
-data "azurerm_key_vault_secret" "ecommerce_payment_requests_active_api_for_checkout_carts_auth_key" {
-  name         = "ecommerce-payment-requests-active-api-key"
-  key_vault_id = data.azurerm_key_vault.key_vault_checkout.id
-}
-
-resource "azurerm_api_management_named_value" "ecommerce_payment_requests_api_key_value_for_checkout_carts_auth" {
-  name                = "ecommerce-payment-requests-api-key-for-checkout-carts-auth-value"
-  api_management_name = data.azurerm_api_management.apim.name
-  resource_group_name = data.azurerm_resource_group.rg_api.name
-  display_name        = "ecommerce-payment-requests-api-key-for-checkout-carts-auth-value"
-  value               = data.azurerm_key_vault_secret.ecommerce_payment_requests_active_api_for_checkout_carts_auth_key.value
-  secret              = true
-}

--- a/src/domains/checkout-app/04_apim_checkout_ec.tf
+++ b/src/domains/checkout-app/04_apim_checkout_ec.tf
@@ -66,16 +66,3 @@ module "apim_checkout_ec_api_v1" {
   })
 }
 
-data "azurerm_key_vault_secret" "ecommerce_payment_requests_active_api_for_checkout_ec_key" {
-  name         = "ecommerce-payment-requests-active-api-key"
-  key_vault_id = data.azurerm_key_vault.key_vault_checkout.id
-}
-
-resource "azurerm_api_management_named_value" "ecommerce_payment_requests_api_key_value_for_checkout_ec" {
-  name                = "ecommerce-payment-requests-api-key-for-checkout-ec-value"
-  api_management_name = data.azurerm_api_management.apim.name
-  resource_group_name = data.azurerm_resource_group.rg_api.name
-  display_name        = "ecommerce-payment-requests-api-key-for-checkout-ec-value"
-  value               = data.azurerm_key_vault_secret.ecommerce_payment_requests_active_api_for_checkout_ec_key.value
-  secret              = true
-}

--- a/src/domains/checkout-app/api/checkout/checkout_carts_auth/v1/_base_policy.xml.tpl
+++ b/src/domains/checkout-app/api/checkout/checkout_carts_auth/v1/_base_policy.xml.tpl
@@ -20,7 +20,7 @@
       </choose>
       <!-- Set payment-requests API Key header -->
       <set-header name="x-api-key" exists-action="override">
-        <value>{{ecommerce-payment-requests-api-key-for-checkout-carts-auth-value}}</value>
+        <value>{{ecommerce-payment-requests-api-key-value}}</value>
       </set-header>
   </inbound>
 

--- a/src/domains/checkout-app/api/checkout/checkout_ec/v1/_base_policy.xml.tpl
+++ b/src/domains/checkout-app/api/checkout/checkout_ec/v1/_base_policy.xml.tpl
@@ -23,7 +23,7 @@
       </set-header>
       <!-- Set payment-requests API Key header -->
       <set-header name="x-api-key" exists-action="override">
-        <value>{{ecommerce-payment-requests-api-key-for-checkout-ec-value}}</value>
+        <value>{{ecommerce-payment-requests-api-key-value}}</value>
       </set-header>
   </inbound>
 

--- a/src/domains/checkout-common/02_security.tf
+++ b/src/domains/checkout-common/02_security.tf
@@ -174,15 +174,3 @@ resource "azurerm_key_vault_secret" "checkout_gha_bot_pat" {
     ]
   }
 }
-
-resource "azurerm_key_vault_secret" "ecommerce_payment_requests_active_api_key" {
-  name         = "ecommerce-payment-requests-active-api-key"
-  value        = "<TO UPDATE MANUALLY ON PORTAL>"
-  key_vault_id = module.key_vault.id
-
-  lifecycle {
-    ignore_changes = [
-      value,
-    ]
-  }
-}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Remove duplicated named value for invoke eCommerce payment request service into checkout domain
make use of the single named value
<!--- Describe your changes in detail -->

### Motivation and context
those modifications are needed to remove useless named value duplication that can lead to misalignment in api key values
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [x] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

```code
//dominio app
sh terraform.sh apply weu-dev \
--target=azurerm_api_management_named_value.azurerm_api_management_named_value \
--target=azurerm_api_management_named_value.ecommerce_payment_requests_api_key_value_for_checkout_ec \
--target=module.apim_checkout_carts_auth_v1 \
--target=module.apim_checkout_ec_api_v1

//dominio core
sh terraform.sh apply weu-dev \
--target=azurerm_key_vault_secret.ecommerce_payment_requests_active_api_key
```
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
