### PR TITLE
feat(alert): [PIDM-836] update queue alerts

### DIFF
--- a/src/domains/ecommerce-common/03_storage.tf
+++ b/src/domains/ecommerce-common/03_storage.tf
@@ -327,6 +327,24 @@ locals {
       "frequency"         = 15
       "threshold"         = 20
       "dynamic_threshold" = 2.0
+    },
+    {
+      "queue_key"         = "transaction-auth-outcome-waiting-queue"
+      "severity"          = 1
+      "time_window"       = 30
+      "fetch_time_window" = 45
+      "frequency"         = 15
+      "threshold"         = 100
+      "dynamic_threshold" = 3.0
+    },
+    {
+      "queue_key"         = "transaction-auth-requested-queue"
+      "severity"          = 1
+      "time_window"       = 30
+      "fetch_time_window" = 45
+      "frequency"         = 15
+      "threshold"         = 400
+      "dynamic_threshold" = 3.0
     }
   ] : []
 }
@@ -422,22 +440,6 @@ locals {
       "fetch_time_window" = 75
       "frequency"         = 15
       "threshold"         = 10
-    },
-    {
-      "queue_key"         = "transaction-auth-outcome-waiting-queue"
-      "severity"          = 1
-      "time_window"       = 30
-      "fetch_time_window" = 75
-      "frequency"         = 15
-      "threshold"         = 40
-    },
-    {
-      "queue_key"         = "transaction-auth-requested-queue"
-      "severity"          = 1
-      "time_window"       = 30
-      "fetch_time_window" = 75
-      "frequency"         = 15
-      "threshold"         = 400
     },
     {
       "queue_key"         = "transactions-close-payment-retry-queue"


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Moved transaction-auth-requested-queue and transaction-auth-outcome-waiting-queue queues to different type of alert

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
