### PR TITLE
chore: [PAYMCLOUD-463] Remove HA suffix from Redis instance name

### DIFF
--- a/src/domains/checkout-common/03_redis_std.tf
+++ b/src/domains/checkout-common/03_redis_std.tf
@@ -11,7 +11,7 @@ resource "azurerm_resource_group" "redis_std_checkout_rg" {
 
 module "pagopa_checkout_redis_std" {
   source                        = "./.terraform/modules/__v4__/redis_cache"
-  name                          = var.redis_checkout_params_std.ha_enabled ? "${local.project}-redis-std-ha" : "${local.project}-redis-std"
+  name                          = "${local.project}-redis-std"
   resource_group_name           = azurerm_resource_group.redis_std_checkout_rg.name
   location                      = azurerm_resource_group.redis_std_checkout_rg.location
   capacity                      = var.redis_checkout_params_std.capacity


### PR DESCRIPTION
### List of changes

- Removed the "HA" suffix from Redis standard instance name.

### Motivation and context

- The change aligns with naming conventions and avoids unnecessary redundancy in the Redis instance name.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

None.

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->