### PR TITLE
fix(nodo-app): PAGOPA-3209 Alerts' tuning

### DIFF
--- a/src/domains/nodo-app/00_alert_nodo.tf
+++ b/src/domains/nodo-app/00_alert_nodo.tf
@@ -11,7 +11,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "nodo_all_api_availabilit
   frequency           = 5
   # the time window was updated from 5 to 7 because the delay between the call and log
   # sometimes can be 2 minutes, this can affect the alert query
-  time_window         = 7
+  time_window = 7
   action {
     action_group           = local.action_groups
     email_subject          = "Nodo PagoPA ${upper(each.key)} API Availability Alert"
@@ -70,8 +70,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "nodo_all_psp_api_fault_c
   description    = "Alert when any PagoPA Nodo PSP operation API falls, based on fault code, below 99% availability."
   enabled        = true
 
-  severity    = 1
-  frequency   = 5
+  severity  = 1
+  frequency = 5
   # the time window was updated from 5 to 7 because the delay between the call and log
   # sometimes can be 2 minutes, this can affect the alert query
   time_window = 7

--- a/src/domains/nodo-app/00_alert_nodo_pagopa.tf
+++ b/src/domains/nodo-app/00_alert_nodo_pagopa.tf
@@ -25,8 +25,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "nodo_pagopa_api_availabi
         ${local.formatted_operation_data["node_for_psp_auth"].formatted_operations}
     ];
     let operationIds = toscalar(operationMap | summarize make_list(operationId_s, 20));
-    let thresholdTrafficMin = 150;
-    let thresholdTrafficLinear = 400;
+    let thresholdTrafficMin = 100;
+    let thresholdTrafficLinear = 200;
     let lowTrafficAvailability = 92;
     let highTrafficAvailability = 99;
     let thresholdDelta = thresholdTrafficLinear - thresholdTrafficMin;
@@ -84,8 +84,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "nodo_pagopa_psp_api_faul
         ${local.formatted_operation_data["node_for_psp_auth"].formatted_operations}
     ];
     let operationIds = toscalar(operationMap | summarize make_list(operationId_s, 20));
-    let thresholdTrafficMin = 150;
-    let thresholdTrafficLinear = 400;
+    let thresholdTrafficMin = 100;
+    let thresholdTrafficLinear = 200;
     let lowTrafficAvailability = 95;
     let highTrafficAvailability = 97;
     let thresholdDelta = thresholdTrafficLinear - thresholdTrafficMin;

--- a/src/domains/nodo-app/00_alert_nodo_pagopa.tf
+++ b/src/domains/nodo-app/00_alert_nodo_pagopa.tf
@@ -11,7 +11,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "nodo_pagopa_api_availabi
   frequency           = 5
   # the time window was updated from 5 to 7 because the delay between the call and log
   # sometimes can be 2 minutes, this can affect the alert query
-  time_window         = 7
+  time_window = 7
 
   action {
     action_group           = local.action_groups
@@ -73,8 +73,8 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "nodo_pagopa_psp_api_faul
   description    = "Alert when any PagoPA Nodo PSP operation API falls, based on fault code, below 99% availability."
   enabled        = true
 
-  severity    = 1
-  frequency   = 5
+  severity  = 1
+  frequency = 5
   # the time window was updated from 5 to 7 because the delay between the call and log
   # sometimes can be 2 minutes, this can affect the alert query
   time_window = 7

--- a/src/domains/nodo-app/00_alert_nodo_pagopa.tf
+++ b/src/domains/nodo-app/00_alert_nodo_pagopa.tf
@@ -9,7 +9,9 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "nodo_pagopa_api_availabi
   enabled             = true
   severity            = 1
   frequency           = 5
-  time_window         = 5
+  # the time window was updated from 5 to 7 because the delay between the call and log
+  # sometimes can be 2 minutes, this can affect the alert query
+  time_window         = 7
 
   action {
     action_group           = local.action_groups
@@ -25,19 +27,19 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "nodo_pagopa_api_availabi
     let operationIds = toscalar(operationMap | summarize make_list(operationId_s, 20));
     let thresholdTrafficMin = 150;
     let thresholdTrafficLinear = 400;
-    let lowTrafficAvailability = 90;
+    let lowTrafficAvailability = 92;
     let highTrafficAvailability = 99;
     let thresholdDelta = thresholdTrafficLinear - thresholdTrafficMin;
     let availabilityDelta = highTrafficAvailability - lowTrafficAvailability;
     AzureDiagnostics
-    | where TimeGenerated > ago(5m)
+    | where TimeGenerated > ago(7m)
     | where backendUrl_s == "${local.pagopa_nodo_ingress}${local.nodo_soap_path}"
     | where url_s matches regex "${local.formatted_operation_data["node_for_psp_auth"].sub_service}"
     | where operationId_s in (operationIds)
     | summarize
         Total = count(),
         Success = countif(todouble(responseCode_d) < 500)
-        by bin(TimeGenerated, 5m), operationId_s
+        by bin(TimeGenerated, 7m), operationId_s
     | extend trafficUp = Total-thresholdTrafficMin
     | extend deltaRatio = todouble(todouble(trafficUp)/todouble(thresholdDelta))
     | extend expectedAvailability = iff(Total >= thresholdTrafficLinear, toreal(highTrafficAvailability), iff(Total <= thresholdTrafficMin, toreal(lowTrafficAvailability), (deltaRatio*(availabilityDelta))+lowTrafficAvailability))
@@ -73,7 +75,9 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "nodo_pagopa_psp_api_faul
 
   severity    = 1
   frequency   = 5
-  time_window = 5
+  # the time window was updated from 5 to 7 because the delay between the call and log
+  # sometimes can be 2 minutes, this can affect the alert query
+  time_window = 7
   query       = <<-EOT
     let operationMap = datatable(operationId_s: string, apiName: string)
     [
@@ -87,7 +91,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "nodo_pagopa_psp_api_faul
     let thresholdDelta = thresholdTrafficLinear - thresholdTrafficMin;
     let availabilityDelta = highTrafficAvailability - lowTrafficAvailability;
     dependencies
-    | where timestamp > ago(5m)
+    | where timestamp > ago(7m)
     | where name == "POST ${local.nodo_soap_path}/"
     | where target == "${local.pagopa_nodo_ingress}"
     | extend operationId_s = tostring(split(operation_Name, " - ")[1])
@@ -98,7 +102,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "nodo_pagopa_psp_api_faul
     | summarize
         Total=count(),
         Success=countif(outcome == "OK" or faultCode !in ${local.error_fault_code})
-        by bin(timestamp, 5m), operationId_s
+        by bin(timestamp, 7m), operationId_s
     | extend trafficUp = Total-thresholdTrafficMin
     | extend deltaRatio = todouble(todouble(trafficUp)/todouble(thresholdDelta))
     | extend expectedAvailability = iff(Total >= thresholdTrafficLinear, toreal(highTrafficAvailability), iff(Total <= thresholdTrafficMin, toreal(lowTrafficAvailability), (deltaRatio*(availabilityDelta))+lowTrafficAvailability))


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- the time window was updated from 5 to 7 because the delay between the call and log sometimes can be 2 minutes, this can affect the alert query;
- threshold update;
- Reduce thresholdTrafficMin, thresholdTrafficLinear because there will be less traffic

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
