### PR TITLE
fix(nodo-app): PAGOPA-3209 Update fault-code alert

### DIFF
--- a/src/domains/nodo-app/00_alert_locals.tf
+++ b/src/domains/nodo-app/00_alert_locals.tf
@@ -379,9 +379,9 @@ locals {
   error_fault_code = "('${join("', '", ["PPT_AUTENTICAZIONE", "PPT_SYSTEM_ERROR", "PPT_ERRORE_IDEMPOTENZA"])}')"
 
   // Nodo SOAP path
-  nodo_soap_path = "/webservices/input"
+  nodo_soap_path = "/nodo/webservices/input"
   // PagoPA Nodo ingress
-  pagopa_nodo_ingress = "https://weuprod.nodo.internal.platform.pagopa.it/nodo"
+  pagopa_nodo_ingress = "https://weuprod.nodo.internal.platform.pagopa.it"
 
   # Default alert action groups: slack channel and email
   action_groups_default = [data.azurerm_monitor_action_group.email.id, data.azurerm_monitor_action_group.slack.id]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

```
sh terraform.sh apply weu-{env} --target=azurerm_monitor_scheduled_query_rules_alert.nodo_pagopa_psp_api_fault_code_availability_alert
```
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

target is equal to `https://weuprod.nodo.internal.platform.pagopa.it`
name is equal to `POST /nodo/webservices/input/`

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
