### PR TITLE
feat: [PAYMCLOUD-486] Add Grafana Infinity data source integration with AzureAD

### DIFF
--- a/src/grafana-monitoring/10_infinity.tf
+++ b/src/grafana-monitoring/10_infinity.tf
@@ -33,3 +33,33 @@ resource "azurerm_role_assignment" "grafana_infinity_viewer" {
   role_definition_name = "Cost Management Reader"
   principal_id         = azuread_service_principal.grafana_infinity.object_id
 }
+
+resource "grafana_data_source" "infinity" {
+  provider    = grafana.cloudinternal
+  type        = "yesoreyeram-infinity-datasource"
+  name        = "${local.product}-infinity"
+  access_mode = "proxy"
+  is_default  = false
+
+  json_data_encoded = jsonencode({
+    allowedHosts = [
+      "https://management.azure.com/"
+    ]
+    auth_method    = "oauth2"
+    global_queries = []
+    oauth2 = {
+      client_secret = azurerm_key_vault_secret.grafana_infinity.value
+      client_id     = azuread_service_principal.grafana_infinity.application_id
+      scopes = [
+        ""
+      ],
+      token_url = "https://login.microsoftonline.com/${data.azurerm_subscription.current.tenant_id}/oauth2/token"
+    },
+    oauth2EndPointParamsName1 = "resource"
+  })
+
+  secure_json_data_encoded = jsonencode({
+    oauth2ClientSecret         = azurerm_key_vault_secret.grafana_infinity.value
+    oauth2EndPointParamsValue1 = "https://management.azure.com/"
+  })
+}

--- a/src/grafana-monitoring/10_infinity.tf
+++ b/src/grafana-monitoring/10_infinity.tf
@@ -10,8 +10,6 @@ resource "azuread_application" "grafana_infinity" {
       type = "Scope"
     }
   }
-
-  owners = [data.azuread_group.adgroup_admin.object_id]
 }
 
 resource "azuread_service_principal" "grafana_infinity" {

--- a/src/grafana-monitoring/10_infinity.tf
+++ b/src/grafana-monitoring/10_infinity.tf
@@ -1,0 +1,31 @@
+
+resource "azuread_application" "grafana_infinity" {
+  display_name = "${local.product}-grafana-infinity"
+
+  required_resource_access {
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+
+    resource_access {
+      id   = "e1fe6dd8-ba31-4d61-89e7-88639da4683d" # User.Read
+      type = "Scope"
+    }
+  }
+
+  owners = [data.azuread_group.adgroup_admin.object_id]
+}
+
+resource "azuread_service_principal" "grafana_infinity" {
+  application_id = azuread_application.grafana_infinity.application_id
+}
+
+resource "azuread_application_password" "grafana_infinity" {
+  application_object_id = azuread_application.grafana_infinity.object_id
+  display_name          = "GrafanaInfinitySecret"
+  end_date              = "2099-01-01T01:02:03Z"
+}
+
+resource "azurerm_key_vault_secret" "grafana_infinity" {
+  key_vault_id = data.azurerm_key_vault.kv.id
+  name         = "grafana-infinity-principal-secret"
+  value        = azuread_application_password.grafana_infinity.value
+}

--- a/src/grafana-monitoring/10_infinity.tf
+++ b/src/grafana-monitoring/10_infinity.tf
@@ -27,3 +27,9 @@ resource "azurerm_key_vault_secret" "grafana_infinity" {
   name         = "grafana-infinity-principal-secret"
   value        = azuread_application_password.grafana_infinity.value
 }
+
+resource "azurerm_role_assignment" "grafana_infinity_viewer" {
+  scope                = data.azurerm_subscription.current.id
+  role_definition_name = "Cost Management Reader"
+  principal_id         = azuread_service_principal.grafana_infinity.object_id
+}

--- a/src/grafana-monitoring/README.md
+++ b/src/grafana-monitoring/README.md
@@ -33,6 +33,7 @@
 | [azurerm_role_assignment.grafana_dashboard_monitoring_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.grafana_infinity_viewer](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [grafana_dashboard.azure_monitor_grafana](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/dashboard) | resource |
+| [grafana_data_source.infinity](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source) | resource |
 | [grafana_folder.customfolder](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/folder) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.10.0/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/2.10.0/docs/data-sources/group) | data source |

--- a/src/grafana-monitoring/README.md
+++ b/src/grafana-monitoring/README.md
@@ -31,6 +31,7 @@
 | [azurerm_resource_group.grafana_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.grafana_dashboard_monitoring_data_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.grafana_dashboard_monitoring_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.grafana_infinity_viewer](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [grafana_dashboard.azure_monitor_grafana](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/dashboard) | resource |
 | [grafana_folder.customfolder](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/folder) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.10.0/docs/data-sources/group) | data source |

--- a/src/grafana-monitoring/README.md
+++ b/src/grafana-monitoring/README.md
@@ -22,7 +22,11 @@
 
 | Name | Type |
 |------|------|
+| [azuread_application.grafana_infinity](https://registry.terraform.io/providers/hashicorp/azuread/2.10.0/docs/resources/application) | resource |
+| [azuread_application_password.grafana_infinity](https://registry.terraform.io/providers/hashicorp/azuread/2.10.0/docs/resources/application_password) | resource |
+| [azuread_service_principal.grafana_infinity](https://registry.terraform.io/providers/hashicorp/azuread/2.10.0/docs/resources/service_principal) | resource |
 | [azurerm_dashboard_grafana.grafana_dashboard](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dashboard_grafana) | resource |
+| [azurerm_key_vault_secret.grafana_infinity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_kusto_database_principal_assignment.grafana_viewer](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kusto_database_principal_assignment) | resource |
 | [azurerm_resource_group.grafana_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.grafana_dashboard_monitoring_data_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |


### PR DESCRIPTION
### List of changes

- Added Terraform configuration for Grafana Infinity data source integration.
- Assigned 'Cost Management Reader' role to the Grafana Infinity service principal.
- Removed unused `owners` attribute from the Grafana Infinity AzureAD app configuration.
- Configured AzureAD application setup for Grafana Infinity integration.

### Motivation and context

The changes enable the integration of Grafana Infinity with AzureAD for enhanced functionality and streamlined operations. The assigned role ensures proper access management, and removing the unused attribute optimizes the configuration.

### Type of changes

- [x] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

None.

--- 

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->