### PR TITLE
[PIDM-914] feat(redis-standard): Add redis standard secrets

### DIFF
--- a/src/domains/checkout-common/02_security.tf
+++ b/src/domains/checkout-common/02_security.tf
@@ -174,3 +174,15 @@ resource "azurerm_key_vault_secret" "checkout_gha_bot_pat" {
     ]
   }
 }
+
+resource "azurerm_key_vault_secret" "redis_std_checkout_access_key" {
+  name         = "redis-std-checkout-access-key"
+  value        = module.pagopa_checkout_redis_std.primary_access_key
+  key_vault_id = module.key_vault.id
+}
+
+resource "azurerm_key_vault_secret" "redis_std_checkout_hostname" {
+  name         = "redis-std-checkout-hostname"
+  value        = module.pagopa_checkout_redis_std.hostname
+  key_vault_id = module.key_vault.id
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Added redis standard secrets
<!--- Describe your changes in detail -->

### Motivation and context
The goal is to migrate to redis standard to reduce costs. [Enable zone redundancy for Azure Cache for Redis](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-how-to-zone-redundancy)
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
