### PR TITLE
feat: add txt records for accounting reconciliation dcv

### DIFF
--- a/src/core/dns_plaftorm.tf
+++ b/src/core/dns_plaftorm.tf
@@ -68,29 +68,3 @@ resource "azurerm_dns_txt_record" "dns-txt-email-platform-pagopa-it-aws-ses" {
   }
   tags = module.tag_config.tags
 }
-
-# accounting reconciliation DCV TXT record
-resource "azurerm_dns_txt_record" "dns-txt-acc-recon-platform-pagopa-it-digicert" {
-  count               = var.env_short == "u" ? 1 : 0
-  name                = "accounting-reconciliation"
-  zone_name           = data.azurerm_dns_zone.public[0].name
-  resource_group_name = data.azurerm_resource_group.rg_vnet.name
-  ttl                 = var.dns_default_ttl_sec
-  record {
-    value = "_iovto2zqvvt3nymbfo8d3osk5xp459y"
-  }
-  tags = module.tag_config.tags
-}
-
-# accounting reconciliation www DCV TXT record
-resource "azurerm_dns_txt_record" "dns-txt-www-acc-recon-platform-pagopa-it-digicert" {
-  count               = var.env_short == "u" ? 1 : 0
-  name                = "www.accounting-reconciliation"
-  zone_name           = data.azurerm_dns_zone.public[0].name
-  resource_group_name = data.azurerm_resource_group.rg_vnet.name
-  ttl                 = var.dns_default_ttl_sec
-  record {
-    value = "_iovto2zqvvt3nymbfo8d3osk5xp459y"
-  }
-  tags = module.tag_config.tags
-}

--- a/src/next-core/01_dns_public.tf
+++ b/src/next-core/01_dns_public.tf
@@ -195,3 +195,29 @@ resource "azurerm_dns_a_record" "dns_a_management_prf" {
   records             = [azurerm_public_ip.appgateway_public_ip.ip_address]
   tags                = module.tag_config.tags
 }
+
+# accounting reconciliation DCV TXT record
+resource "azurerm_dns_txt_record" "dns-txt-acc-recon-platform-pagopa-it-digicert" {
+  count               = var.env_short == "u" ? 1 : 0
+  name                = "accounting-reconciliation"
+  zone_name           = azurerm_dns_zone.public[0].name
+  resource_group_name = azurerm_resource_group.rg_vnet.name
+  ttl                 = var.dns_default_ttl_sec
+  record {
+    value = "_iovto2zqvvt3nymbfo8d3osk5xp459y"
+  }
+  tags = module.tag_config.tags
+}
+
+# accounting reconciliation www DCV TXT record
+resource "azurerm_dns_txt_record" "dns-txt-www-acc-recon-platform-pagopa-it-digicert" {
+  count               = var.env_short == "u" ? 1 : 0
+  name                = "www.accounting-reconciliation"
+  zone_name           = azurerm_dns_zone.public[0].name
+  resource_group_name = azurerm_resource_group.rg_vnet.name
+  ttl                 = var.dns_default_ttl_sec
+  record {
+    value = "_iovto2zqvvt3nymbfo8d3osk5xp459y"
+  }
+  tags = module.tag_config.tags
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

Add two TXT record to DNS zone `uat.platform.pagopa.it`, the records are necessary to allow the domain control validation `DCV` by DigiCert in order to issue new client certificate for `Riconciliazione Contabile` initiative. 

To apply:
```
sh terraform.sh apply uat -target="azurerm_dns_txt_record.dns-txt-www-acc-recon-platform-pagopa-it-digicert" \
    -target="azurerm_dns_txt_record.dns-txt-acc-recon-platform-pagopa-it-digicert"
```

### Motivation and context

This change is necessary to allow the domain control validation `DCV` by DigiCert in order to issue new client certificate for `Riconciliazione Contabile` initiative. 

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
