### PR TITLE
fix: PAYMCLOUD-528 update debezium health checker image to specific version

### DIFF
--- a/src/domains/gps-app/yaml/debezium-health-checker-cron.yaml
+++ b/src/domains/gps-app/yaml/debezium-health-checker-cron.yaml
@@ -17,7 +17,7 @@ spec:
         spec:
           containers:
           - name: debezium-health-checker
-            image: bitnamisecure/kubectl:latest
+            image: public.ecr.aws/bitnami/kubectl:1.34.1@sha256:e912dce42add40fe6c173bb692e4587e771d3127b130ddde11c1f30d6ac7f093
             command: ["/bin/bash", "/scripts/check_kafka_connect.sh"]
             volumeMounts:
             - name: script-volume


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

Avoid to use the latest images, and change docker registry to avoid problem with binami migration

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
