### PR TITLE
feat(cosmos-gpd-upload) [PAGOPA-3284]: Define and use cosmos TTL

### DIFF
--- a/src/domains/gps-common/03_cosmosdb.tf
+++ b/src/domains/gps-common/03_cosmosdb.tf
@@ -85,11 +85,13 @@ locals {
     {
       name               = "creditor_institutions",
       partition_key_path = "/fiscalCode",
+      default_ttl        = -1,  // the value is set to -1 -> items don’t expire by default
       autoscale_settings = { max_throughput = 1000 }
     },
     {
       name               = "services",
       partition_key_path = "/transferCategory",
+      default_ttl        = -1, // the value is set to -1 -> items don’t expire by default
       autoscale_settings = { max_throughput = 1000 }
     },
   ]
@@ -98,6 +100,7 @@ locals {
     {
       name               = "gpd_upload_status",
       partition_key_path = "/fiscalCode",
+      default_ttl        = var.gpd_upload_status_ttl,
       autoscale_settings = { max_throughput = var.gpd_upload_status_throughput }
     },
   ]
@@ -114,6 +117,7 @@ module "gpd_cosmosdb_containers" {
   database_name       = module.gpd_cosmosdb_database.name
   partition_key_path  = each.value.partition_key_path
   throughput          = lookup(each.value, "throughput", null)
+  default_ttl         = each.value.default_ttl
 
   autoscale_settings = contains(var.cosmos_gps_db_params.capabilities, "EnableServerless") ? null : lookup(each.value, "autoscale_settings", null)
 }

--- a/src/domains/gps-common/99_variables.tf
+++ b/src/domains/gps-common/99_variables.tf
@@ -251,6 +251,12 @@ variable "gpd_db_name" {
   default     = "apd"
 }
 
+variable "gpd_upload_status_ttl" {
+  type        = number
+  description = "The default time in seconds to live of SQL container. If present and the value is set to -1, it is equal to infinity, and items don’t expire by default. "
+  default     = -1
+}
+
 variable "cosmos_gps_db_params" {
   type = object({
     kind           = string

--- a/src/domains/gps-common/env/weu-dev/terraform.tfvars
+++ b/src/domains/gps-common/env/weu-dev/terraform.tfvars
@@ -45,6 +45,8 @@ cosmos_gps_db_params = {
   backup_continuous_enabled = false
 }
 
+gpd_upload_status_ttl = 604800 // 7 days
+
 # Postgres Flexible
 pgres_flex_params = {
 

--- a/src/domains/gps-common/env/weu-prod/terraform.tfvars
+++ b/src/domains/gps-common/env/weu-prod/terraform.tfvars
@@ -49,6 +49,7 @@ cosmos_gps_db_params = {
 }
 
 gpd_upload_status_throughput = 10000
+gpd_upload_status_ttl = 7776000 // 90 days
 
 # Postgres Flexible
 # https://docs.microsoft.com/it-it/azure/postgresql/flexible-server/concepts-high-availability

--- a/src/domains/gps-common/env/weu-uat/terraform.tfvars
+++ b/src/domains/gps-common/env/weu-uat/terraform.tfvars
@@ -46,6 +46,7 @@ cosmos_gps_db_params = {
 }
 
 gpd_upload_status_throughput = 10000
+gpd_upload_status_ttl = 5184000 // 60 days
 
 # Postgres Flexible
 pgres_flex_params = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

`gpd_upload_status_ttl` was defined for each environment and was used in the `gpd_upload_status` container.

-  TTL_DEV = 7 days
-  TTL_UAT = 60 days
-  TTL_PROD = 90 days

```
sh terraform.sh apply weu-dev --target=module.gpd_cosmosdb_containers --target=module.gps_cosmosdb_containers
```
### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Data lifecycle management for GPD-Upload.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
