### PR TITLE
feat: [PRGP-342] Update ClouDO image tags to latest versions in PROD v0.19.0

### DIFF
--- a/src/cloudo/env/prod/terraform.tfvars
+++ b/src/cloudo/env/prod/terraform.tfvars
@@ -13,7 +13,7 @@ application_insisght_resource_group_name = "pagopa-p-monitor-rg"
 # ClouDO orchestrator parameters
 cloudo_orchestrator = {
   image_name        = "pagopa/cloudo-orchestrator"
-  image_tag         = "0.16.0"
+  image_tag         = "0.20.0"
   registry_url      = "https://ghcr.io"
   registry_username = "payments-cloud-bot"
 }
@@ -21,7 +21,7 @@ cloudo_orchestrator = {
 # ClouDO UI parameters
 cloudo_ui = {
   image_name        = "pagopa/cloudo-ui"
-  image_tag         = "0.8.0"
+  image_tag         = "0.12.0"
   registry_url      = "https://ghcr.io"
   registry_username = "payments-cloud-bot"
 }
@@ -29,7 +29,7 @@ cloudo_ui = {
 # ClouDO worker parameters
 cloudo_worker = {
   image_name        = "pagopa/cloudo-worker"
-  image_tag         = "0.10.0"
+  image_tag         = "0.14.0"
   registry_url      = "https://ghcr.io"
   registry_username = "payments-cloud-bot"
 }


### PR DESCRIPTION
### List of changes

- Updated ClouDO image tags to the following versions:  
  - **Orchestrator**: v0.20.0  
  - **UI**: v0.12.0  
  - **Worker**: v0.14.0  

### Motivation and context

- Upgrade to the latest stable versions to benefit from performance improvements, bug fixes, and new features.

### Type of changes

- [ ] Add new resources  
- [x] Update configuration to existing resources  
- [ ] Remove existing resources  

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change  
- [ ] No  

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes  
- [x] No  

### Other information

N/A  

---  

### If PR is partially applied, why? (reserved to mantainers)

N/A  