### PR TITLE
chore: add admin dev as app owner for selfcare app config

### DIFF
--- a/src/domains/selfcare-common/00_azuread.tf
+++ b/src/domains/selfcare-common/00_azuread.tf
@@ -49,3 +49,7 @@ data "azuread_group" "adgroup_admin" {
 data "azuread_group" "adgroup_developers" {
   display_name = "${local.product}-adgroup-developers"
 }
+
+data "azuread_group" "adgroup_admin_dev" {
+  display_name = "${local.product}-adgroup-admin-dev"
+}

--- a/src/domains/selfcare-common/04_app_configuration_feature.tf
+++ b/src/domains/selfcare-common/04_app_configuration_feature.tf
@@ -24,6 +24,12 @@ resource "azurerm_role_assignment" "appconf_dataowner_adgroup_admin" {
   principal_id         = data.azuread_group.adgroup_admin.object_id
 }
 
+resource "azurerm_role_assignment" "appconf_dataowner_adgroup_admin_dev" {
+  scope                = azurerm_app_configuration.selfcare_appconf.id
+  role_definition_name = "App Configuration Data Owner"
+  principal_id         = data.azuread_group.adgroup_admin_dev.object_id
+}
+
 resource "azurerm_app_configuration_feature" "maintenance_banner_flag" {
   configuration_store_id = azurerm_app_configuration.selfcare_appconf.id
   description            = "It enables the banner"

--- a/src/domains/selfcare-common/README.md
+++ b/src/domains/selfcare-common/README.md
@@ -63,12 +63,14 @@
 | [azurerm_private_dns_a_record.ingress](https://registry.terraform.io/providers/hashicorp/azurerm/3.116.0/docs/resources/private_dns_a_record) | resource |
 | [azurerm_resource_group.bopagopa_rg](https://registry.terraform.io/providers/hashicorp/azurerm/3.116.0/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.appconf_dataowner_adgroup_admin](https://registry.terraform.io/providers/hashicorp/azurerm/3.116.0/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.appconf_dataowner_adgroup_admin_dev](https://registry.terraform.io/providers/hashicorp/azurerm/3.116.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.appconf_dataowner_adgroup_developers](https://registry.terraform.io/providers/hashicorp/azurerm/3.116.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.selfcare_apim_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/3.116.0/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.selfcare_appconf_dataowner_sp](https://registry.terraform.io/providers/hashicorp/azurerm/3.116.0/docs/resources/role_assignment) | resource |
 | [null_resource.github_runner_app_permissions_to_namespace_cd_01](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [time_rotating.selfcare_application](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_admin_dev](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azurerm_api_management.apim](https://registry.terraform.io/providers/hashicorp/azurerm/3.116.0/docs/data-sources/api_management) | data source |
 | [azurerm_application_insights.application_insights](https://registry.terraform.io/providers/hashicorp/azurerm/3.116.0/docs/data-sources/application_insights) | data source |


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add admin dev group with role `App Configuration Owner` for Backoffice app configuration
<!--- Describe your changes in detail -->

### Motivation and context
This role is needed in order to allow admin dev team to have permission to retrieve/add new feature flags during apply in prod env
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
