### PR TITLE
chore: calculate mock response payment token randomically

### DIFF
--- a/src/domains/ecommerce-app/api/ecommerce-mock/nodeForPsp/v1/_base_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-mock/nodeForPsp/v1/_base_policy.xml.tpl
@@ -1,6 +1,10 @@
 <policies>
   <inbound>
     <base />
+    <set-variable name="payment_token" value="@{
+      Guid randomUUID = Guid.NewGuid();
+      return randomUUID.ToString().Replace("-","");
+    }" />
     <!-- verifyPaymentNotice -->
     <choose>
       <when condition="@(((string)context.Request.Headers.GetValueOrDefault("SOAPAction","")).Equals("verifyPaymentNotice"))">
@@ -60,7 +64,7 @@
                   <fiscalCodePA>77777777777</fiscalCodePA>
                   <companyName>company PA</companyName>
                   <officeName>office PA</officeName>
-                  <paymentToken>3d82a804063f46ed99dfa9e4a235774d</paymentToken>
+                  <paymentToken>{{ context.Variables["payment_token"] }}</paymentToken>
                   <transferList>
                     <transfer>
                       <idTransfer>1</idTransfer>
@@ -103,7 +107,7 @@
                         <fiscalCodePA>77777777777</fiscalCodePA>
                         <companyName>company</companyName>
                         <officeName>office</officeName>
-                        <paymentToken>622918c5dd3142668826d3bdd9282589</paymentToken>
+                        <paymentToken>{{ context.Variables["payment_token"] }}</paymentToken>
                         <transferList>
                             <transfer>
                                 <idTransfer>1</idTransfer>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Update Node mock to calculate payment token randomically in response instead of fixed value
<!--- Describe your changes in detail -->

### Motivation and context
this is needed since eCommerce transactions-service now put lock on payment token during request authorization processing so payment token needs to be different for each transactions
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
