### PR TITLE
feat: [PAYMCLOUD-917] Add HAProxy ingress on DEV environment and update azurerm-v4 to v10.10.0

### DIFF
--- a/src/aks-leonardo/05_ingress.tf
+++ b/src/aks-leonardo/05_ingress.tf
@@ -51,3 +51,98 @@ module "nginx_ingress" {
     }
   ]
 }
+
+###############################################################################
+# HAProxy Ingress module - production configuration
+###############################################################################
+
+module "haproxy_ingress" {
+  source = "./.terraform/modules/__v4__/kubernetes_haproxy_ingress_controller"
+  count  = var.env_short == "d" ? 1 : 0
+
+  release_name         = "haproxy-ingress"
+  namespace            = "haproxy-ingress"
+  chart_version        = "1.49.0"
+  controller_image_tag = "3.2.6"
+
+  # ---- Namespace labels for Azure Policy / Workload Identity ----
+  namespace_labels = {
+    "azure.workload.identity/use" = "false"
+    "environment"                 = var.env
+  }
+
+  # ---- Replicas & aggressive autoscaling ----
+  replica_count = 3
+
+  autoscaling = {
+    enabled                   = true
+    min_replicas              = 3
+    max_replicas              = 20
+    target_cpu_utilization    = 70
+    target_memory_utilization = 75
+  }
+
+  # ---- PDB: keep at least 2 pods always available ----
+  pod_disruption_budget = {
+    enabled       = true
+    min_available = 2
+  }
+
+  # ---- Resources (production sizing) ----
+  resources = {
+    requests_cpu    = "200m"
+    requests_memory = "256Mi"
+    limits_cpu      = "1000m"
+    limits_memory   = "1Gi"
+  }
+
+  # ---- Resource Quota on the namespace ----
+  enable_resource_quota = false
+
+  # ---- Internal Load Balancer with static IP ----
+  service_type     = "LoadBalancer"
+  load_balancer_ip = var.haproxy_ingress_load_balancer_ip
+
+  service_annotations = {
+    # Force the Load Balancer to be internal to the VNet
+    "service.beta.kubernetes.io/azure-load-balancer-internal" = "true"
+    # Dedicated subnet for the Load Balancer (optional)
+    "service.beta.kubernetes.io/azure-load-balancer-internal-subnet" = "${local.product_location}-${var.env}-user-aks"
+  }
+
+  # ---- Default IngressClass ----
+  ingress_class_name           = "haproxy"
+  set_as_default_ingress_class = false
+
+  # ---- Full monitoring ----
+  enable_metrics         = true
+  enable_stats           = true
+  enable_service_monitor = true # requires Prometheus Operator to be installed
+  metrics_port           = 1024
+
+  # ---- Network Policy ----
+  enable_network_policy = true
+
+  # ---- Distribution across Azure availability zones (zones 1, 2, 3) ----
+  enable_topology_spread     = true
+  anti_affinity_topology_key = "topology.kubernetes.io/zone"
+
+  # ---- Logging ----
+  log_level = "info"
+
+  # ---- Generous timeout for environments with slow policies ----
+  timeout_seconds = 600
+  atomic          = true
+
+  # ---- Targeted overrides for advanced HAProxy settings ----
+  extra_set_values = {
+    "controller.config.ssl-redirect"      = "true"
+    "controller.config.timeout-connect"   = "5s"
+    "controller.config.timeout-client"    = "60s"
+    "controller.config.timeout-server"    = "60s"
+    "controller.config.nbthread"          = "4"
+    "controller.config.max-spread-checks" = "10"
+    "controller.config.forwarded-for"     = "true"
+    "controller.config.load-balance"      = "roundrobin"
+  }
+}

--- a/src/aks-leonardo/05_ingress.tf
+++ b/src/aks-leonardo/05_ingress.tf
@@ -53,7 +53,7 @@ module "nginx_ingress" {
 }
 
 ###############################################################################
-# HAProxy Ingress module - production configuration
+# HAProxy Ingress module - configuration
 ###############################################################################
 
 module "haproxy_ingress" {

--- a/src/aks-leonardo/99_main.tf
+++ b/src/aks-leonardo/99_main.tf
@@ -53,6 +53,6 @@ provider "helm" {
 }
 
 module "__v4__" {
-  # v10.8.0
-  source = "git::https://github.com/pagopa/terraform-azurerm-v4?ref=e5f5d152b9dc360e0b9753e4fa9dfb0e14137b62"
+  # https://github.com/pagopa/terraform-azurerm-v4/releases/tag/v10.10.0
+  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git?ref=c474c98742d71e8829292e38e2a5b9f73e23163f"
 }

--- a/src/aks-leonardo/99_variables.tf
+++ b/src/aks-leonardo/99_variables.tf
@@ -140,6 +140,10 @@ variable "ingress_load_balancer_ip" {
   type = string
 }
 
+variable "haproxy_ingress_load_balancer_ip" {
+  type = string
+}
+
 variable "nginx_helm_version" {
   type        = string
   description = "NGINX helm verison"

--- a/src/aks-leonardo/README.md
+++ b/src/aks-leonardo/README.md
@@ -27,7 +27,7 @@ Re-enable all the resource, commented before to complete the procedure
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.5 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | <= 2.47.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 4.26 |
@@ -39,7 +39,7 @@ Re-enable all the resource, commented before to complete the procedure
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4.git | c474c98742d71e8829292e38e2a5b9f73e23163f |
 | <a name="module_aks_leonardo"></a> [aks\_leonardo](#module\_aks\_leonardo) | ./.terraform/modules/__v4__//kubernetes_cluster | n/a |
 | <a name="module_aks_prometheus_install"></a> [aks\_prometheus\_install](#module\_aks\_prometheus\_install) | ./.terraform/modules/__v4__//kubernetes_prometheus_install | n/a |
@@ -56,7 +56,7 @@ Re-enable all the resource, commented before to complete the procedure
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [azurerm_kubernetes_cluster_node_pool.user_nodepool_default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool) | resource |
 | [azurerm_linux_virtual_machine.vm_debug_italy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine) | resource |
 | [azurerm_network_interface.vm_debug_italy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) | resource |
@@ -114,7 +114,7 @@ Re-enable all the resource, commented before to complete the procedure
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_aks_alerts_enabled"></a> [aks\_alerts\_enabled](#input\_aks\_alerts\_enabled) | Aks alert enabled? | `bool` | `true` | no |
 | <a name="input_aks_enable_workload_identity"></a> [aks\_enable\_workload\_identity](#input\_aks\_enable\_workload\_identity) | n/a | `bool` | `false` | no |
 | <a name="input_aks_kubernetes_version"></a> [aks\_kubernetes\_version](#input\_aks\_kubernetes\_version) | Kubernetes version of cluster aks | `string` | n/a | yes |

--- a/src/aks-leonardo/README.md
+++ b/src/aks-leonardo/README.md
@@ -27,7 +27,7 @@ Re-enable all the resource, commented before to complete the procedure
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.5 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | <= 2.47.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 4.26 |
@@ -39,12 +39,13 @@ Re-enable all the resource, commented before to complete the procedure
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
-| <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4 | e5f5d152b9dc360e0b9753e4fa9dfb0e14137b62 |
+| ---- | ------ | ------- |
+| <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4.git | c474c98742d71e8829292e38e2a5b9f73e23163f |
 | <a name="module_aks_leonardo"></a> [aks\_leonardo](#module\_aks\_leonardo) | ./.terraform/modules/__v4__//kubernetes_cluster | n/a |
 | <a name="module_aks_prometheus_install"></a> [aks\_prometheus\_install](#module\_aks\_prometheus\_install) | ./.terraform/modules/__v4__//kubernetes_prometheus_install | n/a |
 | <a name="module_aks_storage_class"></a> [aks\_storage\_class](#module\_aks\_storage\_class) | ./.terraform/modules/__v4__//kubernetes_storage_class | n/a |
 | <a name="module_elastic_agent"></a> [elastic\_agent](#module\_elastic\_agent) | ./.terraform/modules/__v4__//elastic_agent | n/a |
+| <a name="module_haproxy_ingress"></a> [haproxy\_ingress](#module\_haproxy\_ingress) | ./.terraform/modules/__v4__/kubernetes_haproxy_ingress_controller | n/a |
 | <a name="module_keda_workload_identity_configuration"></a> [keda\_workload\_identity\_configuration](#module\_keda\_workload\_identity\_configuration) | ./.terraform/modules/__v4__//kubernetes_workload_identity_configuration | n/a |
 | <a name="module_keda_workload_identity_init"></a> [keda\_workload\_identity\_init](#module\_keda\_workload\_identity\_init) | ./.terraform/modules/__v4__//kubernetes_workload_identity_init | n/a |
 | <a name="module_nginx_ingress"></a> [nginx\_ingress](#module\_nginx\_ingress) | terraform-module/release/helm | 2.7.0 |
@@ -55,7 +56,7 @@ Re-enable all the resource, commented before to complete the procedure
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azurerm_kubernetes_cluster_node_pool.user_nodepool_default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool) | resource |
 | [azurerm_linux_virtual_machine.vm_debug_italy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine) | resource |
 | [azurerm_network_interface.vm_debug_italy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) | resource |
@@ -113,7 +114,7 @@ Re-enable all the resource, commented before to complete the procedure
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_aks_alerts_enabled"></a> [aks\_alerts\_enabled](#input\_aks\_alerts\_enabled) | Aks alert enabled? | `bool` | `true` | no |
 | <a name="input_aks_enable_workload_identity"></a> [aks\_enable\_workload\_identity](#input\_aks\_enable\_workload\_identity) | n/a | `bool` | `false` | no |
 | <a name="input_aks_kubernetes_version"></a> [aks\_kubernetes\_version](#input\_aks\_kubernetes\_version) | Kubernetes version of cluster aks | `string` | n/a | yes |
@@ -127,6 +128,7 @@ Re-enable all the resource, commented before to complete the procedure
 | <a name="input_enable_elastic_agent"></a> [enable\_elastic\_agent](#input\_enable\_elastic\_agent) | n/a | `bool` | `true` | no |
 | <a name="input_env"></a> [env](#input\_env) | n/a | `string` | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
+| <a name="input_haproxy_ingress_load_balancer_ip"></a> [haproxy\_ingress\_load\_balancer\_ip](#input\_haproxy\_ingress\_load\_balancer\_ip) | n/a | `string` | n/a | yes |
 | <a name="input_ingress_load_balancer_ip"></a> [ingress\_load\_balancer\_ip](#input\_ingress\_load\_balancer\_ip) | n/a | `string` | n/a | yes |
 | <a name="input_ingress_replica_count"></a> [ingress\_replica\_count](#input\_ingress\_replica\_count) | n/a | `string` | n/a | yes |
 | <a name="input_k8s_kube_config_path_prefix"></a> [k8s\_kube\_config\_path\_prefix](#input\_k8s\_kube\_config\_path\_prefix) | Kubernetes Cluster Configurations | `string` | `"~/.kube"` | no |

--- a/src/aks-leonardo/env/itn-dev/terraform.tfvars
+++ b/src/aks-leonardo/env/itn-dev/terraform.tfvars
@@ -59,9 +59,10 @@ aks_user_node_pool = {
 
 
 # This is the k8s ingress controller ip. It must be in the aks subnet range.
-ingress_load_balancer_ip = "10.3.2.250"
-ingress_replica_count    = "2"
-nginx_helm_version       = "4.14.2"
+ingress_load_balancer_ip         = "10.3.2.250"
+haproxy_ingress_load_balancer_ip = "10.3.2.252"
+ingress_replica_count            = "2"
+nginx_helm_version               = "4.14.2"
 
 keda_helm_version    = "2.17.2"
 enable_elastic_agent = false

--- a/src/aks-leonardo/env/itn-prod/terraform.tfvars
+++ b/src/aks-leonardo/env/itn-prod/terraform.tfvars
@@ -63,9 +63,10 @@ aks_user_node_pool = {
 
 
 # This is the k8s ingress controller ip. It must be in the aks subnet range.
-ingress_load_balancer_ip = "10.3.2.250"
-ingress_replica_count    = "2"
-nginx_helm_version       = "4.14.2"
+ingress_load_balancer_ip         = "10.3.2.250"
+haproxy_ingress_load_balancer_ip = "10.3.2.252"
+ingress_replica_count            = "2"
+nginx_helm_version               = "4.14.2"
 
 keda_helm_version = "2.17.2"
 

--- a/src/aks-leonardo/env/itn-uat/terraform.tfvars
+++ b/src/aks-leonardo/env/itn-uat/terraform.tfvars
@@ -60,9 +60,10 @@ aks_user_node_pool = {
 
 
 # This is the k8s ingress controller ip. It must be in the aks subnet range.
-ingress_load_balancer_ip = "10.3.2.250"
-ingress_replica_count    = "2"
-nginx_helm_version       = "4.14.2"
+ingress_load_balancer_ip         = "10.3.2.250"
+haproxy_ingress_load_balancer_ip = "10.3.2.252"
+ingress_replica_count            = "2"
+nginx_helm_version               = "4.14.2"
 
 keda_helm_version    = "2.17.2"
 enable_elastic_agent = false

--- a/src/aks-platform/03_ingress.tf
+++ b/src/aks-platform/03_ingress.tf
@@ -88,7 +88,7 @@ module "nginx_ingress" {
 }
 
 ###############################################################################
-# HAProxy Ingress module - production configuration
+# HAProxy Ingress module - configuration
 ###############################################################################
 
 module "haproxy_ingress" {

--- a/src/aks-platform/03_ingress.tf
+++ b/src/aks-platform/03_ingress.tf
@@ -86,3 +86,96 @@ module "nginx_ingress" {
     }
   ]
 }
+
+###############################################################################
+# HAProxy Ingress module - production configuration
+###############################################################################
+
+module "haproxy_ingress" {
+  source = "./.terraform/modules/__v4__/kubernetes_haproxy_ingress_controller"
+  count  = var.env_short == "d" ? 1 : 0
+
+  release_name         = "haproxy-ingress"
+  namespace            = "haproxy-ingress"
+  chart_version        = "1.49.0"
+  controller_image_tag = "3.2.6"
+
+  # ---- Namespace labels for Azure Policy / Workload Identity ----
+  namespace_labels = {
+    "azure.workload.identity/use" = "false"
+    "environment"                 = var.env
+  }
+
+  # ---- Replicas & aggressive autoscaling ----
+  replica_count = 3
+
+  autoscaling = {
+    enabled                   = true
+    min_replicas              = 3
+    max_replicas              = 20
+    target_cpu_utilization    = 70
+    target_memory_utilization = 75
+  }
+
+  # ---- PDB: keep at least 2 pods always available ----
+  pod_disruption_budget = {
+    enabled       = true
+    min_available = 2
+  }
+
+  # ---- Resources (production sizing) ----
+  resources = {
+    requests_cpu    = "200m"
+    requests_memory = "256Mi"
+    limits_cpu      = "1000m"
+    limits_memory   = "1Gi"
+  }
+
+  # ---- Resource Quota on the namespace ----
+  enable_resource_quota = false
+
+  # ---- Internal Load Balancer with static IP ----
+  service_type     = "LoadBalancer"
+  load_balancer_ip = var.haproxy_ingress_load_balancer_ip
+
+  service_annotations = {
+    # Force the Load Balancer to be internal to the VNet
+    "service.beta.kubernetes.io/azure-load-balancer-internal" = "true"
+  }
+
+  # ---- Default IngressClass ----
+  ingress_class_name           = "haproxy"
+  set_as_default_ingress_class = false
+
+  # ---- Full monitoring ----
+  enable_metrics         = true
+  enable_stats           = true
+  enable_service_monitor = true # requires Prometheus Operator to be installed
+  metrics_port           = 1024
+
+  # ---- Network Policy ----
+  enable_network_policy = true
+
+  # ---- Distribution across Azure availability zones (zones 1, 2, 3) ----
+  enable_topology_spread     = true
+  anti_affinity_topology_key = "topology.kubernetes.io/zone"
+
+  # ---- Logging ----
+  log_level = "info"
+
+  # ---- Generous timeout for environments with slow policies ----
+  timeout_seconds = 600
+  atomic          = true
+
+  # ---- Targeted overrides for advanced HAProxy settings ----
+  extra_set_values = {
+    "controller.config.ssl-redirect"      = "true"
+    "controller.config.timeout-connect"   = "5s"
+    "controller.config.timeout-client"    = "60s"
+    "controller.config.timeout-server"    = "60s"
+    "controller.config.nbthread"          = "4"
+    "controller.config.max-spread-checks" = "10"
+    "controller.config.forwarded-for"     = "true"
+    "controller.config.load-balance"      = "roundrobin"
+  }
+}

--- a/src/aks-platform/99_main.tf
+++ b/src/aks-platform/99_main.tf
@@ -53,6 +53,6 @@ provider "helm" {
 }
 
 module "__v4__" {
-  # v10.8.0
-  source = "git::https://github.com/pagopa/terraform-azurerm-v4?ref=e5f5d152b9dc360e0b9753e4fa9dfb0e14137b62"
+  # https://github.com/pagopa/terraform-azurerm-v4/releases/tag/v10.10.0
+  source = "git::https://github.com/pagopa/terraform-azurerm-v4.git?ref=c474c98742d71e8829292e38e2a5b9f73e23163f"
 }

--- a/src/aks-platform/99_variables.tf
+++ b/src/aks-platform/99_variables.tf
@@ -148,6 +148,11 @@ variable "ingress_load_balancer_ip" {
   type = string
 }
 
+variable "haproxy_ingress_load_balancer_ip" {
+  type = string
+}
+
+
 variable "ingress_min_replica_count" {
   type = string
 }

--- a/src/aks-platform/README.md
+++ b/src/aks-platform/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | <= 2.47.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.26.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | <= 2.12.1 |
@@ -14,7 +14,7 @@
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4.git | c474c98742d71e8829292e38e2a5b9f73e23163f |
 | <a name="module_aks"></a> [aks](#module\_aks) | ./.terraform/modules/__v4__//kubernetes_cluster | n/a |
 | <a name="module_aks_snet"></a> [aks\_snet](#module\_aks\_snet) | ./.terraform/modules/__v4__//subnet | n/a |
@@ -30,7 +30,7 @@
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [azurerm_public_ip.aks_outbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_resource_group.aks_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.aks_to_acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
@@ -76,7 +76,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_aks_alerts_enabled"></a> [aks\_alerts\_enabled](#input\_aks\_alerts\_enabled) | AKS alerts enabled? | `bool` | `false` | no |
 | <a name="input_aks_cidr_subnet"></a> [aks\_cidr\_subnet](#input\_aks\_cidr\_subnet) | Aks network address space. | `list(string)` | n/a | yes |
 | <a name="input_aks_enable_workload_identity"></a> [aks\_enable\_workload\_identity](#input\_aks\_enable\_workload\_identity) | n/a | `bool` | `false` | no |

--- a/src/aks-platform/README.md
+++ b/src/aks-platform/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | <= 2.47.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.26.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | <= 2.12.1 |
@@ -14,10 +14,11 @@
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
-| <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4 | e5f5d152b9dc360e0b9753e4fa9dfb0e14137b62 |
+| ---- | ------ | ------- |
+| <a name="module___v4__"></a> [\_\_v4\_\_](#module\_\_\_v4\_\_) | git::https://github.com/pagopa/terraform-azurerm-v4.git | c474c98742d71e8829292e38e2a5b9f73e23163f |
 | <a name="module_aks"></a> [aks](#module\_aks) | ./.terraform/modules/__v4__//kubernetes_cluster | n/a |
 | <a name="module_aks_snet"></a> [aks\_snet](#module\_aks\_snet) | ./.terraform/modules/__v4__//subnet | n/a |
+| <a name="module_haproxy_ingress"></a> [haproxy\_ingress](#module\_haproxy\_ingress) | ./.terraform/modules/__v4__/kubernetes_haproxy_ingress_controller | n/a |
 | <a name="module_nginx_ingress"></a> [nginx\_ingress](#module\_nginx\_ingress) | terraform-module/release/helm | 2.8.0 |
 | <a name="module_non_critical_node_pool"></a> [non\_critical\_node\_pool](#module\_non\_critical\_node\_pool) | ./.terraform/modules/__v4__/IDH/aks_node_pool | n/a |
 | <a name="module_prometheus_managed_addon"></a> [prometheus\_managed\_addon](#module\_prometheus\_managed\_addon) | ./.terraform/modules/__v4__/kubernetes_prometheus_managed | n/a |
@@ -29,7 +30,7 @@
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [azurerm_public_ip.aks_outbound](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
 | [azurerm_resource_group.aks_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.aks_to_acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
@@ -75,7 +76,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_aks_alerts_enabled"></a> [aks\_alerts\_enabled](#input\_aks\_alerts\_enabled) | AKS alerts enabled? | `bool` | `false` | no |
 | <a name="input_aks_cidr_subnet"></a> [aks\_cidr\_subnet](#input\_aks\_cidr\_subnet) | Aks network address space. | `list(string)` | n/a | yes |
 | <a name="input_aks_enable_workload_identity"></a> [aks\_enable\_workload\_identity](#input\_aks\_enable\_workload\_identity) | n/a | `bool` | `false` | no |
@@ -88,6 +89,7 @@
 | <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | n/a | yes |
 | <a name="input_env"></a> [env](#input\_env) | n/a | `string` | n/a | yes |
 | <a name="input_env_short"></a> [env\_short](#input\_env\_short) | n/a | `string` | n/a | yes |
+| <a name="input_haproxy_ingress_load_balancer_ip"></a> [haproxy\_ingress\_load\_balancer\_ip](#input\_haproxy\_ingress\_load\_balancer\_ip) | n/a | `string` | n/a | yes |
 | <a name="input_ingress_load_balancer_ip"></a> [ingress\_load\_balancer\_ip](#input\_ingress\_load\_balancer\_ip) | n/a | `string` | n/a | yes |
 | <a name="input_ingress_max_replica_count"></a> [ingress\_max\_replica\_count](#input\_ingress\_max\_replica\_count) | n/a | `string` | n/a | yes |
 | <a name="input_ingress_min_replica_count"></a> [ingress\_min\_replica\_count](#input\_ingress\_min\_replica\_count) | n/a | `string` | n/a | yes |

--- a/src/aks-platform/env/weu-dev/terraform.tfvars
+++ b/src/aks-platform/env/weu-dev/terraform.tfvars
@@ -52,9 +52,10 @@ aks_cidr_subnet = ["10.1.0.0/17"]
 aks_kubernetes_version = "1.34.1"
 
 
-ingress_min_replica_count = "1"
-ingress_max_replica_count = "3"
-ingress_load_balancer_ip  = "10.1.100.250"
+ingress_min_replica_count        = "1"
+ingress_max_replica_count        = "3"
+ingress_load_balancer_ip         = "10.1.100.250"
+haproxy_ingress_load_balancer_ip = "10.1.100.252"
 # ingress-nginx helm charts releases 4.X.X: https://github.com/kubernetes/ingress-nginx/releases?expanded=true&page=1&q=tag%3Ahelm-chart-4
 # Pinned versions from "4.7.2" release: https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.7.2/charts/ingress-nginx/values.yaml
 nginx_helm = {

--- a/src/aks-platform/env/weu-prod/terraform.tfvars
+++ b/src/aks-platform/env/weu-prod/terraform.tfvars
@@ -52,9 +52,10 @@ aks_cidr_subnet = ["10.1.0.0/17"]
 
 aks_kubernetes_version = "1.34.2"
 
-ingress_min_replica_count = "2"
-ingress_max_replica_count = "30"
-ingress_load_balancer_ip  = "10.1.100.250"
+ingress_min_replica_count        = "2"
+ingress_max_replica_count        = "30"
+ingress_load_balancer_ip         = "10.1.100.250"
+haproxy_ingress_load_balancer_ip = "10.1.100.252"
 # ingress-nginx helm charts releases 4.X.X: https://github.com/kubernetes/ingress-nginx/releases?expanded=true&page=1&q=tag%3Ahelm-chart-4
 # Pinned versions from "4.1.0" release: https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.1.0/charts/ingress-nginx/values.yaml
 nginx_helm = {

--- a/src/aks-platform/env/weu-uat/terraform.tfvars
+++ b/src/aks-platform/env/weu-uat/terraform.tfvars
@@ -53,9 +53,10 @@ aks_cidr_subnet = ["10.1.0.0/17"]
 aks_kubernetes_version = "1.34.2"
 
 
-ingress_min_replica_count = "2"
-ingress_max_replica_count = "30"
-ingress_load_balancer_ip  = "10.1.100.250"
+ingress_min_replica_count        = "2"
+ingress_max_replica_count        = "30"
+ingress_load_balancer_ip         = "10.1.100.250"
+haproxy_ingress_load_balancer_ip = "10.1.100.252"
 # ingress-nginx helm charts releases 4.X.X: https://github.com/kubernetes/ingress-nginx/releases?expanded=true&page=1&q=tag%3Ahelm-chart-4
 # Pinned versions from "4.1.0" release: https://github.com/kubernetes/ingress-nginx/blob/helm-chart-4.1.0/charts/ingress-nginx/values.yaml
 nginx_helm = {

--- a/src/domains/afm-secrets/README.md
+++ b/src/domains/afm-secrets/README.md
@@ -19,9 +19,15 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azurerm_key_vault_access_policy.adgroup_admin_dev_policy](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_key.generated](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_key) | resource |
 | [azurerm_key_vault_secret.secret](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/resources/key_vault_secret) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/client_config) | data source |
+| [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_admin_dev](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_security](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/client_config) | data source |
 | [azurerm_key_vault.afm_kv](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/key_vault) | data source |
 | [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/2.99.0/docs/data-sources/resource_group) | data source |

--- a/src/domains/bizevents-secrets/README.md
+++ b/src/domains/bizevents-secrets/README.md
@@ -21,10 +21,16 @@ No modules.
 | Name | Type |
 |------|------|
 | [azurerm_api_management_subscription.receipt_service_internal_subkey](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_subscription) | resource |
+| [azurerm_key_vault_access_policy.adgroup_admin_dev_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_key.generated](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_key) | resource |
 | [azurerm_key_vault_secret.receipt_service_internal_subkey_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/client_config) | data source |
+| [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_admin_dev](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_security](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
 | [azurerm_api_management_product.apim_receipts_internal_product](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/api_management_product) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_key_vault.bizevents_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |

--- a/src/domains/checkout-app/05_checkout_fe_frontdoor_cdn.tf
+++ b/src/domains/checkout-app/05_checkout_fe_frontdoor_cdn.tf
@@ -1,9 +1,9 @@
 locals {
-  npg_sdk_hostname = var.env_short == "p" ? "xpay.nexigroup.com" : "stg-ta.nexigroup.com"
-  content_security_policy_header_name  = "Content-Security-Policy"
-  cdn_storage_account_name       = "${local.project}cdnsa"
-  cdn_index_document             = "index.html"
-  cdn_error_document             = "index.html"
+  npg_sdk_hostname                    = var.env_short == "p" ? "xpay.nexigroup.com" : "stg-ta.nexigroup.com"
+  content_security_policy_header_name = "Content-Security-Policy"
+  cdn_storage_account_name            = "${local.project}cdnsa"
+  cdn_index_document                  = "index.html"
+  cdn_error_document                  = "index.html"
 
   # shared CSP value -> single source of truth for both CDN delivery rules and APIM policy
   checkout_csp_value = join("", [

--- a/src/domains/fdr-secret/README.md
+++ b/src/domains/fdr-secret/README.md
@@ -25,6 +25,7 @@
 | Name | Type |
 |------|------|
 | [azurerm_key_vault_access_policy.ad_group_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.adgroup_admin_dev_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_developers_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_externals_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.azdevops_iac_legacy_policies](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
@@ -37,6 +38,7 @@
 | [kubernetes_config_map.fdr_cacerts](https://registry.terraform.io/providers/hashicorp/kubernetes/2.16.1/docs/resources/config_map) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/client_config) | data source |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_admin_dev](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_security](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |

--- a/src/domains/gps-secret/README.md
+++ b/src/domains/gps-secret/README.md
@@ -20,9 +20,15 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azurerm_key_vault_access_policy.adgroup_admin_dev_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_key.generated](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_key) | resource |
 | [azurerm_key_vault_secret.secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/client_config) | data source |
+| [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_admin_dev](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_security](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_key_vault.gps_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |

--- a/src/domains/payopt-secrets/README.md
+++ b/src/domains/payopt-secrets/README.md
@@ -25,6 +25,7 @@
 | Name | Type |
 |------|------|
 | [azurerm_key_vault_access_policy.ad_group_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.adgroup_admin_dev_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_developers_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_externals_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.azdevops_iac_managed_identities](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
@@ -33,6 +34,7 @@
 | [azurerm_key_vault_secret.secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_admin_dev](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_security](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |

--- a/src/domains/printit-secrets/README.md
+++ b/src/domains/printit-secrets/README.md
@@ -29,6 +29,7 @@
 | Name | Type |
 |------|------|
 | [azurerm_key_vault_access_policy.ad_group_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.adgroup_admin_dev_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_developers_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_externals_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.azdevops_iac_managed_identities](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
@@ -41,6 +42,7 @@
 | [random_string.random_aes_key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_string.random_aes_salt](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_admin_dev](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_security](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |

--- a/src/domains/receipts-secrets/README.md
+++ b/src/domains/receipts-secrets/README.md
@@ -25,6 +25,7 @@
 | Name | Type |
 |------|------|
 | [azurerm_key_vault_access_policy.ad_group_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.adgroup_admin_dev_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_developers_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.adgroup_externals_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_access_policy.azdevops_iac_legacy_policies](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
@@ -41,6 +42,7 @@
 | [azurerm_resource_group.sec_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/client_config) | data source |
 | [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_admin_dev](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_security](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |

--- a/src/domains/shared-secrets/README.md
+++ b/src/domains/shared-secrets/README.md
@@ -20,11 +20,17 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azurerm_key_vault_access_policy.adgroup_admin_dev_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
 | [azurerm_key_vault_key.generated](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_key) | resource |
 | [azurerm_key_vault_secret.ecommerce_pdv_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.pay_wallet_pdv_secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_key_vault_secret.secret](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/client_config) | data source |
+| [azuread_group.adgroup_admin](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_admin_dev](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_developers](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_externals](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_security](https://registry.terraform.io/providers/hashicorp/azuread/2.21.0/docs/data-sources/group) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_key_vault.ecommerce_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
 | [azurerm_key_vault.pay_wallet_kv](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |


### PR DESCRIPTION
### List of changes

- Integrated HAProxy ingress controller in dev environment.
- Added `haproxy_ingress_load_balancer_ip` variable to allow static IP assignments.
- Upgraded `terraform-azurerm-v4` module to version 10.10.0.
- Updated the README and variable files to reflect these changes.

### Motivation and context

This change introduces HAProxy ingress to enable better load balancing and static IP assignment capabilities. Additionally, updating the `terraform-azurerm-v4` module ensures compatibility with the latest improvements and fixes.

### Type of changes

- [x] Add new resources  
- [x] Update configuration to existing resources  
- [ ] Remove existing resources  

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change  
- [ ] No  

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes  
- [x] No  

### Other information

N/A  

---  

### If PR is partially applied, why? (reserved to maintainers)

N/A  