### PR TITLE
fix(infra): [PIDM-2021] remove env_short guard on ecommerce_ingress_hostname - attivazione

### DIFF
--- a/src/domains/checkout-app/04_apim_checkout_ec.tf
+++ b/src/domains/checkout-app/04_apim_checkout_ec.tf
@@ -89,7 +89,7 @@ module "apim_checkout_ec_api_v2" {
   })
 
   xml_content = templatefile("./api/checkout/checkout_ec/v2/_base_policy.xml.tpl", {
-    ecommerce_ingress_hostname = var.env_short == "p" ? "disabled" : var.ecommerce_ingress_hostname,
+    ecommerce_ingress_hostname = var.ecommerce_ingress_hostname,
   })
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- remove env_short guard on ecommerce_ingress_hostname

### Motivation and context

The `ecommerce_ingress_hostname` variable was previously disabled in 
production by a conditional that forced the value to `"disabled"` when 
`var.env_short == "p"`. This prevented the ecommerce ingress task from 
being active in the production environment.

This change removes the guard so that `ecommerce_ingress_hostname` always 
uses the value provided by `var.ecommerce_ingress_hostname`, enabling the 
ecommerce ingress task consistently across all environments, including 
production.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
