### PR TITLE
feat: Update cloudo module image tags to latest versions

### DIFF
--- a/src/cloudo/cloudo-core/env/prod/terraform.tfvars
+++ b/src/cloudo/cloudo-core/env/prod/terraform.tfvars
@@ -13,7 +13,7 @@ application_insisght_resource_group_name = "pagopa-p-monitor-rg"
 # ClouDO orchestrator parameters
 cloudo_orchestrator = {
   image_name        = "pagopa/cloudo-orchestrator"
-  image_tag         = "0.20.0"
+  image_tag         = "0.24.2"
   registry_url      = "https://ghcr.io"
   registry_username = "payments-cloud-bot"
 }
@@ -21,7 +21,7 @@ cloudo_orchestrator = {
 # ClouDO UI parameters
 cloudo_ui = {
   image_name        = "pagopa/cloudo-ui"
-  image_tag         = "0.12.0"
+  image_tag         = "0.14.1"
   registry_url      = "https://ghcr.io"
   registry_username = "payments-cloud-bot"
 }
@@ -29,7 +29,7 @@ cloudo_ui = {
 # ClouDO worker parameters
 cloudo_worker = {
   image_name        = "pagopa/cloudo-worker"
-  image_tag         = "0.14.0"
+  image_tag         = "0.18.0"
   registry_url      = "https://ghcr.io"
   registry_username = "payments-cloud-bot"
 }

--- a/src/cloudo/cloudo-core/env/uat/terraform.tfvars
+++ b/src/cloudo/cloudo-core/env/uat/terraform.tfvars
@@ -13,7 +13,7 @@ application_insisght_resource_group_name = "pagopa-u-monitor-rg"
 # ClouDO orchestrator parameters
 cloudo_orchestrator = {
   image_name        = "pagopa/cloudo-orchestrator"
-  image_tag         = "0.24.0"
+  image_tag         = "0.24.2"
   registry_url      = "https://ghcr.io"
   registry_username = "payments-cloud-bot"
 }
@@ -21,7 +21,7 @@ cloudo_orchestrator = {
 # ClouDO UI parameters
 cloudo_ui = {
   image_name        = "pagopa/cloudo-ui"
-  image_tag         = "0.14.0"
+  image_tag         = "0.14.1"
   registry_url      = "https://ghcr.io"
   registry_username = "payments-cloud-bot"
 }


### PR DESCRIPTION
### List of changes

- Bumped cloudo module image tags:
  - Image 1: v0.24.2
  - Image 2: v0.14.1
  - Image 3: v0.18.0

### Motivation and context

This update ensures that the cloudo module images are using the latest stable versions, incorporating the latest features and fixes.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [x] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

N/A

---

### If PR is partially applied, why? (reserved to mantainers)

