### PR TITLE
feat: [PRGP-425] Enable Cloudo API management for production environment

### DIFF
--- a/src/cloudo/cloudo-core/02_cloudo.tf
+++ b/src/cloudo/cloudo-core/02_cloudo.tf
@@ -110,8 +110,8 @@ module "cloudo" {
     registry_password = data.azurerm_key_vault_secret.github_pat.value
   }
 
-  api_management_name       = var.env_short != "p" ? data.azurerm_api_management.apim.name : ""
-  api_management_rg         = var.env_short != "p" ? data.azurerm_api_management.apim.resource_group_name : ""
+  api_management_name       = data.azurerm_api_management.apim.name
+  api_management_rg         = data.azurerm_api_management.apim.resource_group_name
   api_subscription_required = true
 
   tags = module.tag_config.tags


### PR DESCRIPTION
### List of changes

- Added configuration to enable Cloudo API management in the production environment.

### Motivation and context

This change is required to activate Cloudo API management in the production environment, enhancing operational capabilities and resource management.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

No additional information to include.

---

### If PR is partially applied, why? (reserved to mantainers)

N/A