### PR TITLE
chore: [CHK-4874] removed symmetric key validation of jwt

### DIFF
--- a/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/npg-notification/_npg_notifications_policy.xml.tpl
@@ -12,44 +12,17 @@
                 </return-response>
             </when>
         </choose>
-        <!-- Extract 'iss' claim -->
-        <set-variable name="jwtIssuer" value="@{
-            Jwt jwt;
-            context.Request.Url.Query.GetValueOrDefault("sessionToken","").Split(' ').Last().TryParseJwt(out jwt);
-            return jwt?.Claims.GetValueOrDefault("iss", "");
-        }" />
-        <!-- Store useOpenId as string 'true' or 'false' -->
-        <set-variable name="useOpenId" value="@(
-            (context.Variables.GetValueOrDefault<string>("jwtIssuer")?.Contains("jwt-issuer-service") == true).ToString()
-        )" />
-        <!-- Conditional validation -->
-        <choose>
-            <when condition="@(bool.Parse(context.Variables.GetValueOrDefault<string>("useOpenId")))">
-                <validate-jwt query-parameter-name="sessionToken" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized" require-expiration-time="true" require-scheme="Bearer" require-signed-tokens="true" output-token-variable-name="jwtToken">
-                  <openid-config url="https://${hostname}/pagopa-jwt-issuer-service/.well-known/openid-configuration" />
-                  <audiences>
-                    <audience>npg</audience>
-                  </audiences>
-                  <required-claims>
-                    <claim name="orderId" match="all">
-                      <value>@((string)context.Variables.GetValueOrDefault("orderId",""))</value>
-                    </claim>
-                 </required-claims>
-                </validate-jwt>
-            </when>
-            <otherwise>
-                <validate-jwt query-parameter-name="sessionToken" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized" require-expiration-time="true" require-signed-tokens="true" output-token-variable-name="jwtToken">
-                  <issuer-signing-keys>
-                      <key>{{npg-notification-jwt-secret}}</key>
-                  </issuer-signing-keys>
-                  <required-claims>
-                    <claim name="orderId" match="all">
-                      <value>@((string)context.Variables.GetValueOrDefault("orderId",""))</value>
-                    </claim>
-                 </required-claims>
-                </validate-jwt>
-            </otherwise>
-        </choose>
+        <validate-jwt query-parameter-name="sessionToken" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized" require-expiration-time="true" require-scheme="Bearer" require-signed-tokens="true" output-token-variable-name="jwtToken">
+          <openid-config url="https://${hostname}/pagopa-jwt-issuer-service/.well-known/openid-configuration" />
+          <audiences>
+            <audience>npg</audience>
+          </audiences>
+          <required-claims>
+            <claim name="orderId" match="all">
+              <value>@((string)context.Variables.GetValueOrDefault("orderId",""))</value>
+            </claim>
+         </required-claims>
+        </validate-jwt>
         <!-- end validation policy -->
       <!-- start policy variables -->
       <set-variable name="transactionId" value="@{


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- ecommerce-npg-notification-v1 group --> removed symmetric key validation of JWT tokens from APIM policies. The token is now validated using only the jwt-issuer-service.

<!--- Describe your changes in detail -->

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information
API test OK in DEV

https://dev.azure.com/pagopaspa/pagoPA-projects/_build/results?buildId=278225&view=results

API test OK in UAT

https://dev.azure.com/pagopaspa/pagoPA-projects/_build/results?buildId=278262&view=results



<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
