### PR TITLE
chore: remove responder from SNAT connections alert

### DIFF
--- a/src/next-core/08_natgateway.tf
+++ b/src/next-core/08_natgateway.tf
@@ -79,9 +79,6 @@ resource "azurerm_monitor_metric_alert" "snat_connection_over_10K" {
     action_group_id = azurerm_monitor_action_group.email.id
   }
   action {
-    action_group_id = azurerm_monitor_action_group.new_conn_srv_opsgenie[0].id
-  }
-  action {
     action_group_id = azurerm_monitor_action_group.infra_opsgenie.0.id
   }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Remove opsgenie team core responder from SNAT over 10k connections alert
<!--- Describe your changes in detail -->

### Motivation and context
This alert is already routed to pagopa-infra team, no need to route it to dev team too
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
