### PR TITLE
fix: update azuread_group reference for developer externals in ecommerce-common domain

### DIFF
--- a/src/domains/ecommerce-app/api/ecommerce-checkout-auth/v1/_base_policy.xml.tpl
+++ b/src/domains/ecommerce-app/api/ecommerce-checkout-auth/v1/_base_policy.xml.tpl
@@ -41,7 +41,7 @@
         <value>{{ecommerce-payment-requests-api-key-value}}</value>
       </set-header>
       <set-variable name="transactionsOperationId" value="newTransactionAuth" />
-      <set-variable name="paymentMethodsOperationId" value="getAllPaymentMethodsAuth,createSessionAuth" />
+      <set-variable name="paymentMethodsOperationId" value="createSessionAuth" />
       <set-variable name="paymentRequestsOperationId" value="getPaymentRequestInfoAuth" />
       <set-variable name="paymentMethodsHandlerOperationId" value="getAllPaymentMethodsAuth" />
 
@@ -54,9 +54,9 @@
         </when>
         <when condition="@(Array.Exists(context.Variables.GetValueOrDefault("paymentMethodsHandlerOperationId","").Split(','), operations => operations == context.Operation.Id))">
           <set-header name="x-api-key" exists-action="override">
-            <value>{{ecommerce-transactions-service-api-key-value}}</value>
+            <value>{{ecommerce-payment-methods-api-key-value}}</value>
           </set-header>
-          <set-backend-service base-url="@("https://${ecommerce_ingress_hostname}"+context.Variables["blueDeploymentPrefix"]+"/pagopa-ecommerce-transactions-handler")"/>
+          <set-backend-service base-url="@("https://${ecommerce_ingress_hostname}"+context.Variables["blueDeploymentPrefix"]+"/pagopa-ecommerce-payment-methods-handler")"/>
         </when>
         <when condition="@(Array.Exists(context.Variables.GetValueOrDefault("paymentMethodsOperationId","").Split(','), operations => operations == context.Operation.Id))">
           <!-- Set payment-methods API Key header -->

--- a/src/domains/ecommerce-common/00_azuread.tf
+++ b/src/domains/ecommerce-common/00_azuread.tf
@@ -20,5 +20,6 @@ data "azuread_group" "adgroup_admin_dev" {
 }
 
 data "azuread_group" "adgroup_developer_externals" {
+  count        = var.env_short != "p" ? 1 : 0
   display_name = "${local.product}-adgroup-developer-externals"
 }

--- a/src/domains/ecommerce-common/02_security.tf
+++ b/src/domains/ecommerce-common/02_security.tf
@@ -55,7 +55,7 @@ resource "azurerm_key_vault_access_policy" "adgroup_external_dev_policy" {
   key_vault_id = module.key_vault.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
-  object_id = data.azuread_group.adgroup_developer_externals.object_id
+  object_id = data.azuread_group.adgroup_developer_externals[0].object_id
 
   key_permissions     = ["Get", "List", "Update", "Create", "Import", "Delete", ]
   secret_permissions  = ["Get", "List", "Set", "Delete", ]


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

### Motivation and context

This pull request updates the handling of the adgroup_developer_externals Azure AD group to make its creation conditional based on the environment, and adjusts the key vault access policy to account for this change.

### Type of changes

- [ ] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
