### PR TITLE
chore: [CHK-4929] update alert of Ecommerce for Checkout API

### DIFF
--- a/src/domains/ecommerce-common/00_alerts.tf
+++ b/src/domains/ecommerce-common/00_alerts.tf
@@ -79,7 +79,7 @@ AzureDiagnostics
 | where url_s startswith 'https://api.platform.pagopa.it/ecommerce/checkout/'
 | summarize
     Total=count(),
-    Success=countif(responseCode_d < 500 or (operationId_s in ("getPaymentRequestInfo", "getPaymentRequestInfoAuth") and responseCode_d in (502, 504)))
+    Success=countif(responseCode_d < 500 or (operationId_s in ("getPaymentRequestInfo","getPaymentRequestInfoV3","getPaymentRequestInfoAuth") and responseCode_d in (502, 504)))
     by Time = bin(TimeGenerated, 15m)
 | extend trafficUp = Total-thresholdTrafficMin
 | extend deltaRatio = todouble(todouble(trafficUp)/todouble(thresholdDelta))

--- a/src/domains/ecommerce-common/00_alerts.tf
+++ b/src/domains/ecommerce-common/00_alerts.tf
@@ -79,7 +79,7 @@ AzureDiagnostics
 | where url_s startswith 'https://api.platform.pagopa.it/ecommerce/checkout/'
 | summarize
     Total=count(),
-    Success=countif(responseCode_d < 500 or (operationId_s in ("getPaymentRequestInfo", "getPaymentRequestInfoV3") and responseCode_d in (502, 504)))
+    Success=countif(responseCode_d < 500 or (operationId_s in ("getPaymentRequestInfo", "getPaymentRequestInfoAuth") and responseCode_d in (502, 504)))
     by Time = bin(TimeGenerated, 15m)
 | extend trafficUp = Total-thresholdTrafficMin
 | extend deltaRatio = todouble(todouble(trafficUp)/todouble(thresholdDelta))


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
- Update the operationId used to identify the auth request version of the getPaymentRequestInfo 

<!--- Describe your changes in detail -->

### Motivation and context
With the migration to the new group of auth version of Ecommerce for checkout API, the existing alerts must be update with the new operationIds used.
No other references to the v3 and v4 old group were found.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
