### PR TITLE
feat: add peak-hours autoscaling profile for PDF engine services

### DIFF
--- a/src/domains/shared-app/01_app_service_pdf_engine.tf
+++ b/src/domains/shared-app/01_app_service_pdf_engine.tf
@@ -262,6 +262,27 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
 
 
   }
+
+  # Peak hours profile (7 AM to 8 PM) - Workdays only
+  # This profile ensures 20 instances are always available during peak business hours
+  # Applied Monday through Friday, from 07:00 to 19:59 (8 PM)
+  # Helps handle high traffic during working hours with guaranteed capacity
+  profile {
+    name = "peak-hours"
+
+    capacity {
+      default = 20
+      minimum = 20
+      maximum = 20
+    }
+
+    recurrence {
+      timezone = "Europe/Rome"
+      days     = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+      hours    = [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+      minutes  = [0]
+    }
+  }
 }
 
 
@@ -492,6 +513,27 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
         value     = "1"
         cooldown  = "PT10M"
       }
+    }
+  }
+
+  # Peak hours profile (7 AM to 8 PM) - Workdays only
+  # This profile ensures 20 instances are always available during peak business hours
+  # Applied Monday through Friday, from 07:00 to 19:59 (8 PM)
+  # Helps handle high traffic during working hours with guaranteed capacity
+  profile {
+    name = "peak-hours"
+
+    capacity {
+      default = 20
+      minimum = 20
+      maximum = 20
+    }
+
+    recurrence {
+      timezone = "Europe/Rome"
+      days     = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+      hours    = [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+      minutes  = [0]
     }
   }
 }

--- a/src/domains/shared-app/01_app_service_pdf_engine.tf
+++ b/src/domains/shared-app/01_app_service_pdf_engine.tf
@@ -110,6 +110,9 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
   target_resource_id  = module.shared_pdf_engine_app_service[0].plan_id
   enabled             = var.app_service_pdf_engine_autoscale_enabled
 
+  # ==========================================
+  # 1. PROFILO DI DEFAULT (Applicato nei weekend e come fallback)
+  # ==========================================
   profile {
     name = "default"
 
@@ -119,7 +122,7 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
       maximum = var.env_short == "p" ? 21 : 1
     }
 
-    # Requests
+    # -- REGOLE METRICHE (REQUESTS) --
     rule {
       metric_trigger {
         metric_name              = "Requests"
@@ -133,7 +136,6 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
         threshold                = 400
         divide_by_instance_count = false
       }
-
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
@@ -155,7 +157,6 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
         threshold                = 400
         divide_by_instance_count = false
       }
-
       scale_action {
         direction = "Decrease"
         type      = "ChangeCount"
@@ -164,10 +165,7 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
       }
     }
 
-    # HttpResponseTime
-
-    # Supported metrics for Microsoft.Web/sites
-    # 👀 https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-metrics
+    # -- REGOLE METRICHE (HTTP RESPONSE TIME) --
     rule {
       metric_trigger {
         metric_name              = "HttpResponseTime"
@@ -181,7 +179,6 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
         threshold                = 3 #sec
         divide_by_instance_count = false
       }
-
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
@@ -203,7 +200,6 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
         threshold                = 2 #sec
         divide_by_instance_count = false
       }
-
       scale_action {
         direction = "Decrease"
         type      = "ChangeCount"
@@ -212,10 +208,7 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
       }
     }
 
-    # CpuPercentage
-
-    # Supported metrics for Microsoft.Web/sites
-    # 👀 https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-metrics
+    # -- REGOLE METRICHE (CPU PERCENTAGE) --
     rule {
       metric_trigger {
         metric_name              = "CpuPercentage"
@@ -229,7 +222,6 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
         threshold                = 75
         divide_by_instance_count = false
       }
-
       scale_action {
         direction = "Increase"
         type      = "ChangeCount"
@@ -248,10 +240,9 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
         time_window              = "PT5M"
         time_aggregation         = "Average"
         operator                 = "LessThan"
-        threshold                = 30 #sec
+        threshold                = 30
         divide_by_instance_count = false
       }
-
       scale_action {
         direction = "Decrease"
         type      = "ChangeCount"
@@ -259,14 +250,11 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
         cooldown  = "PT10M"
       }
     }
-
-
   }
 
-  # Peak hours profile (7 AM to 8 PM) - Workdays only
-  # This profile ensures 20 instances are always available during peak business hours
-  # Applied Monday through Friday, from 07:00 to 19:59 (8 PM)
-  # Helps handle high traffic during working hours with guaranteed capacity
+  # ==========================================
+  # 2. PROFILO PEAK HOURS (Orari di punta lavorativi: fisso a 20)
+  # ==========================================
   profile {
     name = "peak-hours"
 
@@ -276,15 +264,163 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
       maximum = 20
     }
 
+    # Niente regole qui: la capacità è fissa a 20.
+
     recurrence {
-      timezone = "Europe/Rome"
+      timezone = "Romance Standard Time"
       days     = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
-      hours    = [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+      hours    = [7] # Si attiva alle 07:00
+      minutes  = [0]
+    }
+  }
+
+  # ==========================================
+  # 3. PROFILO OFF-PEAK (Notte: torna dinamico)
+  # ==========================================
+  profile {
+    name = "off-peak"
+
+    capacity {
+      default = var.env_short == "p" ? 3 : 1
+      minimum = var.env_short == "p" ? 3 : 1
+      maximum = var.env_short == "p" ? 21 : 1
+    }
+
+    # -- DUPLICATO DELLE REGOLE METRICHE PER LA NOTTE --
+    rule {
+      metric_trigger {
+        metric_name              = "Requests"
+        metric_resource_id       = module.shared_pdf_engine_app_service[0].id
+        metric_namespace         = "microsoft.web/sites"
+        time_grain               = "PT1M"
+        statistic                = "Sum"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "GreaterThan"
+        threshold                = 400
+        divide_by_instance_count = false
+      }
+      scale_action {
+        direction = "Increase"
+        type      = "ChangeCount"
+        value     = "2"
+        cooldown  = "PT5M"
+      }
+    }
+
+    rule {
+      metric_trigger {
+        metric_name              = "Requests"
+        metric_resource_id       = module.shared_pdf_engine_app_service[0].id
+        metric_namespace         = "microsoft.web/sites"
+        time_grain               = "PT1M"
+        statistic                = "Sum"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "LessThan"
+        threshold                = 400
+        divide_by_instance_count = false
+      }
+      scale_action {
+        direction = "Decrease"
+        type      = "ChangeCount"
+        value     = "1"
+        cooldown  = "PT10M"
+      }
+    }
+
+    rule {
+      metric_trigger {
+        metric_name              = "HttpResponseTime"
+        metric_resource_id       = module.shared_pdf_engine_app_service[0].id
+        metric_namespace         = "microsoft.web/sites"
+        time_grain               = "PT1M"
+        statistic                = "Average"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "GreaterThan"
+        threshold                = 3
+        divide_by_instance_count = false
+      }
+      scale_action {
+        direction = "Increase"
+        type      = "ChangeCount"
+        value     = "2"
+        cooldown  = "PT5M"
+      }
+    }
+
+    rule {
+      metric_trigger {
+        metric_name              = "HttpResponseTime"
+        metric_resource_id       = module.shared_pdf_engine_app_service[0].id
+        metric_namespace         = "microsoft.web/sites"
+        time_grain               = "PT1M"
+        statistic                = "Average"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "LessThan"
+        threshold                = 2
+        divide_by_instance_count = false
+      }
+      scale_action {
+        direction = "Decrease"
+        type      = "ChangeCount"
+        value     = "1"
+        cooldown  = "PT10M"
+      }
+    }
+
+    rule {
+      metric_trigger {
+        metric_name              = "CpuPercentage"
+        metric_resource_id       = module.shared_pdf_engine_app_service[0].plan_id
+        metric_namespace         = "microsoft.web/serverfarms"
+        time_grain               = "PT1M"
+        statistic                = "Average"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "GreaterThan"
+        threshold                = 75
+        divide_by_instance_count = false
+      }
+      scale_action {
+        direction = "Increase"
+        type      = "ChangeCount"
+        value     = "2"
+        cooldown  = "PT5M"
+      }
+    }
+
+    rule {
+      metric_trigger {
+        metric_name              = "CpuPercentage"
+        metric_resource_id       = module.shared_pdf_engine_app_service[0].plan_id
+        metric_namespace         = "microsoft.web/serverfarms"
+        time_grain               = "PT1M"
+        statistic                = "Average"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "LessThan"
+        threshold                = 30
+        divide_by_instance_count = false
+      }
+      scale_action {
+        direction = "Decrease"
+        type      = "ChangeCount"
+        value     = "1"
+        cooldown  = "PT10M"
+      }
+    }
+
+    recurrence {
+      timezone = "Romance Standard Time"
+      days     = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+      hours    = [20] # Si attiva alle 20:00 per spegnere il peak-hours
       minutes  = [0]
     }
   }
 }
-
 
 ################
 # java
@@ -365,6 +501,9 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
   target_resource_id  = module.shared_pdf_engine_app_service_java[0].plan_id
   enabled             = var.app_service_pdf_engine_autoscale_enabled
 
+  # ==========================================
+  # 1. PROFILO DI DEFAULT (Applicato nei weekend e come fallback)
+  # ==========================================
   profile {
     name = "default"
 
@@ -420,9 +559,6 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
     }
 
     # HttpResponseTime
-
-    # Supported metrics for Microsoft.Web/sites
-    # 👀 https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-metrics
     rule {
       metric_trigger {
         metric_name              = "HttpResponseTime"
@@ -468,9 +604,6 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
     }
 
     # CpuPercentage
-
-    # Supported metrics for Microsoft.Web/sites
-    # 👀 https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-web-sites-metrics
     rule {
       metric_trigger {
         metric_name              = "CpuPercentage"
@@ -516,10 +649,9 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
     }
   }
 
-  # Peak hours profile (7 AM to 8 PM) - Workdays only
-  # This profile ensures 20 instances are always available during peak business hours
-  # Applied Monday through Friday, from 07:00 to 19:59 (8 PM)
-  # Helps handle high traffic during working hours with guaranteed capacity
+  # ==========================================
+  # 2. PROFILO PEAK HOURS (Orari di punta lavorativi: fisso a 20)
+  # ==========================================
   profile {
     name = "peak-hours"
 
@@ -530,11 +662,167 @@ resource "azurerm_monitor_autoscale_setting" "autoscale_app_service_shared_pdf_e
     }
 
     recurrence {
-      timezone = "Europe/Rome"
+      timezone = "Romance Standard Time"
       days     = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
-      hours    = [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+      hours    = [7] # Si attiva alle 07:00
+      minutes  = [0]
+    }
+  }
+
+  # ==========================================
+  # 3. PROFILO OFF-PEAK (Notte: torna dinamico)
+  # ==========================================
+  profile {
+    name = "off-peak"
+
+    capacity {
+      default = var.env_short == "p" ? 3 : 1
+      minimum = var.env_short == "p" ? 3 : 1
+      maximum = var.env_short == "p" ? 21 : 1
+    }
+
+    # -- DUPLICATO DELLE REGOLE METRICHE PER LA NOTTE --
+
+    # Requests
+    rule {
+      metric_trigger {
+        metric_name              = "Requests"
+        metric_resource_id       = module.shared_pdf_engine_app_service_java[0].id
+        metric_namespace         = "microsoft.web/sites"
+        time_grain               = "PT1M"
+        statistic                = "Sum"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "GreaterThan"
+        threshold                = 400
+        divide_by_instance_count = false
+      }
+
+      scale_action {
+        direction = "Increase"
+        type      = "ChangeCount"
+        value     = "2"
+        cooldown  = "PT5M"
+      }
+    }
+
+    rule {
+      metric_trigger {
+        metric_name              = "Requests"
+        metric_resource_id       = module.shared_pdf_engine_app_service_java[0].id
+        metric_namespace         = "microsoft.web/sites"
+        time_grain               = "PT1M"
+        statistic                = "Sum"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "LessThan"
+        threshold                = 400
+        divide_by_instance_count = false
+      }
+
+      scale_action {
+        direction = "Decrease"
+        type      = "ChangeCount"
+        value     = "1"
+        cooldown  = "PT10M"
+      }
+    }
+
+    # HttpResponseTime
+    rule {
+      metric_trigger {
+        metric_name              = "HttpResponseTime"
+        metric_resource_id       = module.shared_pdf_engine_app_service_java[0].id
+        metric_namespace         = "microsoft.web/sites"
+        time_grain               = "PT1M"
+        statistic                = "Average"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "GreaterThan"
+        threshold                = 3 #sec
+        divide_by_instance_count = false
+      }
+
+      scale_action {
+        direction = "Increase"
+        type      = "ChangeCount"
+        value     = "2"
+        cooldown  = "PT5M"
+      }
+    }
+
+    rule {
+      metric_trigger {
+        metric_name              = "HttpResponseTime"
+        metric_resource_id       = module.shared_pdf_engine_app_service_java[0].id
+        metric_namespace         = "microsoft.web/sites"
+        time_grain               = "PT1M"
+        statistic                = "Average"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "LessThan"
+        threshold                = 2 #sec
+        divide_by_instance_count = false
+      }
+
+      scale_action {
+        direction = "Decrease"
+        type      = "ChangeCount"
+        value     = "1"
+        cooldown  = "PT10M"
+      }
+    }
+
+    # CpuPercentage
+    rule {
+      metric_trigger {
+        metric_name              = "CpuPercentage"
+        metric_resource_id       = module.shared_pdf_engine_app_service_java[0].plan_id
+        metric_namespace         = "microsoft.web/serverfarms"
+        time_grain               = "PT1M"
+        statistic                = "Average"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "GreaterThan"
+        threshold                = 75
+        divide_by_instance_count = false
+      }
+
+      scale_action {
+        direction = "Increase"
+        type      = "ChangeCount"
+        value     = "2"
+        cooldown  = "PT5M"
+      }
+    }
+
+    rule {
+      metric_trigger {
+        metric_name              = "CpuPercentage"
+        metric_resource_id       = module.shared_pdf_engine_app_service_java[0].plan_id
+        metric_namespace         = "microsoft.web/serverfarms"
+        time_grain               = "PT1M"
+        statistic                = "Average"
+        time_window              = "PT5M"
+        time_aggregation         = "Average"
+        operator                 = "LessThan"
+        threshold                = 30 #sec
+        divide_by_instance_count = false
+      }
+
+      scale_action {
+        direction = "Decrease"
+        type      = "ChangeCount"
+        value     = "1"
+        cooldown  = "PT10M"
+      }
+    }
+
+    recurrence {
+      timezone = "Romance Standard Time"
+      days     = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+      hours    = [20] # Si attiva alle 20:00 per spegnere il peak-hours
       minutes  = [0]
     }
   }
 }
-


### PR DESCRIPTION
## Description
Add time-based autoscaling profiles to PDF engine App Services (both Node and Java versions).

## Changes
- **New peak-hours profile** with guaranteed 20 instances
- **Applies**: Monday-Friday, 7 AM to 8 PM
- **Timezone**: Europe/Rome
- **Outside peak hours**: Metric-based scaling continues (CPU, Requests, HttpResponseTime)
- **Weekends**: Standard metric-based scaling only

## Benefits
✅ Guaranteed capacity during business hours
✅ Automatic cost optimization outside peak hours
✅ Handles high traffic predictably during working hours
✅ Applied to both Node and Java PDF engine services