### PR TITLE
feat: PIDM-2130 remediation namespace gpd PDV

### DIFF
--- a/src/domains/gps-secret/secret/weu-dev/noedit_secret_enc.json
+++ b/src/domains/gps-secret/secret/weu-dev/noedit_secret_enc.json
@@ -3,6 +3,7 @@
 	"cdc-logical-replication-apd-user": "ENC[AES256_GCM,data:A3+k23I+,iv:TygCKKbqy37+7f9j/V40um/ADNmuBkkpRdhY1FNNn7Y=,tag:wVZDORQ8/OSrhz53RQuKOQ==,type:str]",
 	"cdc-logical-replication-apd-pwd": "ENC[AES256_GCM,data:ZYpNes5H0L7wEmU=,iv:U8O5Wz6lxWVPLzeO0/soqk1OcMS34qQGgXBZ8ch3XU4=,tag:cZ0rt7H+F65lmFE2L6eugQ==,type:str]",
 	"tokenizer-api-key": "ENC[AES256_GCM,data:q5Hzo9lITSxU5VZBCTHaZp1Pt+tJsoDAGkdG8hOj1rrE3G0mV3OI6Q==,iv:xYXTKLzP/kpH965PsfUpTePYONCmsYO2YjXbitWygPQ=,tag:4FhsG96+j4MWmovTghqKCg==,type:str]",
+	"tokenizer-api-key-gpd": "ENC[AES256_GCM,data:qQp2OrIoWhFqkt3Bo13wCl6tOqGqzfWS8xsCWQqt2dbp1AIj3Xd17g==,iv:DWPUibsLjqUvnA6Zf1AIV/Z4LLf7G44HTB7TW9ohVD8=,tag:t45P6Tx3rxBWSSHaD7HUGQ==,type:str]",
 	"pagopa-platform-domain-github-bot-cd-pat": "ENC[AES256_GCM,data:sQ/Jcn7dUSCdJtMUBz/zWbFAbL6AfGxJ6ZVk4MAsPNWDHY/z20E+aA==,iv:+wZTUyjIGuheEb0VXMkSablFtvZuFsitxm58m+E5Nbc=,tag:bRiYeipyX5D/6PYIYWNZvw==,type:str]",
 	"gpd-d-send-subscription-key": "ENC[AES256_GCM,data:AlmeyY6+pRnuNOQf/Cmpl2l3hPtysdjCPSNjqcwPCmBfXyRN,iv:HeU66l5SErPVXJU65Hu3OoEuuJ/jBgW0fD8VIuLhaR4=,tag:AipNPxO9u2VFoVFvL/57sg==,type:str]",
 	"rtp-keycloak-client-secret": "ENC[AES256_GCM,data:to9NaPCjl2Grzjv5LyNKWATk5PaRrSNq0jhPi3uCxoIHKPtU,iv:ITPTrbFHB/0BDhV2GcLw1hB2l/8MPwCBrOw+yniPfPI=,tag:9W1aGYW894DgHblK7huTqw==,type:str]",
@@ -13,6 +14,8 @@
 	"pgres-adf-user-login": "ENC[AES256_GCM,data:ohThh4ODgJ2rL0cZHEXuwQAW9g07b6I=,iv:OcwvqJVb/WHeahFujHuom2yF5ZXozZJAIerEMnxA4Y4=,tag:IzGigueG7DwbynrVBLN5pg==,type:str]",
 	"pgres-apd-storico-user-login": "ENC[AES256_GCM,data:zdeo+jIE1z6qW8//Izpgrw==,iv:MhUyU9eq0iW2iHQiQ/Gz3E9zFeFsVjGYCJoZpGcASnQ=,tag:tFC6wd7aSiZWQ/4PhdjK4A==,type:str]",
 	"sops": {
+		"kms": null,
+		"gcp_kms": null,
 		"azure_kv": [
 			{
 				"vault_url": "https://pagopa-d-gps-kv.vault.azure.net",
@@ -22,8 +25,11 @@
 				"enc": "NoMOisiuQsbmHYMFd1kyNWjL6fLDRJAt4Auf6k_eOsOd8lwYQlk1z1fRdaat2w52OpcKHXqsckwz5g6LoBOt4AsNdO-RwN1_FfxLdOxqxE8hpQtgTLyJLFP2esti-JdGNvxV8Ou9o6374X2869WlX0Lra61-lCNv4gQmAjj6JKqkURlFaWyeY2SIy4-bupzLxE2ssD_6dn_yfGvKIGVgNasquPVhnHzyreVIcYtY1_663KrSDaFf2OJG4TxWZ-R2m6HiWqt9VGlA_VWPBstz2PeaSbo7tBlmzW9VfRJG5l5EGiNVYI0Q5r4kZefAVq1baAHpyvUBxCyNekTaCafE3Q"
 			}
 		],
-		"lastmodified": "2026-03-20T14:05:00Z",
-		"mac": "ENC[AES256_GCM,data:6yGA2ujg/B6BVyqXTKN7y8q28oM9I9QDVWx3Eyvbx9SP/0HV2+uo0ah9OHxbc+etGVqR4vm9PqQQ7gd0ulp/WHja12npH93OORTn3U5j0fVgYAvmeQCIOCN2hgbJa67lLU1596rlC/xNy8X5uLgMW8GfsUvObEIRVVVUh89RNH8=,iv:j/fiPEr+hC5ZcXAg7GesJtkrdx4ptGze++/ZYWOpNoc=,tag:C9ixs7zyJsu+ElxVkwhosQ==,type:str]",
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2026-07-28T13:00:26Z",
+		"mac": "ENC[AES256_GCM,data:q0VgQ2+em93a7r7TchSeeH+ZnYIl11HbW/RgFSTFl6b5kCNWle/tEjLMoPX99fnemZpJ2JCB9fHYC6NAto/qPjoviZbhf6kO+OMa/32QCS9MOwS4WczKKeSWKPXTXOdhDYnY3yxM5JL3lmHJ5iF70k28NAIi1fDSHa6EEBwjsTk=,iv:1WYk1DLedlGpIpxvAUvBM0NY7XupCyRkx+Lld2XDDHs=,tag:JJgA4dYNVT5ve4+Grh1gbA==,type:str]",
+		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}

--- a/src/domains/gps-secret/secret/weu-prod/noedit_secret_enc.json
+++ b/src/domains/gps-secret/secret/weu-prod/noedit_secret_enc.json
@@ -3,6 +3,7 @@
 	"cdc-logical-replication-apd-user": "ENC[AES256_GCM,data:2bYTx4PH,iv:NMEyW6KBgwEMmWdbBIkWcI+fn5fSJ3tmIr6BXtCQOCo=,tag:e9QnridAM2ih7Kw1x3e0Zg==,type:str]",
 	"cdc-logical-replication-apd-pwd": "ENC[AES256_GCM,data:wEPhPNDphooGwSZxKYrxy0gHGL7uXg==,iv:QZgRBqOsBlnF/QvmlTda72QWRyX0NxDoaFMFwk5w3eI=,tag:3VeIfeP/5yz2HcCO6xh3zg==,type:str]",
 	"tokenizer-api-key": "ENC[AES256_GCM,data:XzvJZX/FHIO6uPHZUjyrmV6iLQpeb/IylmXruODIGlXTJBrlAT/LZg==,iv:NxOqm6+RZaLXh5c9NsxC3tUBCW1lX/pt4mu9ELn6dWE=,tag:7zv6LL+UjEkZgH4g6fKOyQ==,type:str]",
+	"tokenizer-api-key-gpd": "ENC[AES256_GCM,data:6baDLpmYmT7OGaNnW8nv/OMiwYAzPhIYUIfVoy7sSIfRNYbfAc7JQQ==,iv:6MUMGkMWPVmGTLDQUzvo5JdCWwfkKsMSecZAyMnMDnk=,tag:MhFvvwTzBEauG7zW16GsFg==,type:str]",
 	"pagopa-platform-domain-github-bot-cd-pat": "ENC[AES256_GCM,data:/lVJ1Ew8C+yu/tTNweZR6Pv6lelGfbMnOsaIKgDIF1DlbnFd/8QAjw==,iv:kOHYJCUuYm90oNpJfXYbrVC1UNgETwJvbGmkuItC5Aw=,tag:vaFMYUX9yws7IMZ/H+kJcg==,type:str]",
 	"pagopa-platform-domain-github-bot-pwd": "ENC[AES256_GCM,data:dotkpOEa1sMxH4TRy4WD,iv:+SKoRE7cmESieOyRauuPVkkwgAPGBd6RdfatamyX8co=,tag:d9ZNPbEYQITGKS/MNW2qFA==,type:str]",
 	"gpd-p-send-subscription-key": "ENC[AES256_GCM,data:cucIL/9Zj9CTT2OuicI0Sw6jcfZTl7q+cuQqYnw5M6nKXGky,iv:c8EqyBbk3QqEL4Aqg9SpOHVjPcEVPLnKYumIj2S/EMk=,tag:OCo+T7XfZWAAARzGNAd+hQ==,type:str]",
@@ -29,8 +30,8 @@
 		],
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2026-03-30T10:15:19Z",
-		"mac": "ENC[AES256_GCM,data:j5QjPWSzQewrTC6oa0eFKaLmx7dE/E5rWs5hByDXWg9TxajVZytcK+2wGmZEPZs31ykReyLpAwTw8xl/7doIpNijFk3iW+f6pYtenvTjXiEeaWlUmAyyxmlrPbVGF8lPg3Wvyk9Y4ousST8S3acxfNZgF987+HzdwM0gzi8cKhI=,iv:nop7c7pWnzPokZNjPGh2IUmajOWMqdp0J5Ba/qzNVF8=,tag:Ljs0VRBXksxbCY7hS/HPeQ==,type:str]",
+		"lastmodified": "2026-07-28T13:05:48Z",
+		"mac": "ENC[AES256_GCM,data:C2obfIvgJquFJHyXylsOmGgAeIt86Vfnw4wofPbbVLE9O0uat5+52Y6i9d8uAg3mhNl2otva9hYUcBHw1QWH2VsEk3x9BiHmf6jVbh9i6Xg8+poVUrjxTOQnJ2HAf8t/i91QMxxBo2TeH5pe0kjIqqNM5hMeQs7ru64m1efkyy8=,iv:KnyT9waszt7PJIv84DZHubT8VO0oc8JvstwgAu3ZHgg=,tag:9hE58zdUAcZJumNYPURP8A==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.9.3"

--- a/src/domains/gps-secret/secret/weu-uat/noedit_secret_enc.json
+++ b/src/domains/gps-secret/secret/weu-uat/noedit_secret_enc.json
@@ -3,6 +3,7 @@
 	"cdc-logical-replication-apd-user": "ENC[AES256_GCM,data:evSo198e,iv:kx+k5jooyprJye+mp4PH3ps+rc4WiG6F2f7LqJSIAa0=,tag:Va2WC742cqG3H3PoxydSpA==,type:str]",
 	"cdc-logical-replication-apd-pwd": "ENC[AES256_GCM,data:xCFisM6ZVAmqn54BEPA=,iv:qTWn6zzyAzT1L5LIy7xML8QLCaskwY6ZF7FCBGJXruk=,tag:lgLrXq0XjIujfU4wITKGfg==,type:str]",
 	"tokenizer-api-key": "ENC[AES256_GCM,data:MNT7srBTUktP1H4o4WJn5+7evNje2qwke+MjhYyQ0mQTcST613NvTw==,iv:mdnE7TejTe6C3v1B9OFkkqw9QBjz3fNW+BxQT5QsRIo=,tag:C9aL0nTwETefWbgrL5qKxw==,type:str]",
+	"tokenizer-api-key-gpd": "ENC[AES256_GCM,data:X5LgOLjjPQRrsjK7690fcPbmM+qCX0kOm6J1xJ7Gvw9Q1uEuG4jylA==,iv:BqS9caEK4ld6uTQYXkcPR7V5BTnVEUdtdkq3+hDo8JY=,tag:xE421Yl3/j61g01OZ0ec0Q==,type:str]",
 	"pagopa-platform-domain-github-bot-cd-pat": "ENC[AES256_GCM,data:5WOsAb/7F05Y5MRY61Tf+LXjM6D95rXl6xCh/1ST9lRfqTv/BZfGUg==,iv:/qiOdEgoN7mSjaYMBSCDCcY7doUIukzJyDQLrK0j5Cw=,tag:dXysdo8yGixQPt8T+bZKqQ==,type:str]",
 	"gpd-u-send-subscription-key": "ENC[AES256_GCM,data:Sd+xPC0O/kfYZ9ozWpM1EF9GKpHnPTIUfB7n70uAFQsueWT+,iv:b9JMRs6ZYGdDt5kq/wT2eITjyMWU+jOFfR/eWj0uQPI=,tag:cCH75TKzVVg5hVJ0E2jxrg==,type:str]",
 	"rtp-keycloak-client-secret": "ENC[AES256_GCM,data:y01F+nSXGGMw0JWLjdjcmv7mhc5jd3f9in7Ia7nvNmxh1IrD,iv:hFGepQjrByTR+h+0X2MuIQDlWH2qcaTD2xCIbSNn924=,tag:3Km+oajPoh+0XkwPywLeGw==,type:str]",
@@ -13,6 +14,8 @@
 	"pgres-adf-user-login": "ENC[AES256_GCM,data:8ryfNfAhuuf5YeH/vH5l0Znv+rgXQu0=,iv:lZQfxijcVYiVWsKojoOEq8KsWUMXcozgztyTBpHHr7Q=,tag:y56H8z1YBo7Xh1ZPJ1QbwQ==,type:str]",
 	"pgres-apd-storico-user-login": "ENC[AES256_GCM,data:QPcoQWbkuFl/d6CypU9ejQ==,iv:zMUmXsSXjGPxeqt/VAR0R2HMtq928/5dAKe+XkvCuaQ=,tag:zu4mtaAFDWtUVuU9zykMbA==,type:str]",
 	"sops": {
+		"kms": null,
+		"gcp_kms": null,
 		"azure_kv": [
 			{
 				"vault_url": "https://pagopa-u-gps-kv.vault.azure.net",
@@ -22,8 +25,11 @@
 				"enc": "Sve1Wce166uQ-DBakcY2JatnQn-P-iL13E5u62omSXaoJOe6mU33bi8GN3pC10SY-dUSJajXE_NEk7ozay7x3st3QcdWf6E4F_wkcV_WIiWPhUx4MtxJn-9UaaH6VOyGM1eiVVmFOm4YWY7OjGxxwt6pBfXejIQu2pUpIE6cVAONwxnWKXYoVyDrnbVbT8GUhvfNdolu3M6Hhs0FPvYtaigY7I2Klcq980AAhP5C0LE5rrSpRluVKR9rruXqF6bck22IECskPnLicowh5RiIKE6mFmTy1r5B6ZqX_a5WdOjAtUXDoyf_U3Wg9EI4g1rpaSTs41ZHjia8L_eNQ0AwOA"
 			}
 		],
-		"lastmodified": "2026-03-20T14:06:28Z",
-		"mac": "ENC[AES256_GCM,data:AdTTUGwaDITDWPq1DtPIsR8vKB80D5hcyBtNUnc9AlvemK/KfYUxEN3GqCGAZMBVpka+quvzzZBmgNnULl5Ez8OTvYwM+/4a9f8+EOWW/FmpmWBX0A66ZJQn91VAmexDxSf7T+9kK7LDaQ1GYdKifCOBQ+6I7211Qa6HgANgEAE=,iv:wTGZBr7yus3Kv21waoGmE2epG8zfP8MHAThu8fVyTgY=,tag:0gdyzpQ1LJ07l5axgxabVQ==,type:str]",
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2026-07-28T13:01:25Z",
+		"mac": "ENC[AES256_GCM,data:rDJJaXI4yYrUHDU4Wr2YbApHsLFHSKgQo0QiQX4U5WJ4vY7YYl01kDIXFro9BRm4TL6iwtJRD+3CmaIdinBvtRI9icGRuNmVr6FL3Bd3yB2ABXz1NsIModxM3pZ4rqRsqHWyR5raO+vrs4C02EQHlWQQv7wJ9/zfX88y1t6DcEg=,iv:6f+V0p2AU9IMaf91u04x+Kf1EBwAdmBJYVvJ7Udn3Ak=,tag:BdTNZLkOYOoRh+OWIRmhDg==,type:str]",
+		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.10.2"
 	}


### PR DESCRIPTION
### List of changes

- Added the new secret `tokenizer-api-key-gpd` to the GPS secret manifests for:
  - `weu-dev`
  - `weu-uat`
  - `weu-prod`
- Updated the SOPS metadata for the modified secret files.

### Motivation and context

This change introduces the GPD tokenizer API key in the GPS secret configurations across the affected environments.

- **PROD** → rps 350
- **UAT & DEV** → unique key rps 100

This allows the namespace remediation to use the correct credential and rate limits consistently across environments.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

The change only affects secret manifests and related SOPS metadata.

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->