### PR TITLE
fix: default values

### DIFF
--- a/src/domains/shared-app/01_app_service_pdf_engine.tf
+++ b/src/domains/shared-app/01_app_service_pdf_engine.tf
@@ -61,7 +61,7 @@ module "shared_pdf_engine_app_service" {
   docker_registry_password = data.azurerm_container_registry.container_registry.admin_password
 
   health_check_path            = "/info"
-  health_check_maxpingfailures = 10
+  health_check_maxpingfailures = var.env_short != "p" ? 10 : 2
 
   minimum_tls_version = "1.2"
 
@@ -95,7 +95,7 @@ module "shared_pdf_engine_slot_staging" {
   docker_registry_password = data.azurerm_container_registry.container_registry.admin_password
 
   health_check_path            = "/info"
-  health_check_maxpingfailures = 10
+  health_check_maxpingfailures = var.env_short != "p" ? 10 : 2
 
   minimum_tls_version = "1.2"
 
@@ -457,7 +457,7 @@ module "shared_pdf_engine_app_service_java" {
   docker_registry_password = data.azurerm_container_registry.container_registry.admin_password
 
   health_check_path            = "/info"
-  health_check_maxpingfailures = 10
+  health_check_maxpingfailures = var.env_short != "p" ? 10 : 2
 
   minimum_tls_version = "1.2"
 
@@ -494,7 +494,7 @@ module "shared_pdf_engine_java_slot_staging" {
   docker_registry_password = data.azurerm_container_registry.container_registry.admin_password
 
   health_check_path            = "/info"
-  health_check_maxpingfailures = 10
+  health_check_maxpingfailures = var.env_short != "p" ? 10 : 2
 
   minimum_tls_version = "1.2"
 

--- a/src/domains/shared-app/05_taxonomy_fn.tf
+++ b/src/domains/shared-app/05_taxonomy_fn.tf
@@ -112,7 +112,7 @@ module "taxonomy_function_slot_staging" {
   application_insights_instrumentation_key = data.azurerm_application_insights.application_insights.instrumentation_key
   always_on                                = var.taxonomy_function.always_on
   health_check_path                        = "/info"
-  health_check_maxpingfailures             = null
+  health_check_maxpingfailures             = var.env_short != "p" ? 10 : 2
   runtime_version                          = "~4"
   subnet_id                                = module.taxonomy_function_snet.id
 


### PR DESCRIPTION
### List of changes

- Fixed the handling of default values in Terraform configuration.
- Aligned two configuration files to avoid non-deterministic behavior during plan/apply.
- Changes are limited to fallback/default values, with no new resources introduced.

### Motivation and context

This change is required to ensure that, when no explicit override is provided, consistent and expected default values are applied.  
The goal is to reduce the risk of incomplete or divergent configurations across environments, improving `terraform plan` predictability and provisioning stability.

### Type of changes

- [ ] Add new resources  
- [x] Update configuration to existing resources  
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change  
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes  
- [x] No

### Other information

- Low-impact PR: **2 files changed**, with targeted updates to default values.
- Overall diff: **+5 / -5**.
- No manual migration or follow-up operational activity is expected.