### PR TITLE
fix(GPD): update writeBatchSize in AzurePostgreSqlSink to a static value

### DIFF
--- a/src/domains/gps-common/datafactory/pipelines/GPD_LIFECYCLE_SCRIPT_EXECUTION.json
+++ b/src/domains/gps-common/datafactory/pipelines/GPD_LIFECYCLE_SCRIPT_EXECUTION.json
@@ -169,10 +169,7 @@
           },
           "sink": {
             "type": "AzurePostgreSqlSink",
-            "writeBatchSize": {
-              "value": "@div(int(pipeline().parameters.ChunkSize), 10)",
-              "type": "Expression"
-            },
+            "writeBatchSize": 1000,
             "writeBatchTimeout": "02:30:00",
             "writeMethod": "CopyCommand"
           },


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

- update `writeBatchSize` in AzurePostgreSqlSink to a static value

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

Unmarshalling error in DEV (not in UAT):

```
│ Resource Group Name: "pagopa-d-weu-nodo-df-rg"
│ Factory Name: "pagopa-d-weu-nodo-df"
│ Pipeline Name: "GPD_LIFECYCLE_SCRIPT_EXECUTION"): unmarshaling response body: unmarshaling index 4 field 'Activities' for 'Pipeline': unmarshaling into CopyActivity: unmarshaling field 'Sink' for 'CopyActivityTypeProperties': unmarshaling into AzurePostgreSqlSink: json: cannot unmarshal object into Go struct field AzurePostgreSqlSink.writeBatchSize of type int64
```

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
