### PR TITLE
fix: Update Onemail tenant name and clear email force recipients

### DIFF
--- a/src/portal-pagopa/portal-pagopa-common/env/prod/terraform.tfvars
+++ b/src/portal-pagopa/portal-pagopa-common/env/prod/terraform.tfvars
@@ -24,14 +24,14 @@ github_issues_repo  = "pagopa-payments-department-centralhub"
 onemail_base_url    = "https://onemail.pagopa.it"
 onemail_env         = "prod"
 onemail_from_email  = "noreply@internal-apps.platform.pagopa.it"
-onemail_tenant_name = "PROD"
+onemail_tenant_name = "TEST" # Real tenant name for production
 
 timetrack_email_disable_send = false
-timetrack_email_force_to     = "cristiano.sticca@pagopa.it"
+timetrack_email_force_to     = ""
 timetrack_onemail_from_email = "noreply@internal-apps.platform.pagopa.it"
 
 training_email_disable_send = false
-training_email_force_to     = "cristiano.sticca@pagopa.it"
+training_email_force_to     = ""
 training_onemail_from_email = "noreply@internal-apps.platform.pagopa.it"
 
 websites_enable_app_service_storage = false

--- a/src/portal-pagopa/portal-pagopa-common/env/prod/terraform.tfvars
+++ b/src/portal-pagopa/portal-pagopa-common/env/prod/terraform.tfvars
@@ -24,14 +24,14 @@ github_issues_repo  = "pagopa-payments-department-centralhub"
 onemail_base_url    = "https://onemail.pagopa.it"
 onemail_env         = "prod"
 onemail_from_email  = "noreply@internal-apps.platform.pagopa.it"
-onemail_tenant_name = "PROD"
+onemail_tenant_name = "TEST"
 
 timetrack_email_disable_send = false
-timetrack_email_force_to     = "cristiano.sticca@pagopa.it"
+timetrack_email_force_to     = ""
 timetrack_onemail_from_email = "noreply@internal-apps.platform.pagopa.it"
 
 training_email_disable_send = false
-training_email_force_to     = "cristiano.sticca@pagopa.it"
+training_email_force_to     = ""
 training_onemail_from_email = "noreply@internal-apps.platform.pagopa.it"
 
 websites_enable_app_service_storage = false

--- a/src/portal-pagopa/portal-pagopa-secrets/secret/prod/noedit_secret_enc.json
+++ b/src/portal-pagopa/portal-pagopa-secrets/secret/prod/noedit_secret_enc.json
@@ -10,7 +10,7 @@
 	"portal-test-results-token": "",
 	"db-administrator-login": "ENC[AES256_GCM,data:S/T0KeoH,iv:ZVImNab/ROy7odZezmgbiUfWod6vZdqG2ABY1uH6/As=,tag:EQrfrab5RefgDOJiq3IqOA==,type:str]",
 	"db-administrator-login-password": "ENC[AES256_GCM,data:z1GntNv6VKu2BeQ0kIm8iA==,iv:4Djke/DGahI3qsPD7rIF9yGP3S0fz37qPnoRakYZJCM=,tag:J/z602I3SuPsADZ5JrRyKg==,type:str]",
-	"portal-onemail-api-key": "ENC[AES256_GCM,data:lJJQOk7p/SHmbElgZjjcNmSMCg408ihvM2RPgvNRYFD3Um5479dwhg==,iv:Rf3rgTziN1IoeLsrPH8t88wPgwhKkr3LSLjs9FBqNeI=,tag:XDluVwR8XTPMOLvLFPNl5g==,type:str]",
+	"portal-onemail-api-key": "ENC[AES256_GCM,data:HeJbfx9b22CCgrGJE5rfMy3mIcG/MUo/E40YbVSshrWXPdZZ+hJIPw==,iv:f9CKAV0KPWRxT3ru9tH/K5Z/v12m/fqMSELr1Jokn+w=,tag:PnlkAIZf2eIEKWGVK9xcAA==,type:str]",
 	"portal-aws-secret-access-key": "ENC[AES256_GCM,data:VdaFRLgowlPlm3O5r7ISYfFo0MfaiqXf+hlMJ5EcuGZZunvhlFpg3w==,iv:E/WCah1X5pDe6ZzyEWwX10uyRGCEHh4T87mUwBzUN8I=,tag:q9UzI6H0SAbkG6KhUlgFxw==,type:str]",
 	"portal-aws-access-key-id": "ENC[AES256_GCM,data:JVKt3FBblSP4mkBtOCWKkf+TaqA=,iv:EevVxuSemDwkpeBGrJl63j51ux6waSb0I2c3wOE0yfo=,tag:Ruzsyu4rf6nXNjGnVDG6wg==,type:str]",
 	"portal-github-issues-token": "ENC[AES256_GCM,data:0SKMdapR2hLLHLBasM2bGEqpaIYAWkSm3bEyOQJ0OeYejbhyamEk59/annozTAPe1oFgsql5tWPcvljkV44RntY4xMACwvfHd4KM+PVfr85dqtLKX9zVS7+rH8JP,iv:bjDJ5DxTiIdB89iG8fS/U7y/chdzyQVO1QvXmEHxoy4=,tag:zwLg1bswD6dA90dZvleCLQ==,type:str]",
@@ -24,8 +24,8 @@
 				"enc": "s_0tMZSDT973zrgq-veQWXl3ILgrLqMC3ljCjaw75ktMaNn8j88S56FdJWWhbi2ckpUr0TJ6xyaVE9zCWIm73rrbyYiG9yoTfa8w6cTSXsPJ5hGXnrfOHUcE0Qoej63zEXX6GWLbFC_tPUB43nOM8ujorGCZYiCuGXU2qeAejrnbwZIXtmvk0GS34PnY-Aoxr3e-5GDTPRzWukaYO2Zr_jJxpdwEpgH1YZ3bD80Xt5o5rwtJJ0uwFreOpvGWypol6HsQtQ6FYysm85MOGgZhfzKmfVBTBqHhpJP53wvCE7U6Al-oaFARo4RP0KLrXphVvFwBZKW_l2yQJ-soTtFEAA"
 			}
 		],
-		"lastmodified": "2026-08-04T13:27:49Z",
-		"mac": "ENC[AES256_GCM,data:Y46PO1mR90rUPGY8S9rPZDEpGxwY0mU2dcsxZIuUaXQugF6bx9/wJJKEXxDtxGkHWDbg17/lXept8RkYO5Km+ghlNNET9Z+s0fomx65sJNZUznd7Qrq9VqAg3ZUc/DbyyGaLXYWdN8mLDcggQ2JqVkqS+RWFYCevSXfkv0YMu5o=,iv:U3H1ml3mhLaX1vWEdWQLkFAADll0MGOg2CACp1LtS1M=,tag:nVQExow/oTKsRqTEyFJJNQ==,type:str]",
+		"lastmodified": "2026-08-11T13:58:10Z",
+		"mac": "ENC[AES256_GCM,data:FfpuYK6qQDlB/uG+wD/C1aRpc81sfNBMfolDPYkcGRS28mZW7HQZTII11DOhchSJsWNPezN8Z8t4qS4N/7zkuc1vxtygjm08se+aB45BmnnqCvgWpI1rTHoIA+eKjCkwkcNxfJrgUbpP3sF5DM04PPVRidxYjxYf/TdZqC0QbGs=,iv:rQHpifj9kl+PxQm80UDVXhz1fdL4vZ5iX9kPQcaN940=,tag:2/P4Fb32xH/N0wmySZjQqw==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.12.2"
 	}


### PR DESCRIPTION
### List of changes

- Updated the Onemail tenant name to "TEST". Working for production env...
- Cleared the email force recipients configuration.

### Motivation and context

This change aligns the email tenant setup with the expected TEST environment configuration while removing unnecessary email force recipient settings.

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

N/A

---

### If PR is partially applied, why? (reserved to mantainers)

